### PR TITLE
fix examples

### DIFF
--- a/v1/examples/failure_strategies/group.yaml
+++ b/v1/examples/failure_strategies/group.yaml
@@ -18,9 +18,7 @@ spec:
                   spec:
                     url: httpsss://www.dummyurl.com
                     method: GET
-                    input_vars: [ ]
                     headers: [ ]
-                    output_vars: [ ]
                     body: null
                   timeout: 10s
             failure:

--- a/v1/examples/failure_strategies/stage.yaml
+++ b/v1/examples/failure_strategies/stage.yaml
@@ -14,9 +14,7 @@ spec:
             spec:
               url: httpsss://www.dummyurl.com
               method: GET
-              input_vars: [ ]
               headers: [ ]
-              output_vars: [ ]
               body: null
             timeout: 10s
       failure:

--- a/v1/examples/failure_strategies/step.yaml
+++ b/v1/examples/failure_strategies/step.yaml
@@ -14,9 +14,7 @@ spec:
             spec:
               url: httpsss://www.dummyurl.com
               method: GET
-              input_vars: [ ]
               headers: [ ]
-              output_vars: [ ]
               body: null
             timeout: 10s
             failure:

--- a/v1/examples/parallel/group.yaml
+++ b/v1/examples/parallel/group.yaml
@@ -20,9 +20,7 @@ spec:
                       spec:
                         url: https://www.google.com
                         method: GET
-                        input_vars: [ ]
                         headers: [ ]
-                        output_vars: [ ]
                         body:
                       timeout: 10m
                     - name: http2
@@ -30,9 +28,7 @@ spec:
                       spec:
                         url: https://www.google.com
                         method: GET
-                        input_vars: [ ]
                         headers: [ ]
-                        output_vars: [ ]
                         body:
                       timeout: 10m
               - name: group2
@@ -45,9 +41,7 @@ spec:
                       spec:
                         url: https://www.google.com
                         method: GET
-                        input_vars: []
                         headers: []
-                        output_vars: []
                         body:
                       timeout: 10m
                     - name: http2
@@ -55,8 +49,6 @@ spec:
                       spec:
                         url: https://www.google.com
                         method: GET
-                        input_vars: [ ]
                         headers: [ ]
-                        output_vars: [ ]
                         body:
                       timeout: 10m

--- a/v1/examples/parallel/stages.yaml
+++ b/v1/examples/parallel/stages.yaml
@@ -17,9 +17,7 @@ spec:
                   spec:
                     url: https://www.google.com
                     method: GET
-                    input_vars: []
                     headers: []
-                    output_vars: []
                     body:
                   timeout: 10m
           - name: custom2
@@ -33,8 +31,6 @@ spec:
                   spec:
                     url: https://www.google.com
                     method: GET
-                    input_vars: []
                     headers: []
-                    output_vars: []
                     body:
                   timeout: 10m

--- a/v1/examples/parallel/steps.yaml
+++ b/v1/examples/parallel/steps.yaml
@@ -17,9 +17,7 @@ spec:
                 spec:
                   url: https://www.google.com
                   method: GET
-                  input_vars: []
                   headers: []
-                  output_vars: []
                   body:
                 timeout: 10m
               - name: http
@@ -29,8 +27,6 @@ spec:
                 spec:
                   url: https://www.google.com
                   method: GET
-                  input_vars: []
                   headers: []
-                  output_vars: []
                   body:
                 timeout: 10m

--- a/v1/examples/pipeline/pipeline_with_options.yaml
+++ b/v1/examples/pipeline/pipeline_with_options.yaml
@@ -14,6 +14,8 @@ spec:
               url: https://www.dummyurl.com
               method: GET
               headers: [ ]
+              input_vars: {}
+              output_vars: {}
               body: null
             timeout: 10s
   options:

--- a/v1/examples/pipeline/pipeline_with_options.yaml
+++ b/v1/examples/pipeline/pipeline_with_options.yaml
@@ -13,9 +13,7 @@ spec:
             spec:
               url: https://www.dummyurl.com
               method: GET
-              input_vars: [ ]
               headers: [ ]
-              output_vars: [ ]
               body: null
             timeout: 10s
   options:

--- a/v1/examples/templates/pipeline.yaml
+++ b/v1/examples/templates/pipeline.yaml
@@ -14,5 +14,7 @@ spec:
                 url: https://www.google.com
                 method: GET
                 headers: [ ]
+                input_vars: { }
+                output_vars: { }
                 body: null
               timeout: 10s

--- a/v1/examples/templates/pipeline.yaml
+++ b/v1/examples/templates/pipeline.yaml
@@ -13,8 +13,6 @@ spec:
               spec:
                 url: https://www.google.com
                 method: GET
-                input_vars: [ ]
                 headers: [ ]
-                output_vars: [ ]
                 body: null
               timeout: 10s

--- a/v1/examples/when/group.yaml
+++ b/v1/examples/when/group.yaml
@@ -18,9 +18,7 @@ spec:
                   spec:
                     url: httpsss://www.dummyurl.com
                     method: GET
-                    input_vars: [ ]
                     headers: [ ]
-                    output_vars: [ ]
                     body: null
                   timeout: 10s
             when: <+Always> && <+service.name> == "service2"

--- a/v1/examples/when/stage.yaml
+++ b/v1/examples/when/stage.yaml
@@ -14,9 +14,7 @@ spec:
             spec:
               url: httpsss://www.dummyurl.com
               method: GET
-              input_vars: [ ]
               headers: [ ]
-              output_vars: [ ]
               body: null
             timeout: 10s
       when: <+environment.name> != "QA"

--- a/v1/examples/when/step.yaml
+++ b/v1/examples/when/step.yaml
@@ -14,9 +14,7 @@ spec:
             spec:
               url: httpsss://www.dummyurl.com
               method: GET
-              input_vars: [ ]
               headers: [ ]
-              output_vars: [ ]
               body: null
             timeout: 10s
             when: <+OnStageFailure> && <+environment.name> == "QA"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -3685,7 +3685,7 @@
             "type" : "object",
             "required" : [ "steps" ],
             "properties" : {
-              "rollbackSteps" : {
+              "rollback_steps" : {
                 "type" : "array",
                 "items" : {
                   "oneOf" : [ {

--- a/v1/pipeline/stages/custom/custom-stage-spec-element-config.yaml
+++ b/v1/pipeline/stages/custom/custom-stage-spec-element-config.yaml
@@ -3,7 +3,7 @@ type: object
 required:
 - steps
 properties:
-  rollbackSteps:
+  rollback_steps:
     type: array
     items:
       configRef: ./custom-stage-spec-element-wrapper-config.yaml/steps

--- a/v1/template.json
+++ b/v1/template.json
@@ -62630,7 +62630,7 @@
             "type" : "object",
             "required" : [ "steps" ],
             "properties" : {
-              "rollbackSteps" : {
+              "rollback_steps" : {
                 "type" : "array",
                 "items" : {
                   "oneOf" : [ {


### PR DESCRIPTION
Removing input_vars: [] and output_vars: [] from http step examples for v1 because these fields are required to be of type   object in v1