### PR TITLE
feat: [SSCA-1004]: Updating the ssca enforcement schema to use either the policy object or the policySet object

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11365,16 +11365,15 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
+              "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ],
               "properties" : {
-                "description" : {
-                  "desc" : "This is the description for CdSscaEnforcementStepInfo"
-                },
                 "infrastructure" : {
                   "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-                  }, {
-                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
+                    "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
                   } ]
+                },
+                "policy" : {
+                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -11386,7 +11385,26 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ]
+            "required" : [ "infrastructure", "policy", "source" ],
+            "properties" : {
+              "infrastructure" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
+                } ]
+              },
+              "policy" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+              },
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
+              },
+              "verifyAttestation" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
+              },
+              "description" : {
+                "desc" : "This is the description for CdSscaEnforcementStepInfo"
+              }
+            }
           },
           "EnforcementPolicy" : {
             "title" : "EnforcementPolicy",
@@ -11432,20 +11450,6 @@
                 }
               }
             } ]
-          },
-          "SscaOpaPolicyConfig" : {
-            "title" : "SscaOpaPolicyConfig",
-            "type" : "object",
-            "required" : [ "policySet" ],
-            "properties" : {
-              "policySet" : {
-                "type" : "string"
-              },
-              "description" : {
-                "desc" : "The reference of the SBOM OPA policy set."
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "VerifyAttestation" : {
             "title" : "VerifyAttestation",
@@ -11505,6 +11509,20 @@
                 "desc" : "This is the description for VerifyAttestationSpec"
               }
             }
+          },
+          "SscaOpaPolicyConfig" : {
+            "title" : "SscaOpaPolicyConfig",
+            "type" : "object",
+            "required" : [ "policySet" ],
+            "properties" : {
+              "policySet" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "The reference of the SBOM OPA policy set."
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "HttpStepNode" : {
             "title" : "HttpStepNode",

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11378,12 +11378,8 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "object",
-                    "properties" : {
-                      "policySet" : {
-                        "type" : "string"
-                      }
-                    },
+                    "type" : "string",
+                    "title" : "policySet",
                     "description" : {
                       "desc" : "The reference of the SBOM OPA policy set."
                     }
@@ -16639,12 +16635,8 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "object",
-                    "properties" : {
-                      "policySet" : {
-                        "type" : "string"
-                      }
-                    },
+                    "type" : "string",
+                    "title" : "policySet",
                     "description" : {
                       "desc" : "The reference of the SBOM OPA policy set."
                     }

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11371,18 +11371,9 @@
                 },
                 "infrastructure" : {
                   "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
-                  } ]
-                },
-                "policy" : {
-                  "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "string",
-                    "title" : "policySet",
-                    "description" : {
-                      "desc" : "The reference of the SBOM OPA policy set."
-                    }
+                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
                   } ]
                 },
                 "source" : {
@@ -11408,7 +11399,8 @@
                 "desc" : "This is the description for EnforcementPolicy"
               }
             },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "required" : [ "store" ]
           },
           "PolicyStore" : {
             "title" : "PolicyStore",
@@ -11440,6 +11432,20 @@
                 }
               }
             } ]
