### PR TITLE
fix: [CDS-80869]: support runtime input for stacknames

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -16653,10 +16653,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -16741,10 +16747,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkSynthStepInfo"
@@ -16910,10 +16922,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -16995,10 +17013,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDiffStepInfo"
@@ -17173,10 +17197,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -17267,10 +17297,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDeployStepInfo"
@@ -17436,10 +17472,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -17521,10 +17563,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDestroyStepInfo"

--- a/v0/pipeline/steps/common/aws-cdk-deploy-step-info.yaml
+++ b/v0/pipeline/steps/common/aws-cdk-deploy-step-info.yaml
@@ -65,9 +65,13 @@ allOf:
         format: int32
       - type: string
     stackNames:
-      type: array
-      items:
-        type: string
+      oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -133,8 +137,12 @@ properties:
       format: int32
     - type: string
   stackNames:
-    type: array
-    items:
-      type: string
+    oneOf:
+    - type: array
+      items:
+        type: string
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for AwsCdkDeployStepInfo

--- a/v0/pipeline/steps/common/aws-cdk-destroy-step-info.yaml
+++ b/v0/pipeline/steps/common/aws-cdk-destroy-step-info.yaml
@@ -58,9 +58,13 @@ allOf:
         format: int32
       - type: string
     stackNames:
-      type: array
-      items:
-        type: string
+      oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -119,8 +123,12 @@ properties:
       format: int32
     - type: string
   stackNames:
-    type: array
-    items:
-      type: string
+    oneOf:
+    - type: array
+      items:
+        type: string
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for AwsCdkDestroyStepInfo

--- a/v0/pipeline/steps/common/aws-cdk-diff-step-info.yaml
+++ b/v0/pipeline/steps/common/aws-cdk-diff-step-info.yaml
@@ -58,9 +58,13 @@ allOf:
         format: int32
       - type: string
     stackNames:
-      type: array
-      items:
-        type: string
+      oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -119,8 +123,12 @@ properties:
       format: int32
     - type: string
   stackNames:
-    type: array
-    items:
-      type: string
+    oneOf:
+    - type: array
+      items:
+        type: string
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for AwsCdkDiffStepInfo

--- a/v0/pipeline/steps/common/aws-cdk-synth-step-info.yaml
+++ b/v0/pipeline/steps/common/aws-cdk-synth-step-info.yaml
@@ -60,9 +60,13 @@ allOf:
         format: int32
       - type: string
     stackNames:
-      type: array
-      items:
-        type: string
+      oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -123,8 +127,12 @@ properties:
       format: int32
     - type: string
   stackNames:
-    type: array
-    items:
-      type: string
+    oneOf:
+    - type: array
+      items:
+        type: string
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for AwsCdkSynthStepInfo

--- a/v0/template.json
+++ b/v0/template.json
@@ -45195,10 +45195,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -45283,10 +45289,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkSynthStepInfo"
@@ -45440,10 +45452,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -45525,10 +45543,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDiffStepInfo"
@@ -45691,10 +45715,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -45785,10 +45815,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDeployStepInfo"
@@ -45942,10 +45978,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -46027,10 +46069,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDestroyStepInfo"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -16243,10 +16243,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -16331,10 +16337,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkSynthStepInfo"
@@ -16500,10 +16512,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -16585,10 +16603,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDiffStepInfo"
@@ -16763,10 +16787,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -16857,10 +16887,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDeployStepInfo"
@@ -17026,10 +17062,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -17111,10 +17153,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDestroyStepInfo"

--- a/v1/pipeline/steps/common/aws-cdk-deploy-step-info.yaml
+++ b/v1/pipeline/steps/common/aws-cdk-deploy-step-info.yaml
@@ -65,9 +65,13 @@ allOf:
         format: int32
       - type: string
     stackNames:
-      type: array
-      items:
-        type: string
+      oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -133,8 +137,12 @@ properties:
       format: int32
     - type: string
   stackNames:
-    type: array
-    items:
-      type: string
+    oneOf:
+    - type: array
+      items:
+        type: string
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for AwsCdkDeployStepInfo

--- a/v1/pipeline/steps/common/aws-cdk-destroy-step-info.yaml
+++ b/v1/pipeline/steps/common/aws-cdk-destroy-step-info.yaml
@@ -58,9 +58,13 @@ allOf:
         format: int32
       - type: string
     stackNames:
-      type: array
-      items:
-        type: string
+      oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -119,8 +123,12 @@ properties:
       format: int32
     - type: string
   stackNames:
-    type: array
-    items:
-      type: string
+    oneOf:
+    - type: array
+      items:
+        type: string
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for AwsCdkDestroyStepInfo

--- a/v1/pipeline/steps/common/aws-cdk-diff-step-info.yaml
+++ b/v1/pipeline/steps/common/aws-cdk-diff-step-info.yaml
@@ -58,9 +58,13 @@ allOf:
         format: int32
       - type: string
     stackNames:
-      type: array
-      items:
-        type: string
+      oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -119,8 +123,12 @@ properties:
       format: int32
     - type: string
   stackNames:
-    type: array
-    items:
-      type: string
+    oneOf:
+    - type: array
+      items:
+        type: string
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for AwsCdkDiffStepInfo

--- a/v1/pipeline/steps/common/aws-cdk-synth-step-info.yaml
+++ b/v1/pipeline/steps/common/aws-cdk-synth-step-info.yaml
@@ -60,9 +60,13 @@ allOf:
         format: int32
       - type: string
     stackNames:
-      type: array
-      items:
-        type: string
+      oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -123,8 +127,12 @@ properties:
       format: int32
     - type: string
   stackNames:
-    type: array
-    items:
-      type: string
+    oneOf:
+    - type: array
+      items:
+        type: string
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for AwsCdkSynthStepInfo

--- a/v1/template.json
+++ b/v1/template.json
@@ -44409,10 +44409,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -44497,10 +44503,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkSynthStepInfo"
@@ -44654,10 +44666,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -44739,10 +44757,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDiffStepInfo"
@@ -44905,10 +44929,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -44999,10 +45029,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDeployStepInfo"
@@ -45156,10 +45192,16 @@
                   } ]
                 },
                 "stackNames" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -45241,10 +45283,16 @@
                 } ]
               },
               "stackNames" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsCdkDestroyStepInfo"


### PR DESCRIPTION
fix: [CDS-80869]: support runtime input for stacknames

[CDS-80869]: https://harness.atlassian.net/browse/CDS-80869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