### PR TITLE
feat: [CDS-87189]: updated schema for ssh aws infra

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -3483,7 +3483,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/Infrastructure"
             }, {
               "type" : "object",
-              "required" : [ "awsInstanceFilter", "connectorRef", "credentialsRef", "hostConnectionType", "region" ],
+              "required" : [ "connectorRef", "credentialsRef", "hostConnectionType", "region" ],
               "properties" : {
                 "awsInstanceFilter" : {
                   "$ref" : "#/definitions/pipeline/stages/cd/AwsInstanceFilter"
@@ -3507,6 +3507,9 @@
                 "region" : {
                   "type" : "string",
                   "minLength" : 1
+                },
+                "asgName" : {
+                  "type" : "string"
                 }
               }
             } ],
@@ -3532,10 +3535,16 @@
                 } ]
               },
               "vpcs" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsInstanceFilter"

--- a/v0/pipeline/stages/cd/aws-instance-filter.yaml
+++ b/v0/pipeline/stages/cd/aws-instance-filter.yaml
@@ -8,9 +8,13 @@ properties:
         type: string
     - type: string
   vpcs:
-    type: array
-    items:
-      type: string
+    oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
   description:
     desc: This is the description for AwsInstanceFilter
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/stages/cd/ssh-win-rm-aws-infrastructure.yaml
+++ b/v0/pipeline/stages/cd/ssh-win-rm-aws-infrastructure.yaml
@@ -3,7 +3,6 @@ allOf:
 - $ref: ../../steps/common/infrastructure.yaml
 - type: object
   required:
-  - awsInstanceFilter
   - connectorRef
   - credentialsRef
   - hostConnectionType
@@ -28,6 +27,8 @@ allOf:
     region:
       type: string
       minLength: 1
+    asgName:
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/template.json
+++ b/v0/template.json
@@ -64690,7 +64690,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/Infrastructure"
             }, {
               "type" : "object",
-              "required" : [ "awsInstanceFilter", "connectorRef", "credentialsRef", "hostConnectionType", "region" ],
+              "required" : [ "connectorRef", "credentialsRef", "hostConnectionType", "region" ],
               "properties" : {
                 "awsInstanceFilter" : {
                   "$ref" : "#/definitions/pipeline/stages/cd/AwsInstanceFilter"
@@ -64714,6 +64714,9 @@
                 "region" : {
                   "type" : "string",
                   "minLength" : 1
+                },
+                "asgName" : {
+                  "type" : "string"
                 }
               }
             } ],
@@ -64739,10 +64742,16 @@
                 } ]
               },
               "vpcs" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for AwsInstanceFilter"

--- a/v1/pipeline/stages/cd/aws-instance-filter.yaml
+++ b/v1/pipeline/stages/cd/aws-instance-filter.yaml
@@ -8,9 +8,13 @@ properties:
         type: string
     - type: string
   vpcs:
-    type: array
-    items:
-      type: string
+    oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
   description:
     desc: This is the description for AwsInstanceFilter
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/ssh-win-rm-aws-infrastructure.yaml
+++ b/v1/pipeline/stages/cd/ssh-win-rm-aws-infrastructure.yaml
@@ -3,7 +3,6 @@ allOf:
 - $ref: ../../steps/common/infrastructure.yaml
 - type: object
   required:
-  - awsInstanceFilter
   - connectorRef
   - credentialsRef
   - hostConnectionType
@@ -28,6 +27,8 @@ allOf:
     region:
       type: string
       minLength: 1
+    asgName:
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:


### PR DESCRIPTION
updated schema for ssh aws infra with Vpcs and AsgName 

With filter:
```
infrastructureDefinition:
  name: pdcAws
  identifier: pdcAws
  orgIdentifier: default
  projectIdentifier: vitalie
  environmentRef: ssh
  deploymentType: Ssh
  type: SshWinRmAws
  spec:
    credentialsRef: account.vit2CdPlay
    connectorRef: account.awsCdplay
    region: us-east-1
    awsInstanceFilter:
      tags:
        vit: "true"
        Name: vitasg
      vpcs:
        - vpc-0c5b9086ccea05263xx
    hostConnectionType: PublicIP
  allowSimultaneousDeployments: false

```

With ASG
```
infrastructureDefinition:
  name: pdcAws2
  identifier: pdcAws2
  orgIdentifier: default
  projectIdentifier: vitalie
  environmentRef: ssh
  deploymentType: Ssh
  type: SshWinRmAws
  spec:
    credentialsRef: account.vit2CdPlay
    connectorRef: account.awsCdplay
    region: us-east-1
    asgName: myAsg
    hostConnectionType: PublicIP
  allowSimultaneousDeployments: false

```