+          },
+          "SscaOpaPolicyConfig" : {
+            "title" : "SscaOpaPolicyConfig",
+            "type" : "object",
+            "required" : [ "policySet" ],
+            "properties" : {
+              "policySet" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "The reference of the SBOM OPA policy set."
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "VerifyAttestation" : {
             "title" : "VerifyAttestation",
@@ -16635,11 +16641,7 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "string",
-                    "title" : "policySet",
-                    "description" : {
-                      "desc" : "The reference of the SBOM OPA policy set."
-                    }
+                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
                   } ]
                 },
                 "source" : {

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11365,15 +11365,29 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ],
               "properties" : {
+                "description" : {
+                  "desc" : "This is the description for CdSscaEnforcementStepInfo"
+                },
                 "infrastructure" : {
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
                   } ]
                 },
                 "policy" : {
-                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "policySet" : {
+                        "type" : "string"
+                      }
+                    },
+                    "description" : {
+                      "desc" : "The reference of the SBOM OPA policy set."
+                    }
+                  } ]
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -11385,26 +11399,7 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "infrastructure", "policy", "source" ],
-            "properties" : {
-              "infrastructure" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
-                } ]
-              },
-              "policy" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-              },
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
-              },
-              "verifyAttestation" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
-              },
-              "description" : {
-                "desc" : "This is the description for CdSscaEnforcementStepInfo"
-              }
-            }
+            "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ]
           },
           "EnforcementPolicy" : {
             "title" : "EnforcementPolicy",
@@ -16636,10 +16631,24 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "policy", "source" ],
               "properties" : {
+                "description" : {
+                  "desc" : "This is the description for SscaEnforcementStepInfo"
+                },
                 "policy" : {
-                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "policySet" : {
+                        "type" : "string"
+                      }
+                    },
+                    "description" : {
+                      "desc" : "The reference of the SBOM OPA policy set."
+                    }
+                  } ]
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -16654,24 +16663,7 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "policy", "source" ],
-            "properties" : {
-              "policy" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-              },
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
-              },
-              "verifyAttestation" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
-              },
-              "description" : {
-                "desc" : "This is the description for SscaEnforcementStepInfo"
-              },
-              "resources" : {
-                "$ref" : "#/definitions/pipeline/common/ContainerResource"
-              }
-            }
+            "required" : [ "policy", "source" ]
           },
           "SscaOrchestrationStepNode" : {
             "title" : "SscaOrchestrationStepNode",

--- a/v0/pipeline/steps/common/ssca-enforcement-step-info.yaml
+++ b/v0/pipeline/steps/common/ssca-enforcement-step-info.yaml
@@ -2,12 +2,18 @@ title: SscaEnforcementStepInfo
 allOf:
 - $ref: ../../common/step-spec-type.yaml
 - type: object
-  required:
-  - policy
-  - source
   properties:
+    description:
+      desc: This is the description for SscaEnforcementStepInfo
     policy:
-      $ref: ../custom/enforcement-policy.yaml
+      oneOf:
+        - $ref: ../custom/enforcement-policy.yaml
+        - type: object
+          properties:
+            policySet:
+              type: string
+          description:
+            desc: The reference of the SBOM OPA policy set.
     source:
       $ref: ../custom/sbom-source.yaml
     verifyAttestation:
@@ -19,14 +25,3 @@ type: object
 required:
 - policy
 - source
-properties:
-  policy:
-    $ref: ../custom/enforcement-policy.yaml
-  source:
-    $ref: ../custom/sbom-source.yaml
-  verifyAttestation:
-    $ref: ../custom/verify-attestation.yaml
-  description:
-    desc: This is the description for SscaEnforcementStepInfo
-  resources:
-    $ref: ../../common/container-resource.yaml

--- a/v0/pipeline/steps/common/ssca-enforcement-step-info.yaml
+++ b/v0/pipeline/steps/common/ssca-enforcement-step-info.yaml
@@ -8,10 +8,8 @@ allOf:
     policy:
       oneOf:
         - $ref: ../custom/enforcement-policy.yaml
-        - type: object
-          properties:
-            policySet:
-              type: string
+        - type: string
+          title: policySet
           description:
             desc: The reference of the SBOM OPA policy set.
     source:

--- a/v0/pipeline/steps/common/ssca-enforcement-step-info.yaml
+++ b/v0/pipeline/steps/common/ssca-enforcement-step-info.yaml
@@ -8,10 +8,7 @@ allOf:
     policy:
       oneOf:
         - $ref: ../custom/enforcement-policy.yaml
-        - type: string
-          title: policySet
-          description:
-            desc: The reference of the SBOM OPA policy set.
+        - $ref: ../custom/ssca-opa-policy-config.yaml
     source:
       $ref: ../custom/sbom-source.yaml
     verifyAttestation:

--- a/v0/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
+++ b/v0/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
@@ -11,10 +11,8 @@ allOf:
       policy:
         oneOf:
           - $ref: ../custom/enforcement-policy.yaml
-          - type: object
-            properties:
-              policySet:
-                type: string
+          - type: string
+            title: policySet
             description:
               desc: The reference of the SBOM OPA policy set.
       source:

--- a/v0/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
+++ b/v0/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
@@ -7,14 +7,8 @@ allOf:
         desc: This is the description for CdSscaEnforcementStepInfo
       infrastructure:
         oneOf:
-          - $ref: container-k8s-infra.yaml
-      policy:
-        oneOf:
           - $ref: ../custom/enforcement-policy.yaml
-          - type: string
-            title: policySet
-            description:
-              desc: The reference of the SBOM OPA policy set.
+          - $ref: ../custom/ssca-opa-policy-config.yaml
       source:
         $ref: sbom-source.yaml
       verifyAttestation:

--- a/v0/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
+++ b/v0/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
@@ -1,22 +1,37 @@
 title: CdSscaEnforcementStepInfo
 allOf:
-  - $ref: ../../common/step-spec-type.yaml
-  - type: object
-    properties:
-      description:
-        desc: This is the description for CdSscaEnforcementStepInfo
-      infrastructure:
-        oneOf:
-          - $ref: ../custom/enforcement-policy.yaml
-          - $ref: ../custom/ssca-opa-policy-config.yaml
-      source:
-        $ref: sbom-source.yaml
-      verifyAttestation:
-        $ref: verify-attestation.yaml
-$schema: http://json-schema.org/draft-07/schema#
-type: object
-required:
+- $ref: ../../common/step-spec-type.yaml
+- type: object
+  required:
   - infrastructure
   - policy
   - source
   - verifyAttestation
+  properties:
+    infrastructure:
+      oneOf:
+      - $ref: container-k8s-infra.yaml
+    policy:
+      $ref: enforcement-policy.yaml
+    source:
+      $ref: sbom-source.yaml
+    verifyAttestation:
+      $ref: verify-attestation.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+- infrastructure
+- policy
+- source
+properties:
+  infrastructure:
+    oneOf:
+    - $ref: container-k8s-infra.yaml
+  policy:
+    $ref: enforcement-policy.yaml
+  source:
+    $ref: sbom-source.yaml
+  verifyAttestation:
+    $ref: verify-attestation.yaml
+  description:
+    desc: This is the description for CdSscaEnforcementStepInfo

--- a/v0/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
+++ b/v0/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
@@ -1,37 +1,30 @@
 title: CdSscaEnforcementStepInfo
 allOf:
-- $ref: ../../common/step-spec-type.yaml
-- type: object
-  required:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    properties:
+      description:
+        desc: This is the description for CdSscaEnforcementStepInfo
+      infrastructure:
+        oneOf:
+          - $ref: container-k8s-infra.yaml
+      policy:
+        oneOf:
+          - $ref: ../custom/enforcement-policy.yaml
+          - type: object
+            properties:
+              policySet:
+                type: string
+            description:
+              desc: The reference of the SBOM OPA policy set.
+      source:
+        $ref: sbom-source.yaml
+      verifyAttestation:
+        $ref: verify-attestation.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
   - infrastructure
   - policy
   - source
   - verifyAttestation
-  properties:
-    infrastructure:
-      oneOf:
-      - $ref: container-k8s-infra.yaml
-    policy:
-      $ref: enforcement-policy.yaml
-    source:
-      $ref: sbom-source.yaml
-    verifyAttestation:
-      $ref: verify-attestation.yaml
-$schema: http://json-schema.org/draft-07/schema#
-type: object
-required:
-- infrastructure
-- policy
-- source
-properties:
-  infrastructure:
-    oneOf:
-    - $ref: container-k8s-infra.yaml
-  policy:
-    $ref: enforcement-policy.yaml
-  source:
-    $ref: sbom-source.yaml
-  verifyAttestation:
-    $ref: verify-attestation.yaml
-  description:
-    desc: This is the description for CdSscaEnforcementStepInfo

--- a/v0/pipeline/steps/custom/enforcement-policy.yaml
+++ b/v0/pipeline/steps/custom/enforcement-policy.yaml
@@ -6,3 +6,5 @@ properties:
   description:
     desc: This is the description for EnforcementPolicy
 $schema: http://json-schema.org/draft-07/schema#
+required:
+  - store

--- a/v0/pipeline/steps/custom/ssca-opa-policy-config.yaml
+++ b/v0/pipeline/steps/custom/ssca-opa-policy-config.yaml
@@ -1,0 +1,10 @@
+title: SscaOpaPolicyConfig
+type: object
+required:
+- policySet
+properties:
+  policySet:
+    type: string
+  description:
+    desc: The reference of the SBOM OPA policy set.
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/template.json
+++ b/v0/template.json
@@ -34283,15 +34283,29 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ],
               "properties" : {
+                "description" : {
+                  "desc" : "This is the description for CdSscaEnforcementStepInfo"
+                },
                 "infrastructure" : {
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
                   } ]
                 },
                 "policy" : {
-                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "policySet" : {
+                        "type" : "string"
+                      }
+                    },
+                    "description" : {
+                      "desc" : "The reference of the SBOM OPA policy set."
+                    }
+                  } ]
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -34303,26 +34317,7 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "infrastructure", "policy", "source" ],
-            "properties" : {
-              "infrastructure" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
-                } ]
-              },
-              "policy" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-              },
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
-              },
-              "verifyAttestation" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
-              },
-              "description" : {
-                "desc" : "This is the description for CdSscaEnforcementStepInfo"
-              }
-            }
+            "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ]
           },
           "CdSscaOrchestrationStepNode" : {
             "title" : "CdSscaOrchestrationStepNode",
@@ -34630,10 +34625,24 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "policy", "source" ],
               "properties" : {
+                "description" : {
+                  "desc" : "This is the description for SscaEnforcementStepInfo"
+                },
                 "policy" : {
-                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "policySet" : {
+                        "type" : "string"
+                      }
+                    },
+                    "description" : {
+                      "desc" : "The reference of the SBOM OPA policy set."
+                    }
+                  } ]
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -34648,24 +34657,7 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "policy", "source" ],
-            "properties" : {
-              "policy" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-              },
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
-              },
-              "verifyAttestation" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
-              },
-              "description" : {
-                "desc" : "This is the description for SscaEnforcementStepInfo"
-              },
-              "resources" : {
-                "$ref" : "#/definitions/pipeline/common/ContainerResource"
-              }
-            }
+            "required" : [ "policy", "source" ]
           },
           "SscaOrchestrationStepNode_template" : {
             "title" : "SscaOrchestrationStepNode_template",

--- a/v0/template.json
+++ b/v0/template.json
@@ -34298,16 +34298,15 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
+              "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ],
               "properties" : {
-                "description" : {
-                  "desc" : "This is the description for CdSscaEnforcementStepInfo"
-                },
                 "infrastructure" : {
                   "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-                  }, {
-                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
+                    "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
                   } ]
+                },
+                "policy" : {
+                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -34319,7 +34318,26 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ]
+            "required" : [ "infrastructure", "policy", "source" ],
+            "properties" : {
+              "infrastructure" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
+                } ]
+              },
+              "policy" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+              },
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
+              },
+              "verifyAttestation" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
+              },
+              "description" : {
+                "desc" : "This is the description for CdSscaEnforcementStepInfo"
+              }
+            }
           },
           "CdSscaOrchestrationStepNode" : {
             "title" : "CdSscaOrchestrationStepNode",

--- a/v0/template.json
+++ b/v0/template.json
@@ -28943,7 +28943,8 @@
                 "desc" : "This is the description for EnforcementPolicy"
               }
             },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "required" : [ "store" ]
           },
           "PolicyStore" : {
             "title" : "PolicyStore",
@@ -28975,6 +28976,20 @@
                 }
               }
             } ]
