### PR TITLE
feat: [CDS-78628]: update failure strategies schema

### DIFF
--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -8109,8 +8109,8 @@
                 "description" : "The stage conditional logic.",
                 "$ref" : "#/definitions/pipeline/common/When"
               },
-              "on" : {
-                "$ref" : "#/definitions/pipeline/common/On"
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -9862,32 +9862,22 @@
             }
           }
         },
-        "On" : {
-          "title" : "On",
-          "type" : "object",
-          "properties" : {
-            "failure" : {
-              "oneOf" : [ {
-                "$ref" : "#/definitions/pipeline/common/Failure"
-              }, {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/pipeline/common/Failure"
-                }
-              } ]
+        "FailureList" : {
+          "title" : "FailureList",
+          "oneOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Failure"
+          }, {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/pipeline/common/Failure"
             }
-          }
+          } ]
         },
         "Failure" : {
           "title" : "Failure",
           "type" : "object",
           "description" : "Failure defines a failure strategy.",
           "properties" : {
-            "type" : {
-              "description" : "Type defines the failure strategy type.",
-              "type" : "string",
-              "enum" : [ "abort", "ignore", "manual-intervention", "retry", "success", "fail", "retry-step-group", "stage-rollback", "pipeline-rollback" ]
-            },
             "errors" : {
               "description" : "Errors specifies the types of errors.",
               "type" : "array",
@@ -9895,9 +9885,94 @@
                 "type" : "string",
                 "enum" : [ "all", "approval-rejection", "authentication", "authorization", "connectivity", "delegate-provisioning", "delegate-restart", "input-timeout", "policy-evaluation", "timeout", "unknown", "verification", "user-mark-fail" ]
               }
+            },
+            "action" : {
+              "$ref" : "#/definitions/pipeline/common/FailureAction"
+            }
+          }
+        },
+        "FailureAction" : {
+          "title" : "FailureAction",
+          "type" : "object",
+          "description" : "Failure Action defines action to be taken on failure.",
+          "properties" : {
+            "type" : {
+              "description" : "Type defines the failure strategy type.",
+              "type" : "string",
+              "enum" : [ "abort", "fail", "ignore", "manual-intervention", "pipeline-rollback", "retry", "retry-step-group", "stage-rollback", "success" ]
             }
           },
           "oneOf" : [ {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "success"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "fail"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "retry-step-group"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "stage-rollback"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "pipeline-rollback"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
             "allOf" : [ {
               "properties" : {
                 "type" : {
@@ -9953,71 +10028,12 @@
                 }
               }
             } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : {
-                  "const" : "success"
-                }
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : {
-                  "const" : "fail"
-                }
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : "retry-step-group"
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : "stage-rollback"
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : "pipeline-rollback"
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
           } ]
+        },
+        "EmptySpec" : {
+          "title" : "EmptySpec",
+          "type" : "object",
+          "properties" : { }
         },
         "Abort" : {
           "title" : "Abort",
@@ -10045,21 +10061,30 @@
                 "format" : "duration"
               } ]
             },
-            "post_action" : {
-              "$ref" : "#/definitions/pipeline/common/PostAction"
+            "failure" : {
+              "$ref" : "#/definitions/pipeline/common/RetryFailure"
             }
           },
           "type" : "object"
         },
