### PR TITLE
[feat]: [CDS-77899]: adding the step-group schema for custom-stage so that the inner spec for the step-group is validated properly

### DIFF
--- a/v1/examples/templates/group.yaml
+++ b/v1/examples/templates/group.yaml
@@ -2,13 +2,20 @@ version: 1
 kind: template
 spec:
   type: group
+  stage: custom
   spec:
     steps:
-      - type: plugin
-        id: http1
-        timeout: 10m
+      - type: http
+        id: http_1
         spec:
-          uses: http
-          with:
-            url: https://www.<+ template.inputs.env>.harness.io
-            method: GET
+          url: https://www.google.com
+          method: GET
+      - type: shell-script
+        id: shell_script_1
+        spec:
+          shell: bash
+          on_delegate: true
+          source:
+            type: Inline
+            spec:
+              script: echo Hi

--- a/v1/template.json
+++ b/v1/template.json
@@ -715,7 +715,7 @@
         "StepGroupTemplate" : {
           "type" : "object",
           "title" : "StepGroupTemplate",
-          "required" : [ "type", "spec" ],
+          "required" : [ "type", "spec" ,"stage"],
           "properties" : {
             "labels" : {
               "type" : "object",
@@ -749,20 +749,25 @@
               "description" : "defines the type of template",
               "type" : "string",
               "enum" : [ "group" ]
+            },
+            "stage" : {
+              "description" : "defines the stage type of the group template",
+              "type" : "string",
+              "enum" : [ "custom", "deployment", "ci" ]
             }
           },
           "allOf" : [ {
             "if" : {
               "properties" : {
-                "type" : {
-                  "const" : "group"
+                "stage" : {
+                  "const" : "custom"
                 }
               }
             },
             "then" : {
               "properties" : {
                 "spec" : {
-                  "type" : "object"
+                  "$ref" : "#/definitions/pipeline/stages/custom/CustomStageSpecElementConfig"
                 }
               }
             }
@@ -63237,5 +63242,6 @@
         }
       }
     }
-  }
+  },
+  "$schema" : "http://json-schema.org/draft-07/schema#"
 }


### PR DESCRIPTION
Adding the step-group schema for custom-stage so that the inner spec for the step-group is validated properly.

Till now the spec of the step-group was simply an object. So any random object as spec of the step-group was valid according to schema.

Now we are using the correct ref so that the ref schema validates the correct YAML only.
The below YAML validates correctly.
```version: 1
kind: template
spec:
  type: group
  stage: custom
  spec:
    steps:
      - type: http
        name: http_1
        spec:
           url: www.google.com
           method: GET
      - type: http
        name: http_2
        spec:
           url: www.google.com
           method: GET
```

But the below YAML will give error that the method is a required field but missing in the http step. See the scrrenshot attached belowl.
(In earlier schema that would also be considered valid.)
```version: 1
kind: template
spec:
  type: group
  stage: custom
  spec:
    steps:
      - type: http
        name: http_1
        spec:
           url: www.google.com
      - type: http
        name: http_2
        spec:
           url: www.google.com
           method: GET
```

<img width="656" alt="Screenshot 2023-10-30 at 11 12 10 PM" src="https://github.com/harness/harness-schema/assets/67271723/cd542add-ed67-422a-9464-59e690983648">