+          },
+          "SscaOpaPolicyConfig" : {
+            "title" : "SscaOpaPolicyConfig",
+            "type" : "object",
+            "required" : [ "policySet" ],
+            "properties" : {
+              "policySet" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "The reference of the SBOM OPA policy set."
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "SbomSource" : {
             "title" : "SbomSource",
@@ -34289,18 +34304,9 @@
                 },
                 "infrastructure" : {
                   "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
-                  } ]
-                },
-                "policy" : {
-                  "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "string",
-                    "title" : "policySet",
-                    "description" : {
-                      "desc" : "The reference of the SBOM OPA policy set."
-                    }
+                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
                   } ]
                 },
                 "source" : {
@@ -34629,11 +34635,7 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "string",
-                    "title" : "policySet",
-                    "description" : {
-                      "desc" : "The reference of the SBOM OPA policy set."
-                    }
+                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
                   } ]
                 },
                 "source" : {

--- a/v0/template.json
+++ b/v0/template.json
@@ -34296,12 +34296,8 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "object",
-                    "properties" : {
-                      "policySet" : {
-                        "type" : "string"
-                      }
-                    },
+                    "type" : "string",
+                    "title" : "policySet",
                     "description" : {
                       "desc" : "The reference of the SBOM OPA policy set."
                     }
@@ -34633,12 +34629,8 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "object",
-                    "properties" : {
-                      "policySet" : {
-                        "type" : "string"
-                      }
-                    },
+                    "type" : "string",
+                    "title" : "policySet",
                     "description" : {
                       "desc" : "The reference of the SBOM OPA policy set."
                     }

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -12081,12 +12081,8 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "object",
-                    "properties" : {
-                      "policySet" : {
-                        "type" : "string"
-                      }
-                    },
+                    "type" : "string",
+                    "title" : "policySet",
                     "description" : {
                       "desc" : "The reference of the SBOM OPA policy set."
                     }

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -12068,15 +12068,29 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ],
               "properties" : {
+                "description" : {
+                  "desc" : "This is the description for CdSscaEnforcementStepInfo"
+                },
                 "infrastructure" : {
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
                   } ]
                 },
                 "policy" : {
-                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "policySet" : {
+                        "type" : "string"
+                      }
+                    },
+                    "description" : {
+                      "desc" : "The reference of the SBOM OPA policy set."
+                    }
+                  } ]
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -12088,26 +12102,7 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "infrastructure", "policy", "source" ],
-            "properties" : {
-              "infrastructure" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
-                } ]
-              },
-              "policy" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-              },
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
-              },
-              "verifyAttestation" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
-              },
-              "description" : {
-                "desc" : "This is the description for CdSscaEnforcementStepInfo"
-              }
-            }
+            "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ]
           },
           "EnforcementPolicy" : {
             "title" : "EnforcementPolicy",

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -12068,21 +12068,15 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
+              "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ],
               "properties" : {
-                "description" : {
-                  "desc" : "This is the description for CdSscaEnforcementStepInfo"
-                },
                 "infrastructure" : {
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
                   } ]
                 },
                 "policy" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-                  }, {
-                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
-                  } ]
+                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -12094,7 +12088,26 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ]
+            "required" : [ "infrastructure", "policy", "source" ],
+            "properties" : {
+              "infrastructure" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
+                } ]
+              },
+              "policy" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+              },
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
+              },
+              "verifyAttestation" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
+              },
+              "description" : {
+                "desc" : "This is the description for CdSscaEnforcementStepInfo"
+              }
+            }
           },
           "EnforcementPolicy" : {
             "title" : "EnforcementPolicy",
@@ -12140,20 +12153,6 @@
                 }
               }
             } ]