-        "PostAction" : {
-          "title" : "PostAction",
+        "RetryFailure" : {
+          "title" : "RetryFailure",
+          "type" : "object",
+          "properties" : {
+            "action" : {
+              "$ref" : "#/definitions/pipeline/common/RetryFailureAction"
+            }
+          }
+        },
+        "RetryFailureAction" : {
+          "title" : "RetryFailureAction",
           "type" : "object",
           "description" : "Failure action on failure for all retries",
           "properties" : {
             "type" : {
               "description" : "Type defines the failure strategy type.",
               "type" : "string",
-              "enum" : [ "abort", "ignore", "success", "stage-rollback", "pipeline-rollback", "fail", "manual-intervention" ]
+              "enum" : [ "abort", "fail", "ignore", "manual-intervention", "pipeline-rollback", "stage-rollback", "success" ]
             }
           },
           "oneOf" : [ {
@@ -10072,7 +10097,7 @@
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
@@ -10086,31 +10111,35 @@
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
           }, {
             "allOf" : [ {
               "properties" : {
-                "type" : "stage-rollback"
+                "type" : {
+                  "const" : "stage-rollback"
+                }
               }
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
           }, {
             "allOf" : [ {
               "properties" : {
-                "type" : "pipeline-rollback"
+                "type" : {
+                  "const" : "pipeline-rollback"
+                }
               }
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
@@ -10157,11 +10186,6 @@
               }
             } ]
           } ]
-        },
-        "Empty Spec" : {
-          "title" : "Empty Spec",
-          "type" : "object",
-          "properties" : { }
         },
         "ManualIntervention" : {
           "title" : "ManualIntervention",
@@ -10226,31 +10250,35 @@
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
           }, {
             "allOf" : [ {
               "properties" : {
-                "type" : "stage-rollback"
+                "type" : {
+                  "const" : "stage-rollback"
+                }
               }
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
           }, {
             "allOf" : [ {
               "properties" : {
-                "type" : "pipeline-rollback"
+                "type" : {
+                  "const" : "pipeline-rollback"
+                }
               }
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
@@ -10264,7 +10292,7 @@
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]

--- a/v1/pipeline/common/empty_spec.yaml
+++ b/v1/pipeline/common/empty_spec.yaml
@@ -1,3 +1,3 @@
-title: Empty Spec
+title: EmptySpec
 type: object
 properties: {}

--- a/v1/pipeline/common/failure.yaml
+++ b/v1/pipeline/common/failure.yaml
@@ -2,19 +2,6 @@ title: Failure
 type: object
 description: Failure defines a failure strategy.
 properties:
-  type:
-    description: Type defines the failure strategy type.
-    type: string
-    enum:
-      - abort
-      - ignore
-      - manual-intervention
-      - retry
-      - success
-      - fail
-      - retry-step-group
-      - stage-rollback
-      - pipeline-rollback
   errors:
     description: Errors specifies the types of errors.
     type: array
@@ -34,65 +21,5 @@ properties:
         - unknown
         - verification
         - user-mark-fail
-
-oneOf:
-  - allOf:
-      - properties:
-          type:
-            const: abort
-      - properties:
-          spec:
-            $ref: ./failure_abort.yaml
-  - allOf:
-      - properties:
-          type:
-            const: ignore
-      - properties:
-          spec:
-            $ref: ./failure_ignore.yaml
-  - allOf:
-      - properties:
-          type:
-            const: retry
-      - properties:
-          spec:
-            $ref: ./failure_retry.yaml
-  - allOf:
-      - properties:
-          type:
-            const: manual-intervention
-      - properties:
-          spec:
-            $ref: ./failure_manual.yaml
-  - allOf:
-      - properties:
-          type:
-            const: success
-      - properties:
-          spec:
-            $ref: ./empty_spec.yaml
-  - allOf:
-      - properties:
-          type:
-            const: fail
-      - properties:
-          spec:
-            $ref: ./empty_spec.yaml
-  - allOf:
-      - properties:
-          type: retry-step-group
-      - properties:
-          spec:
-            $ref: ./empty_spec.yaml
-  - allOf:
-      - properties:
-          type: stage-rollback
-      - properties:
-          spec:
-            $ref: ./empty_spec.yaml
-  - allOf:
-      - properties:
-          type: pipeline-rollback
-      - properties:
-          spec:
-            $ref: ./empty_spec.yaml
+  action:
+    $ref: "./failure_action.yaml"

--- a/v1/pipeline/common/failure_action.yaml
+++ b/v1/pipeline/common/failure_action.yaml
@@ -1,18 +1,20 @@
-title: PostAction
+title: FailureAction
 type: object
-description: Failure action on failure for all retries
+description: Failure Action defines action to be taken on failure.
 properties:
   type:
     description: Type defines the failure strategy type.
     type: string
     enum:
       - abort
-      - ignore
-      - success
-      - stage-rollback
-      - pipeline-rollback
       - fail
+      - ignore
       - manual-intervention
+      - pipeline-rollback
+      - retry
+      - retry-step-group
+      - stage-rollback
+      - success
 
 oneOf:
   - allOf:
@@ -31,13 +33,22 @@ oneOf:
             $ref: ./empty_spec.yaml
   - allOf:
       - properties:
-          type: stage-rollback
+          type:
+            const: retry-step-group
       - properties:
           spec:
             $ref: ./empty_spec.yaml
   - allOf:
       - properties:
-          type: pipeline-rollback
+          type:
+            const: stage-rollback
+      - properties:
+          spec:
+            $ref: ./empty_spec.yaml
+  - allOf:
+      - properties:
+          type:
+            const: pipeline-rollback
       - properties:
           spec:
             $ref: ./empty_spec.yaml
@@ -55,6 +66,13 @@ oneOf:
       - properties:
           spec:
             $ref: ./failure_ignore.yaml
+  - allOf:
+      - properties:
+          type:
+            const: retry
+      - properties:
+          spec:
+            $ref: ./failure_retry.yaml
   - allOf:
       - properties:
           type:

--- a/v1/pipeline/common/failure_list.yaml
+++ b/v1/pipeline/common/failure_list.yaml
@@ -1,0 +1,6 @@
+title: FailureList
+oneOf:
+  - $ref: "./failure.yaml"
+  - type: array
+    items:
+      $ref: "./failure.yaml"

--- a/v1/pipeline/common/failure_retry.yaml
+++ b/v1/pipeline/common/failure_retry.yaml
@@ -13,6 +13,6 @@ properties:
       - type: string
         example: 1m
         format: duration
-  post_action:
-    $ref: ./post_action.yaml
+  failure:
+    $ref: ./retry_failure.yaml
 type: object

--- a/v1/pipeline/common/on.yaml
+++ b/v1/pipeline/common/on.yaml
@@ -1,9 +1,0 @@
-title: 'On'
-type: object
-properties:
-  failure:
-    oneOf:
-      - $ref: "./failure.yaml"
-      - type: array
-        items:
-          $ref: "./failure.yaml"

--- a/v1/pipeline/common/retry_failure.yaml
+++ b/v1/pipeline/common/retry_failure.yaml
@@ -1,0 +1,5 @@
+title: RetryFailure
+type: object
+properties:
+  action:
+    $ref: "./retry_failure_action.yaml"

--- a/v1/pipeline/common/retry_failure_action.yaml
+++ b/v1/pipeline/common/retry_failure_action.yaml
@@ -1,33 +1,27 @@
-title: TimeoutAction
+title: RetryFailureAction
 type: object
-description: Manual intervention for timeout failure action
+description: Failure action on failure for all retries
 properties:
   type:
     description: Type defines the failure strategy type.
     type: string
     enum:
       - abort
-      - ignore
-      - success
-      - stage-rollback
-      - pipeline-rollback
       - fail
+      - ignore
+      - manual-intervention
+      - pipeline-rollback
+      - stage-rollback
+      - success
 
 oneOf:
   - allOf:
       - properties:
           type:
-            const: abort
+            const: success
       - properties:
           spec:
-            $ref: ./failure_abort.yaml
-  - allOf:
-      - properties:
-          type:
-            const: ignore
-      - properties:
-          spec:
-            $ref: ./failure_ignore.yaml
+            $ref: ./empty_spec.yaml
   - allOf:
       - properties:
           type:
@@ -52,7 +46,21 @@ oneOf:
   - allOf:
       - properties:
           type:
-            const: success
+            const: abort
       - properties:
           spec:
-            $ref: ./empty_spec.yaml
+            $ref: ./failure_abort.yaml
+  - allOf:
+      - properties:
+          type:
+            const: ignore
+      - properties:
+          spec:
+            $ref: ./failure_ignore.yaml
+  - allOf:
+      - properties:
+          type:
+            const: manual-intervention
+      - properties:
+          spec:
+            $ref: ./failure_manual.yaml

--- a/v1/pipeline/stages/custom/custom-stage-node.yaml
+++ b/v1/pipeline/stages/custom/custom-stage-node.yaml
@@ -25,8 +25,8 @@ properties:
   when:
     description: The stage conditional logic.
     $ref: ../../common/when.yaml
-  on:
-    $ref: ../../common/on.yaml
+  failure:
+    $ref: ../../common/failure_list.yaml
 
 $schema: http://json-schema.org/draft-07/schema#
 allOf:

--- a/v1/pipeline/stages/stages.yaml
+++ b/v1/pipeline/stages/stages.yaml
@@ -32,8 +32,8 @@ properties:
   when:
     description: The stage conditional logic.
     $ref: ../common/when.yaml
-  on:
-    $ref: ../common/on.yaml
+  failure:
+    $ref: ../common/failure_list.yaml
 
 # TODO - check if we can use config ref instead of below oneOf
 

--- a/v1/template.json
+++ b/v1/template.json
@@ -56042,32 +56042,22 @@
             }
           }
         },
-        "On" : {
-          "title" : "On",
-          "type" : "object",
-          "properties" : {
-            "failure" : {
-              "oneOf" : [ {
-                "$ref" : "#/definitions/pipeline/common/Failure"
-              }, {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/pipeline/common/Failure"
-                }
-              } ]
+        "FailureList" : {
+          "title" : "FailureList",
+          "oneOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Failure"
+          }, {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/definitions/pipeline/common/Failure"
             }
-          }
+          } ]
         },
         "Failure" : {
           "title" : "Failure",
           "type" : "object",
           "description" : "Failure defines a failure strategy.",
           "properties" : {
-            "type" : {
-              "description" : "Type defines the failure strategy type.",
-              "type" : "string",
-              "enum" : [ "abort", "ignore", "manual-intervention", "retry", "success", "fail", "retry-step-group", "stage-rollback", "pipeline-rollback" ]
-            },
             "errors" : {
               "description" : "Errors specifies the types of errors.",
               "type" : "array",
@@ -56075,9 +56065,94 @@
                 "type" : "string",
                 "enum" : [ "all", "approval-rejection", "authentication", "authorization", "connectivity", "delegate-provisioning", "delegate-restart", "input-timeout", "policy-evaluation", "timeout", "unknown", "verification", "user-mark-fail" ]
               }
+            },
+            "action" : {
+              "$ref" : "#/definitions/pipeline/common/FailureAction"
+            }
+          }
+        },
+        "FailureAction" : {
+          "title" : "FailureAction",
+          "type" : "object",
+          "description" : "Failure Action defines action to be taken on failure.",
+          "properties" : {
+            "type" : {
+              "description" : "Type defines the failure strategy type.",
+              "type" : "string",
+              "enum" : [ "abort", "fail", "ignore", "manual-intervention", "pipeline-rollback", "retry", "retry-step-group", "stage-rollback", "success" ]
             }
           },
           "oneOf" : [ {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "success"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "fail"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "retry-step-group"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "stage-rollback"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
+            "allOf" : [ {
+              "properties" : {
+                "type" : {
+                  "const" : "pipeline-rollback"
+                }
+              }
+            }, {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
+                }
+              }
+            } ]
+          }, {
             "allOf" : [ {
               "properties" : {
                 "type" : {
@@ -56133,71 +56208,12 @@
                 }
               }
             } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : {
-                  "const" : "success"
-                }
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : {
-                  "const" : "fail"
-                }
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : "retry-step-group"
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : "stage-rollback"
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
-          }, {
-            "allOf" : [ {
-              "properties" : {
-                "type" : "pipeline-rollback"
-              }
-            }, {
-              "properties" : {
-                "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
-                }
-              }
-            } ]
           } ]
