### PR TITLE
[fix]: [CDS-85889] : add oneof logic in between filepaths and manifest source for Apply Step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -47939,6 +47939,12 @@
             "allOf" : [ {
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
+              "oneOf" : [ {
+                "required" : [ "filePaths" ]
+              }, {
+                "required" : [ "manifestSource" ]
+              } ]
+            }, {
               "type" : "object",
               "properties" : {
                 "commandFlags" : {

--- a/v0/pipeline/steps/cd/k8s-apply-step-info.yaml
+++ b/v0/pipeline/steps/cd/k8s-apply-step-info.yaml
@@ -1,6 +1,11 @@
 title: K8sApplyStepInfo
 allOf:
 - $ref: ../../common/step-spec-type.yaml
+- oneOf:
+  - required:
+    - filePaths
+  - required:
+    - manifestSource
 - type: object
   properties:
     commandFlags:

--- a/v0/template.json
+++ b/v0/template.json
@@ -10463,6 +10463,12 @@
             "allOf" : [ {
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
+              "oneOf" : [ {
+                "required" : [ "filePaths" ]
+              }, {
+                "required" : [ "manifestSource" ]
+              } ]
+            }, {
               "type" : "object",
               "properties" : {
                 "commandFlags" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -38807,6 +38807,12 @@
             "allOf" : [ {
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
+              "oneOf" : [ {
+                "required" : [ "filePaths" ]
+              }, {
+                "required" : [ "manifestSource" ]
+              } ]
+            }, {
               "type" : "object",
               "properties" : {
                 "commandFlags" : {

--- a/v1/pipeline/steps/cd/k8s-apply-step-info.yaml
+++ b/v1/pipeline/steps/cd/k8s-apply-step-info.yaml
@@ -1,6 +1,11 @@
 title: K8sApplyStepInfo
 allOf:
 - $ref: ../../common/step-spec-type.yaml
+- oneOf:
+  - required:
+    - filePaths
+  - required:
+    - manifestSource
 - type: object
   properties:
     commandFlags:

--- a/v1/template.json
+++ b/v1/template.json
@@ -12375,6 +12375,12 @@
             "allOf" : [ {
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
+              "oneOf" : [ {
+                "required" : [ "filePaths" ]
+              }, {
+                "required" : [ "manifestSource" ]
+              } ]
+            }, {
               "type" : "object",
               "properties" : {
                 "commandFlags" : {


### PR DESCRIPTION
Description:
Adding logic to not allow user to save when providing both filepaths and manifestSource for K8sApplyStep. Previously added this logic in core repository which used to work on local and devspace but is not working on QA. 
Testing:
1. did local testing by using generated pipeline.json in harness-core, 
When filepath and manifest source both are provided
<img width="851" alt="Screenshot 2023-12-04 at 8 52 56 AM" src="https://github.com/harness/harness-schema/assets/106597485/2bbc8311-d57a-448f-8b5d-b72f48b6e9dd">
2. when only one exists
<img width="569" alt="Screenshot 2023-12-04 at 8 53 06 AM" src="https://github.com/harness/harness-schema/assets/106597485/6842c3a9-2328-46b6-9546-1f3f3b15e535">