-          },
-          "SscaOpaPolicyConfig" : {
-            "title" : "SscaOpaPolicyConfig",
-            "type" : "object",
-            "required" : [ "policySet" ],
-            "properties" : {
-              "policySet" : {
-                "type" : "string"
-              },
-              "description" : {
-                "desc" : "The reference of the SBOM OPA policy set."
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "VerifyAttestation" : {
             "title" : "VerifyAttestation",

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -12081,11 +12081,7 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "string",
-                    "title" : "policySet",
-                    "description" : {
-                      "desc" : "The reference of the SBOM OPA policy set."
-                    }
+                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
                   } ]
                 },
                 "source" : {
@@ -12111,7 +12107,8 @@
                 "desc" : "This is the description for EnforcementPolicy"
               }
             },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "required" : [ "store" ]
           },
           "PolicyStore" : {
             "title" : "PolicyStore",
@@ -12143,6 +12140,20 @@
                 }
               }
             } ]
+          },
+          "SscaOpaPolicyConfig" : {
+            "title" : "SscaOpaPolicyConfig",
+            "type" : "object",
+            "required" : [ "policySet" ],
+            "properties" : {
+              "policySet" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "The reference of the SBOM OPA policy set."
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "VerifyAttestation" : {
             "title" : "VerifyAttestation",

--- a/v1/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
+++ b/v1/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
@@ -2,17 +2,21 @@ title: CdSscaEnforcementStepInfo
 allOf:
 - $ref: ../../common/step-spec-type.yaml
 - type: object
-  required:
-  - infrastructure
-  - policy
-  - source
-  - verifyAttestation
   properties:
+    description:
+      desc: This is the description for CdSscaEnforcementStepInfo
     infrastructure:
       oneOf:
       - $ref: container-k8s-infra.yaml
     policy:
-      $ref: enforcement-policy.yaml
+      oneOf:
+        - $ref: ../custom/enforcement-policy.yaml
+        - type: object
+          properties:
+            policySet:
+              type: string
+          description:
+            desc: The reference of the SBOM OPA policy set.
     source:
       $ref: sbom-source.yaml
     verifyAttestation:
@@ -23,15 +27,5 @@ required:
 - infrastructure
 - policy
 - source
-properties:
-  infrastructure:
-    oneOf:
-    - $ref: container-k8s-infra.yaml
-  policy:
-    $ref: enforcement-policy.yaml
-  source:
-    $ref: sbom-source.yaml
-  verifyAttestation:
-    $ref: verify-attestation.yaml
-  description:
-    desc: This is the description for CdSscaEnforcementStepInfo
+- verifyAttestation
+

--- a/v1/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
+++ b/v1/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
@@ -11,10 +11,7 @@ allOf:
     policy:
       oneOf:
         - $ref: ../custom/enforcement-policy.yaml
-        - type: string
-          title: policySet
-          description:
-            desc: The reference of the SBOM OPA policy set.
+        - $ref: ../custom/ssca-opa-policy-config.yaml
     source:
       $ref: sbom-source.yaml
     verifyAttestation:

--- a/v1/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
+++ b/v1/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
@@ -11,10 +11,8 @@ allOf:
     policy:
       oneOf:
         - $ref: ../custom/enforcement-policy.yaml
-        - type: object
-          properties:
-            policySet:
-              type: string
+        - type: string
+          title: policySet
           description:
             desc: The reference of the SBOM OPA policy set.
     source:

--- a/v1/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
+++ b/v1/pipeline/steps/custom/cd-ssca-enforcement-step-info.yaml
@@ -2,16 +2,17 @@ title: CdSscaEnforcementStepInfo
 allOf:
 - $ref: ../../common/step-spec-type.yaml
 - type: object
+  required:
+  - infrastructure
+  - policy
+  - source
+  - verifyAttestation
   properties:
-    description:
-      desc: This is the description for CdSscaEnforcementStepInfo
     infrastructure:
       oneOf:
       - $ref: container-k8s-infra.yaml
     policy:
-      oneOf:
-        - $ref: ../custom/enforcement-policy.yaml
-        - $ref: ../custom/ssca-opa-policy-config.yaml
+      $ref: enforcement-policy.yaml
     source:
       $ref: sbom-source.yaml
     verifyAttestation:
@@ -22,5 +23,15 @@ required:
 - infrastructure
 - policy
 - source
-- verifyAttestation
-
+properties:
+  infrastructure:
+    oneOf:
+    - $ref: container-k8s-infra.yaml
+  policy:
+    $ref: enforcement-policy.yaml
+  source:
+    $ref: sbom-source.yaml
+  verifyAttestation:
+    $ref: verify-attestation.yaml
+  description:
+    desc: This is the description for CdSscaEnforcementStepInfo

--- a/v1/pipeline/steps/custom/enforcement-policy.yaml
+++ b/v1/pipeline/steps/custom/enforcement-policy.yaml
@@ -6,3 +6,5 @@ properties:
   description:
     desc: This is the description for EnforcementPolicy
 $schema: http://json-schema.org/draft-07/schema#
+required:
+  - store

--- a/v1/pipeline/steps/custom/ssca-opa-policy-config.yaml
+++ b/v1/pipeline/steps/custom/ssca-opa-policy-config.yaml
@@ -1,0 +1,10 @@
+title: SscaOpaPolicyConfig
+type: object
+required:
+- policySet
+properties:
+  policySet:
+    type: string
+  description:
+    desc: The reference of the SBOM OPA policy set.
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/template.json
+++ b/v1/template.json
@@ -34610,21 +34610,15 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
+              "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ],
               "properties" : {
-                "description" : {
-                  "desc" : "This is the description for CdSscaEnforcementStepInfo"
-                },
                 "infrastructure" : {
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
                   } ]
                 },
                 "policy" : {
-                  "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-                  }, {
-                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
-                  } ]
+                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -34636,7 +34630,26 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ]
+            "required" : [ "infrastructure", "policy", "source" ],
+            "properties" : {
+              "infrastructure" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
+                } ]
+              },
+              "policy" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+              },
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
+              },
+              "verifyAttestation" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
+              },
+              "description" : {
+                "desc" : "This is the description for CdSscaEnforcementStepInfo"
+              }
+            }
           },
           "EnforcementPolicy" : {
             "title" : "EnforcementPolicy",
@@ -34682,20 +34695,6 @@
                 }
               }
             } ]
