### PR TITLE
feat: [CDS-79965]: POC - Allow null values for yaml fields in schema

### DIFF
--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -101,7 +101,29 @@
             "minItems" : 1
           },
           "inputs" : {
-            "type" : "object",
+            "anyOf" : [ {
+              "type" : null
+            }, {
+              "type" : "object",
+              "additionalProperties" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/StringInput"
+                }, {
+                  "$ref" : "#/definitions/pipeline/NumberInput"
+                }, {
+                  "$ref" : "#/definitions/pipeline/ArrayInput"
+                }, {
+                  "$ref" : "#/definitions/pipeline/BooleanInput"
+                }, {
+                  "$ref" : "#/definitions/pipeline/ObjectInput"
+                }, {
+                  "$ref" : "#/definitions/pipeline/SecretInput"
+                } ]
+              },
+              "propertyNames" : {
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0,127}$"
+              }
+            } ],
             "description" : "Inputs defines the pipeline input parameters.",
             "additionalProperties" : {
               "oneOf" : [ {
@@ -123,7 +145,7 @@
             }
           },
           "timeout" : {
-            "type" : "string",
+            "type" : [ "string", null ],
             "description" : "Defines pipeline timeout",
             "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
           },

--- a/v1/pipeline/pipeline_spec.yaml
+++ b/v1/pipeline/pipeline_spec.yaml
@@ -10,7 +10,19 @@ properties:
     maxItems: 256
     minItems: 1
   inputs:
-    type: object
+    anyOf:
+      - type: null
+      - type: object
+        additionalProperties:
+          oneOf:
+            - "$ref": ./string-input.yaml
+            - "$ref": ./number-input.yaml
+            - "$ref": ./array-input.yaml
+            - "$ref": ./boolean-input.yaml
+            - "$ref": ./object-input.yaml
+            - "$ref": ./secret-input.yaml
+        propertyNames:
+          pattern: "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0,127}$"
     description: Inputs defines the pipeline input parameters.
     additionalProperties:
       oneOf:
@@ -23,7 +35,9 @@ properties:
     propertyNames:
       pattern: "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0,127}$"
   timeout:
-    type: string
+    type:
+      - string
+      - null
     description: Defines pipeline timeout
     pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
   options:


### PR DESCRIPTION
For primitives we can directly use 
```
type: 
  - null
  - string/boolean/number
 ```

for object/array, we need to use 
```
anyOf:
  - type: null
  - type: object
    $ref: ./input.yaml
```