+        },
+        "EmptySpec" : {
+          "title" : "EmptySpec",
+          "type" : "object",
+          "properties" : { }
         },
         "Abort" : {
           "title" : "Abort",
@@ -56225,21 +56241,30 @@
                 "format" : "duration"
               } ]
             },
-            "post_action" : {
-              "$ref" : "#/definitions/pipeline/common/PostAction"
+            "failure" : {
+              "$ref" : "#/definitions/pipeline/common/RetryFailure"
             }
           },
           "type" : "object"
         },
-        "PostAction" : {
-          "title" : "PostAction",
+        "RetryFailure" : {
+          "title" : "RetryFailure",
+          "type" : "object",
+          "properties" : {
+            "action" : {
+              "$ref" : "#/definitions/pipeline/common/RetryFailureAction"
+            }
+          }
+        },
+        "RetryFailureAction" : {
+          "title" : "RetryFailureAction",
           "type" : "object",
           "description" : "Failure action on failure for all retries",
           "properties" : {
             "type" : {
               "description" : "Type defines the failure strategy type.",
               "type" : "string",
-              "enum" : [ "abort", "ignore", "success", "stage-rollback", "pipeline-rollback", "fail", "manual-intervention" ]
+              "enum" : [ "abort", "fail", "ignore", "manual-intervention", "pipeline-rollback", "stage-rollback", "success" ]
             }
           },
           "oneOf" : [ {
@@ -56252,7 +56277,7 @@
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
@@ -56266,31 +56291,35 @@
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
           }, {
             "allOf" : [ {
               "properties" : {
-                "type" : "stage-rollback"
+                "type" : {
+                  "const" : "stage-rollback"
+                }
               }
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
           }, {
             "allOf" : [ {
               "properties" : {
-                "type" : "pipeline-rollback"
+                "type" : {
+                  "const" : "pipeline-rollback"
+                }
               }
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
@@ -56337,11 +56366,6 @@
               }
             } ]
           } ]
-        },
-        "Empty Spec" : {
-          "title" : "Empty Spec",
-          "type" : "object",
-          "properties" : { }
         },
         "ManualIntervention" : {
           "title" : "ManualIntervention",
@@ -56406,31 +56430,35 @@
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
           }, {
             "allOf" : [ {
               "properties" : {
-                "type" : "stage-rollback"
+                "type" : {
+                  "const" : "stage-rollback"
+                }
               }
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
           }, {
             "allOf" : [ {
               "properties" : {
-                "type" : "pipeline-rollback"
+                "type" : {
+                  "const" : "pipeline-rollback"
+                }
               }
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
@@ -56444,7 +56472,7 @@
             }, {
               "properties" : {
                 "spec" : {
-                  "$ref" : "#/definitions/pipeline/common/Empty Spec"
+                  "$ref" : "#/definitions/pipeline/common/EmptySpec"
                 }
               }
             } ]
@@ -63419,8 +63447,8 @@
                 "description" : "The stage conditional logic.",
                 "$ref" : "#/definitions/pipeline/common/When"
               },
-              "on" : {
-                "$ref" : "#/definitions/pipeline/common/On"
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -63944,8 +63972,8 @@
                 "description" : "The stage conditional logic.",
                 "$ref" : "#/definitions/pipeline/common/When"
               },
-              "on" : {
-                "$ref" : "#/definitions/pipeline/common/On"
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -66358,8 +66386,8 @@
               "description" : "The stage conditional logic.",
               "$ref" : "#/definitions/pipeline/common/When"
             },
-            "on" : {
-              "$ref" : "#/definitions/pipeline/common/On"
+            "failure" : {
+              "$ref" : "#/definitions/pipeline/common/FailureList"
             }
           },
           "oneOf" : [ {


### PR DESCRIPTION
Update failure strategies schema as per drone schema: https://github.com/drone/spec/pull/17

**Updated yaml of failure strategies:**
```
failures:
  - errors:
      - authorization
    action:
      type: abort
  - errors:
      - connectivity
    action:
      type: retry
      spec:
        attempts: 2
        intervals:
          - 10s
          - 20s
        failure:
          action:
            type: manual-intervention
            spec: 
              timeout: 10m
              timeout_action: 
                type: success
  - errors:
      - all
    action:
      type: manual-intervention
      spec: 
        timeout_action:
          type: ignore
        timeout: 10m
```

**older yaml:**
```
on:
  failure:
    - errors:
        - all
      type: retry
      spec: 
        attempts: 2
        interval: 10m
        spec:
           post_action:
              type: abort
```