-          },
-          "SscaOpaPolicyConfig" : {
-            "title" : "SscaOpaPolicyConfig",
-            "type" : "object",
-            "required" : [ "policySet" ],
-            "properties" : {
-              "policySet" : {
-                "type" : "string"
-              },
-              "description" : {
-                "desc" : "The reference of the SBOM OPA policy set."
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "VerifyAttestation" : {
             "title" : "VerifyAttestation",

--- a/v1/template.json
+++ b/v1/template.json
@@ -34610,15 +34610,29 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ],
               "properties" : {
+                "description" : {
+                  "desc" : "This is the description for CdSscaEnforcementStepInfo"
+                },
                 "infrastructure" : {
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
                   } ]
                 },
                 "policy" : {
-                  "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
+                  }, {
+                    "type" : "object",
+                    "properties" : {
+                      "policySet" : {
+                        "type" : "string"
+                      }
+                    },
+                    "description" : {
+                      "desc" : "The reference of the SBOM OPA policy set."
+                    }
+                  } ]
                 },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
@@ -34630,26 +34644,7 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "infrastructure", "policy", "source" ],
-            "properties" : {
-              "infrastructure" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/steps/custom/ContainerK8sInfra"
-                } ]
-              },
-              "policy" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
-              },
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/SbomSource"
-              },
-              "verifyAttestation" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestation"
-              },
-              "description" : {
-                "desc" : "This is the description for CdSscaEnforcementStepInfo"
-              }
-            }
+            "required" : [ "infrastructure", "policy", "source", "verifyAttestation" ]
           },
           "EnforcementPolicy" : {
             "title" : "EnforcementPolicy",

--- a/v1/template.json
+++ b/v1/template.json
@@ -34623,11 +34623,7 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "string",
-                    "title" : "policySet",
-                    "description" : {
-                      "desc" : "The reference of the SBOM OPA policy set."
-                    }
+                    "$ref" : "#/definitions/pipeline/steps/custom/SscaOpaPolicyConfig"
                   } ]
                 },
                 "source" : {
@@ -34653,7 +34649,8 @@
                 "desc" : "This is the description for EnforcementPolicy"
               }
             },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "required" : [ "store" ]
           },
           "PolicyStore" : {
             "title" : "PolicyStore",
@@ -34685,6 +34682,20 @@
                 }
               }
             } ]
+          },
+          "SscaOpaPolicyConfig" : {
+            "title" : "SscaOpaPolicyConfig",
+            "type" : "object",
+            "required" : [ "policySet" ],
+            "properties" : {
+              "policySet" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "The reference of the SBOM OPA policy set."
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "VerifyAttestation" : {
             "title" : "VerifyAttestation",

--- a/v1/template.json
+++ b/v1/template.json
@@ -34623,12 +34623,8 @@
                   "oneOf" : [ {
                     "$ref" : "#/definitions/pipeline/steps/custom/EnforcementPolicy"
                   }, {
-                    "type" : "object",
-                    "properties" : {
-                      "policySet" : {
-                        "type" : "string"
-                      }
-                    },
+                    "type" : "string",
+                    "title" : "policySet",
                     "description" : {
                       "desc" : "The reference of the SBOM OPA policy set."
                     }


### PR DESCRIPTION
**Existing schema**

      policy:
        store:
          type: Harness
          spec:
            file: /valid_policy_file_for_at
      resources:

**New schema**

> with policy object

      policy:
        store:
          type: Harness
          spec:
            file: /valid_policy_file_for_at
      resources:

> with policySet object

      policy:
        policySet: <scopedPolicySetRef>   
      resources: