### PR TITLE
[fix]: [CDS-80821]: added support for expressions for fields in ECS steps

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -41670,7 +41670,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -41688,7 +41688,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -41697,6 +41697,15 @@
                 },
                 "stageListenerRuleArn" : {
                   "type" : "string"
+                },
+                "updateGreenService" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -41721,7 +41730,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -41739,7 +41748,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -41748,6 +41757,15 @@
               },
               "stageListenerRuleArn" : {
                 "type" : "string"
+              },
+              "updateGreenService" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for EcsBlueGreenCreateServiceStepInfo"
@@ -42030,7 +42048,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -42059,7 +42077,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -53455,7 +53473,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -53464,7 +53482,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -53490,7 +53508,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -53499,7 +53517,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v0/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
+++ b/v0/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
@@ -21,7 +21,7 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
     loadBalancer:
       type: string
@@ -33,12 +33,18 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
     stageListener:
       type: string
     stageListenerRuleArn:
       type: string
+    updateGreenService:
+      oneOf:
+      - type: boolean
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -60,7 +66,7 @@ properties:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   loadBalancer:
     type: string
@@ -72,11 +78,17 @@ properties:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   stageListener:
     type: string
   stageListenerRuleArn:
     type: string
+  updateGreenService:
+    oneOf:
+    - type: boolean
+    - type: string
+      pattern: (<\+.+>.*)
+      minLength: 1
   description:
     desc: This is the description for EcsBlueGreenCreateServiceStepInfo

--- a/v0/pipeline/steps/cd/ecs-rolling-deploy-step-info.yaml
+++ b/v0/pipeline/steps/cd/ecs-rolling-deploy-step-info.yaml
@@ -15,13 +15,13 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
     sameAsAlreadyRunningInstances:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
@@ -38,13 +38,13 @@ properties:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   sameAsAlreadyRunningInstances:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   description:
     desc: This is the description for EcsRollingDeployStepInfo

--- a/v0/pipeline/steps/cd/ecs-service-setup-step-info.yaml
+++ b/v0/pipeline/steps/cd/ecs-service-setup-step-info.yaml
@@ -17,7 +17,7 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
@@ -36,7 +36,7 @@ properties:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   description:
     desc: This is the description for EcsServiceSetupStepInfo

--- a/v0/template.json
+++ b/v0/template.json
@@ -6871,7 +6871,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -6889,7 +6889,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -6898,6 +6898,15 @@
                 },
                 "stageListenerRuleArn" : {
                   "type" : "string"
+                },
+                "updateGreenService" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -6922,7 +6931,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -6940,7 +6949,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -6949,6 +6958,15 @@
               },
               "stageListenerRuleArn" : {
                 "type" : "string"
+              },
+              "updateGreenService" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for EcsBlueGreenCreateServiceStepInfo"
@@ -7498,7 +7516,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -7507,7 +7525,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -7533,7 +7551,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -7542,7 +7560,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -8053,7 +8071,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -8082,7 +8100,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -33679,7 +33679,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -33697,7 +33697,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -33706,6 +33706,15 @@
                 },
                 "stageListenerRuleArn" : {
                   "type" : "string"
+                },
+                "updateGreenService" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -33730,7 +33739,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -33748,7 +33757,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -33757,6 +33766,15 @@
               },
               "stageListenerRuleArn" : {
                 "type" : "string"
+              },
+              "updateGreenService" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for EcsBlueGreenCreateServiceStepInfo"
@@ -34039,7 +34057,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -34068,7 +34086,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -45428,7 +45446,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -45437,7 +45455,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -45463,7 +45481,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -45472,7 +45490,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v1/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
+++ b/v1/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
@@ -21,7 +21,7 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
     loadBalancer:
       type: string
@@ -33,12 +33,18 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
     stageListener:
       type: string
     stageListenerRuleArn:
       type: string
+    updateGreenService:
+      oneOf:
+      - type: boolean
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -60,7 +66,7 @@ properties:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   loadBalancer:
     type: string
@@ -72,11 +78,17 @@ properties:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   stageListener:
     type: string
   stageListenerRuleArn:
     type: string
+  updateGreenService:
+    oneOf:
+    - type: boolean
+    - type: string
+      pattern: (<\+.+>.*)
+      minLength: 1
   description:
     desc: This is the description for EcsBlueGreenCreateServiceStepInfo

--- a/v1/pipeline/steps/cd/ecs-rolling-deploy-step-info.yaml
+++ b/v1/pipeline/steps/cd/ecs-rolling-deploy-step-info.yaml
@@ -15,13 +15,13 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
     sameAsAlreadyRunningInstances:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
@@ -38,13 +38,13 @@ properties:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   sameAsAlreadyRunningInstances:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   description:
     desc: This is the description for EcsRollingDeployStepInfo

--- a/v1/pipeline/steps/cd/ecs-service-setup-step-info.yaml
+++ b/v1/pipeline/steps/cd/ecs-service-setup-step-info.yaml
@@ -17,7 +17,7 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
@@ -36,7 +36,7 @@ properties:
     oneOf:
     - type: boolean
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   description:
     desc: This is the description for EcsServiceSetupStepInfo

--- a/v1/template.json
+++ b/v1/template.json
@@ -8799,7 +8799,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -8817,7 +8817,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -8826,6 +8826,15 @@
                 },
                 "stageListenerRuleArn" : {
                   "type" : "string"
+                },
+                "updateGreenService" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -8850,7 +8859,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -8868,7 +8877,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -8877,6 +8886,15 @@
               },
               "stageListenerRuleArn" : {
                 "type" : "string"
+              },
+              "updateGreenService" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for EcsBlueGreenCreateServiceStepInfo"
@@ -9426,7 +9444,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -9435,7 +9453,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -9461,7 +9479,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -9470,7 +9488,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },
@@ -9981,7 +9999,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -10010,7 +10028,7 @@
                   "type" : "boolean"
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },


### PR DESCRIPTION
Description:
Added support for expressions for fields in ECS steps

Testing:
1. validating by saving ECS Pipeline with BG Create Service steps and all boolean fields as expressions.
2. validating by saving ECS Pipeline with BG Create Service steps and all boolean fields as runtime inputs.
3. validating by saving ECS Pipeline with BG Create Service steps and all boolean fields as fixed values.