### PR TITLE
fix: [CDS-86705]: Allow expressions as input for paths field

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -37762,7 +37762,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -37822,7 +37822,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -37945,7 +37945,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -38005,7 +38005,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -38065,7 +38065,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -38130,7 +38130,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -48937,7 +48937,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -49034,7 +49034,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -49083,7 +49083,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -49215,7 +49215,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },

--- a/v0/pipeline/steps/cd/azure-repo-store.yaml
+++ b/v0/pipeline/steps/cd/azure-repo-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v0/pipeline/steps/cd/bitbucket-store.yaml
+++ b/v0/pipeline/steps/cd/bitbucket-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v0/pipeline/steps/cd/git-lab-store.yaml
+++ b/v0/pipeline/steps/cd/git-lab-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v0/pipeline/steps/cd/git-store.yaml
+++ b/v0/pipeline/steps/cd/git-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v0/pipeline/steps/cd/github-store.yaml
+++ b/v0/pipeline/steps/cd/github-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v0/pipeline/steps/cd/helm-chart-manifest.yaml
+++ b/v0/pipeline/steps/cd/helm-chart-manifest.yaml
@@ -38,7 +38,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v0/pipeline/steps/cd/inherit-from-manifest-store-config.yaml
+++ b/v0/pipeline/steps/cd/inherit-from-manifest-store-config.yaml
@@ -9,7 +9,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v0/pipeline/steps/cd/k8s-manifest.yaml
+++ b/v0/pipeline/steps/cd/k8s-manifest.yaml
@@ -23,7 +23,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v0/pipeline/steps/cd/kustomize-manifest.yaml
+++ b/v0/pipeline/steps/cd/kustomize-manifest.yaml
@@ -22,7 +22,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     pluginPath:
       type: string

--- a/v0/pipeline/steps/cd/openshift-manifest.yaml
+++ b/v0/pipeline/steps/cd/openshift-manifest.yaml
@@ -16,7 +16,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     skipResourceVersioning:
       oneOf:

--- a/v0/template.json
+++ b/v0/template.json
@@ -3731,7 +3731,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -3791,7 +3791,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -3914,7 +3914,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -3974,7 +3974,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -4034,7 +4034,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -4099,7 +4099,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -11462,7 +11462,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -11559,7 +11559,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -11608,7 +11608,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -11740,7 +11740,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -29618,7 +29618,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -29678,7 +29678,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -29801,7 +29801,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -29861,7 +29861,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -29921,7 +29921,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -29986,7 +29986,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -40742,7 +40742,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -40839,7 +40839,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -40888,7 +40888,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -41020,7 +41020,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },

--- a/v1/pipeline/steps/cd/azure-repo-store.yaml
+++ b/v1/pipeline/steps/cd/azure-repo-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v1/pipeline/steps/cd/bitbucket-store.yaml
+++ b/v1/pipeline/steps/cd/bitbucket-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v1/pipeline/steps/cd/git-lab-store.yaml
+++ b/v1/pipeline/steps/cd/git-lab-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v1/pipeline/steps/cd/git-store.yaml
+++ b/v1/pipeline/steps/cd/git-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v1/pipeline/steps/cd/github-store.yaml
+++ b/v1/pipeline/steps/cd/github-store.yaml
@@ -25,7 +25,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     repoName:
       type: string

--- a/v1/pipeline/steps/cd/helm-chart-manifest.yaml
+++ b/v1/pipeline/steps/cd/helm-chart-manifest.yaml
@@ -38,7 +38,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v1/pipeline/steps/cd/inherit-from-manifest-store-config.yaml
+++ b/v1/pipeline/steps/cd/inherit-from-manifest-store-config.yaml
@@ -9,7 +9,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v1/pipeline/steps/cd/k8s-manifest.yaml
+++ b/v1/pipeline/steps/cd/k8s-manifest.yaml
@@ -23,7 +23,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v1/pipeline/steps/cd/kustomize-manifest.yaml
+++ b/v1/pipeline/steps/cd/kustomize-manifest.yaml
@@ -22,7 +22,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     pluginPath:
       type: string

--- a/v1/pipeline/steps/cd/openshift-manifest.yaml
+++ b/v1/pipeline/steps/cd/openshift-manifest.yaml
@@ -16,7 +16,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: "(<\\+.+>.*)"
         minLength: 1
     skipResourceVersioning:
       oneOf:

--- a/v1/template.json
+++ b/v1/template.json
@@ -5659,7 +5659,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -5719,7 +5719,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -5842,7 +5842,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -5902,7 +5902,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -5962,7 +5962,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -6027,7 +6027,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -13382,7 +13382,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -13479,7 +13479,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -13528,7 +13528,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -13660,7 +13660,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },


### PR DESCRIPTION
As part of this PR we want remove limit on user not being able to provide expression for K8s related manifests. Before only valid values were actual array list or `<+input>` expression. 

<img width="585" alt="Screenshot 2023-12-13 at 17 27 08" src="https://github.com/harness/harness-schema/assets/64782481/8dc4ccce-a7e7-451f-b0f1-7216c6fea52b">
