### PR TITLE
feat: [CDS-80231]: adds header support in custom webhook notification method

### DIFF
--- a/v0/pipeline/pms-webhook-channel.yaml
+++ b/v0/pipeline/pms-webhook-channel.yaml
@@ -5,6 +5,8 @@ allOf:
   properties:
     webhookUrl:
       type: string
+    headers:
+      type: object
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:


### PR DESCRIPTION
feat: [CDS-80231]: adds header support in custom webhook notification method

Change: Adds headers as map (object here) under PmsWebhookChannel schema.

[CDS-80231]: https://harness.atlassian.net/browse/CDS-80231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