### PR TITLE
feat:[CDS-77084]: Serverless 2.0 and SAM step changes

### DIFF
--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -43142,13 +43142,7 @@
                   "type" : "string"
                 },
                 "samVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -43219,13 +43213,7 @@
                 "type" : "string"
               },
               "samVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for AwsSamBuildStepInfo"
@@ -44028,22 +44016,10 @@
                   } ]
                 },
                 "samVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 },
                 "stackName" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -44112,22 +44088,10 @@
                 } ]
               },
               "samVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "stackName" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for AwsSamDeployStepInfo"
@@ -50468,13 +50432,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -50542,13 +50500,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaDeployV2StepInfo"
@@ -50700,13 +50652,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -50774,13 +50720,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaPackageV2StepInfo"
@@ -50886,9 +50826,6 @@
                     "minLength" : 1
                   } ]
                 },
-                "downloadManifestsFqn" : {
-                  "type" : "string"
-                },
                 "image" : {
                   "type" : "string"
                 },
@@ -50923,13 +50860,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -50950,9 +50881,6 @@
                   "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
-              },
-              "downloadManifestsFqn" : {
-                "type" : "string"
               },
               "image" : {
                 "type" : "string"
@@ -50988,13 +50916,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaPrepareRollbackV2StepInfo"
@@ -51133,17 +51055,8 @@
                     "type" : "string"
                   } ]
                 },
-                "serverlessAwsLambdaRollbackFnq" : {
-                  "type" : "string"
-                },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -51198,17 +51111,8 @@
                   "type" : "string"
                 } ]
               },
-              "serverlessAwsLambdaRollbackFnq" : {
-                "type" : "string"
-              },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaRollbackV2StepInfo"

--- a/v1/pipeline/steps/cd/aws-sam-build-step-info.yaml
+++ b/v1/pipeline/steps/cd/aws-sam-build-step-info.yaml
@@ -49,11 +49,7 @@ allOf:
     samBuildDockerRegistryConnectorRef:
       type: string
     samVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -103,10 +99,6 @@ properties:
   samBuildDockerRegistryConnectorRef:
     type: string
   samVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for AwsSamBuildStepInfo

--- a/v1/pipeline/steps/cd/aws-sam-deploy-step-info.yaml
+++ b/v1/pipeline/steps/cd/aws-sam-deploy-step-info.yaml
@@ -49,17 +49,9 @@ allOf:
         format: int32
       - type: string
     samVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
     stackName:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -109,16 +101,8 @@ properties:
       format: int32
     - type: string
   samVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   stackName:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for AwsSamDeployStepInfo

--- a/v1/pipeline/steps/cd/serverless-aws-lambda-deploy-v2-step-info.yaml
+++ b/v1/pipeline/steps/cd/serverless-aws-lambda-deploy-v2-step-info.yaml
@@ -47,11 +47,7 @@ allOf:
         format: int32
       - type: string
     serverlessVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -99,10 +95,6 @@ properties:
       format: int32
     - type: string
   serverlessVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for ServerlessAwsLambdaDeployV2StepInfo

--- a/v1/pipeline/steps/cd/serverless-aws-lambda-package-v2-step-info.yaml
+++ b/v1/pipeline/steps/cd/serverless-aws-lambda-package-v2-step-info.yaml
@@ -47,11 +47,7 @@ allOf:
         format: int32
       - type: string
     serverlessVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -99,10 +95,6 @@ properties:
       format: int32
     - type: string
   serverlessVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for ServerlessAwsLambdaPackageV2StepInfo

--- a/v1/pipeline/steps/cd/serverless-aws-lambda-prepare-rollback-v2-step-info.yaml
+++ b/v1/pipeline/steps/cd/serverless-aws-lambda-prepare-rollback-v2-step-info.yaml
@@ -13,8 +13,6 @@ allOf:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
-    downloadManifestsFqn:
-      type: string
     image:
       type: string
     imagePullPolicy:
@@ -41,11 +39,7 @@ allOf:
         format: int32
       - type: string
     serverlessVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -59,8 +53,6 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
-  downloadManifestsFqn:
-    type: string
   image:
     type: string
   imagePullPolicy:
@@ -87,10 +79,6 @@ properties:
       format: int32
     - type: string
   serverlessVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for ServerlessAwsLambdaPrepareRollbackV2StepInfo

--- a/v1/pipeline/steps/cd/serverless-aws-lambda-rollback-v2-step-info.yaml
+++ b/v1/pipeline/steps/cd/serverless-aws-lambda-rollback-v2-step-info.yaml
@@ -38,14 +38,8 @@ allOf:
       - type: integer
         format: int32
       - type: string
-    serverlessAwsLambdaRollbackFnq:
-      type: string
     serverlessVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -84,13 +78,7 @@ properties:
     - type: integer
       format: int32
     - type: string
-  serverlessAwsLambdaRollbackFnq:
-    type: string
   serverlessVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for ServerlessAwsLambdaRollbackV2StepInfo

--- a/v1/template.json
+++ b/v1/template.json
@@ -2356,13 +2356,7 @@
                   "type" : "string"
                 },
                 "samVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -2433,13 +2427,7 @@
                 "type" : "string"
               },
               "samVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for AwsSamBuildStepInfo"
@@ -2580,22 +2568,10 @@
                   } ]
                 },
                 "samVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 },
                 "stackName" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -2664,22 +2640,10 @@
                 } ]
               },
               "samVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "stackName" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for AwsSamDeployStepInfo"
@@ -12988,13 +12952,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -13062,13 +13020,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaDeployV2StepInfo"
@@ -13208,13 +13160,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -13282,13 +13228,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaPackageV2StepInfo"
@@ -13382,9 +13322,6 @@
                     "minLength" : 1
                   } ]
                 },
-                "downloadManifestsFqn" : {
-                  "type" : "string"
-                },
                 "image" : {
                   "type" : "string"
                 },
@@ -13419,13 +13356,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -13446,9 +13377,6 @@
                   "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
-              },
-              "downloadManifestsFqn" : {
-                "type" : "string"
               },
               "image" : {
                 "type" : "string"
@@ -13484,13 +13412,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaPrepareRollbackV2StepInfo"
@@ -13723,17 +13645,8 @@
                     "type" : "string"
                   } ]
                 },
-                "serverlessAwsLambdaRollbackFnq" : {
-                  "type" : "string"
-                },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -13788,17 +13701,8 @@
                   "type" : "string"
                 } ]
               },
-              "serverlessAwsLambdaRollbackFnq" : {
-                "type" : "string"
-              },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaRollbackV2StepInfo"


### PR DESCRIPTION
Following are the requirements -

- Remove hard requirements for AWS Manual Creds for SAM Deploy Step

- In SAM Build, if we provide docker connector with no creds we are throwing error.

- Also in this ticket we would add runtime inputs for connector ref for SAM steps

- we would add runtime inputs for connector ref for Serverless 2.0 steps

- Runtime Inputs Not currently supported for SAM stackName . Fixing it in this PR

- Runtime Inputs Not supported Sam version. . Fixing it in this PR

- Runtime Inputs Not supported Serverless 2.0 version. Fixing it in this PR