### PR TITLE
feat: [CDS-87790]: Add schema for v1 trigger yaml

### DIFF
--- a/bundler/schema_store/src/main/java/io/harness/YamlEntityType.java
+++ b/bundler/schema_store/src/main/java/io/harness/YamlEntityType.java
@@ -17,7 +17,8 @@ public enum YamlEntityType {
   PIPELINE_V1("pipeline", SchemaVersion.V1, "pipeline/pipeline.yaml"),
   TEMPLATE_V1("template", SchemaVersion.V1, "template/template_root.yaml"),
   INPUT_SET_V1("inputSet", SchemaVersion.V1, "inputSet/inputSet.yaml"),
-  OVERLAY_INPUT_SET_V1("overlayInputSet", SchemaVersion.V1, "overlayInputSet/overlayInputSet.yaml");
+  OVERLAY_INPUT_SET_V1("overlayInputSet", SchemaVersion.V1, "overlayInputSet/overlayInputSet.yaml"),
+  TRIGGER_V1("trigger", SchemaVersion.V1, "trigger/trigger_root.yaml");
 
   @Getter private final String entityName;
   @Getter private final String entityRootSchemaPath;

--- a/bundler/schema_store/src/main/java/io/harness/bundler/SchemaBundlerRegistrar.java
+++ b/bundler/schema_store/src/main/java/io/harness/bundler/SchemaBundlerRegistrar.java
@@ -32,5 +32,7 @@ public class SchemaBundlerRegistrar {
             YamlEntityType.INPUT_SET_V1, SchemaBundleUtils.builder().yamlEntityType(YamlEntityType.INPUT_SET_V1).build());
     registeredSchemaBundlers.put(
             YamlEntityType.OVERLAY_INPUT_SET_V1, SchemaBundleUtils.builder().yamlEntityType(YamlEntityType.OVERLAY_INPUT_SET_V1).build());
+    registeredSchemaBundlers.put(
+            YamlEntityType.TRIGGER_V1, SchemaBundleUtils.builder().yamlEntityType(YamlEntityType.TRIGGER_V1).build());
   }
 }

--- a/v0/trigger.json
+++ b/v0/trigger.json
@@ -2033,7 +2033,7 @@
         },
         "azure_repo_pr_spec" : {
           "title" : "azure_repo_pr_spec",
-          "kallOf" : [ {
+          "allOf" : [ {
             "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
           }, {
             "type" : "object",

--- a/v0/trigger/webhook_trigger/azure_repo_pr_spec.yaml
+++ b/v0/trigger/webhook_trigger/azure_repo_pr_spec.yaml
@@ -1,5 +1,5 @@
 title: azure_repo_pr_spec
-kallOf:
+allOf:
   - "$ref": "./azure_repo_event_spec.yaml"
   - type: object
     properties:

--- a/v1/examples/trigger/artifact_trigger.yaml
+++ b/v1/examples/trigger/artifact_trigger.yaml
@@ -10,3 +10,9 @@ spec:
       repo: acr_repo
       subscription: subs_id
       tag: v1.2
+# v1 trigger can be set up for a v1 pipeline, in that case, the input yaml will follow v1 structure
+inputs: |
+  env: prod
+  delegates:
+    - del1
+  times: 1

--- a/v1/examples/trigger/artifact_trigger.yaml
+++ b/v1/examples/trigger/artifact_trigger.yaml
@@ -11,8 +11,8 @@ spec:
       subscription: subs_id
       tag: v1.2
 # v1 trigger can be set up for a v1 pipeline, in that case, the input yaml will follow v1 structure
-inputs: |
-  env: prod
-  delegates:
-    - del1
-  times: 1
+  inputs: |
+    env: prod
+    delegates:
+      - del1
+    times: 1

--- a/v1/examples/trigger/artifact_trigger.yaml
+++ b/v1/examples/trigger/artifact_trigger.yaml
@@ -1,18 +1,18 @@
 version: 1
 kind: trigger
+type: artifact
 spec:
-  type: artifact
+  type: acr
   spec:
-    type: acr
-    spec:
-      connector: acr_connector
-      registry: acr_reg
-      repo: acr_repo
-      subscription: subs_id
-      tag: v1.2
-# v1 trigger can be set up for a v1 pipeline, in that case, the input yaml will follow v1 structure
+    connector: acr_connector
+    registry: acr_reg
+    repo: acr_repo
+    subscription: subs_id
+    tag: v1.2
   inputs: |
     env: prod
     delegates:
       - del1
     times: 1
+  execute_stages:
+    - s1

--- a/v1/examples/trigger/artifact_trigger.yaml
+++ b/v1/examples/trigger/artifact_trigger.yaml
@@ -1,0 +1,12 @@
+version: 1
+kind: trigger
+spec:
+  type: artifact
+  spec:
+    type: acr
+    spec:
+      connector: acr_connector
+      registry: acr_reg
+      repo: acr_repo
+      subscription: subs_id
+      tag: v1.2

--- a/v1/examples/trigger/artifact_trigger.yaml
+++ b/v1/examples/trigger/artifact_trigger.yaml
@@ -1,18 +1,18 @@
 version: 1
 kind: trigger
-type: artifact
 spec:
-  type: acr
+  type: artifact
   spec:
-    connector: acr_connector
-    registry: acr_reg
-    repo: acr_repo
-    subscription: subs_id
-    tag: v1.2
+    type: acr
+    spec:
+      connector: acr_connector
+      registry: acr_reg
+      repo: acr_repo
+      subscription: subs_id
+      tag: v1.2
+# v1 trigger can be set up for a v1 pipeline, in that case, the input yaml will follow v1 structure
   inputs: |
     env: prod
     delegates:
       - del1
     times: 1
-  execute_stages:
-    - s1

--- a/v1/examples/trigger/manifest_trigger.yaml
+++ b/v1/examples/trigger/manifest_trigger.yaml
@@ -11,6 +11,6 @@ spec:
         type: http
         spec:
           connector: http_connector
-input_set_refs:
-  - inp1
-  - inp2
+  input_set_refs:
+    - inp1
+    - inp2

--- a/v1/examples/trigger/manifest_trigger.yaml
+++ b/v1/examples/trigger/manifest_trigger.yaml
@@ -1,15 +1,16 @@
 version: 1
 kind: trigger
-type: manifest
 spec:
-  type: helm-chart
+  type: manifest
   spec:
-    chart: chart1@v1
-    helm_version: v3
-    store:
-      type: http
-      spec:
-        connector: http_connector
+    type: helm-chart
+    spec:
+      chart: chart1@v1
+      helm_version: v3
+      store:
+        type: http
+        spec:
+          connector: http_connector
   input_set_refs:
     - inp1
     - inp2

--- a/v1/examples/trigger/manifest_trigger.yaml
+++ b/v1/examples/trigger/manifest_trigger.yaml
@@ -5,7 +5,7 @@ spec:
   spec:
     type: helm-chart
     spec:
-      chart_name: chart1
+      chart: chart1
       helm_version: v3
       store:
         type: http

--- a/v1/examples/trigger/manifest_trigger.yaml
+++ b/v1/examples/trigger/manifest_trigger.yaml
@@ -5,7 +5,7 @@ spec:
   spec:
     type: helm-chart
     spec:
-      chart: chart1
+      chart: chart1@v1
       helm_version: v3
       store:
         type: http

--- a/v1/examples/trigger/manifest_trigger.yaml
+++ b/v1/examples/trigger/manifest_trigger.yaml
@@ -1,0 +1,13 @@
+version: 1
+kind: trigger
+spec:
+  type: manifest
+  spec:
+    type: helm-chart
+    spec:
+      chart_name: chart1
+      helm_version: v3
+      store:
+        type: http
+        spec:
+          connector: http_connector

--- a/v1/examples/trigger/manifest_trigger.yaml
+++ b/v1/examples/trigger/manifest_trigger.yaml
@@ -1,16 +1,15 @@
 version: 1
 kind: trigger
+type: manifest
 spec:
-  type: manifest
+  type: helm-chart
   spec:
-    type: helm-chart
-    spec:
-      chart: chart1@v1
-      helm_version: v3
-      store:
-        type: http
-        spec:
-          connector: http_connector
+    chart: chart1@v1
+    helm_version: v3
+    store:
+      type: http
+      spec:
+        connector: http_connector
   input_set_refs:
     - inp1
     - inp2

--- a/v1/examples/trigger/manifest_trigger.yaml
+++ b/v1/examples/trigger/manifest_trigger.yaml
@@ -11,3 +11,6 @@ spec:
         type: http
         spec:
           connector: http_connector
+input_set_refs:
+  - inp1
+  - inp2

--- a/v1/examples/trigger/multi_region_artifact_trigger.yaml
+++ b/v1/examples/trigger/multi_region_artifact_trigger.yaml
@@ -9,19 +9,19 @@ spec:
         spec:
           connector: bamboo_connector
           plan_key: p1
-          artifact_paths:
+          paths:
             - path1
       - type: bamboo
         spec:
           connector: bamboo_connector1
           plan_key: p2
-          artifact_paths:
+          paths:
             - path2
 # v1 trigger can be set up for a v0 pipeline, in that case, the input yaml will follow v0 structure
-inputs: |
-  pipeline:
-      identifier: Test_JEXL
-      variables:
-        - name: var1
-          type: String
-          value: ""
+  inputs: |
+    pipeline:
+        identifier: Test_JEXL
+        variables:
+          - name: var1
+            type: String
+            value: ""

--- a/v1/examples/trigger/multi_region_artifact_trigger.yaml
+++ b/v1/examples/trigger/multi_region_artifact_trigger.yaml
@@ -1,0 +1,19 @@
+version: 1
+kind: trigger
+spec:
+  type: multi-region-artifact
+  spec:
+    type: bamboo
+    sources:
+      - type: bamboo
+        spec:
+          connector: bamboo_connector
+          plan_key: p1
+          artifact_paths:
+            - path1
+      - type: bamboo
+          spec:
+            connector: bamboo_connector1
+            plan_key: p2
+            artifact_paths:
+              - path2

--- a/v1/examples/trigger/multi_region_artifact_trigger.yaml
+++ b/v1/examples/trigger/multi_region_artifact_trigger.yaml
@@ -1,22 +1,21 @@
 version: 1
 kind: trigger
+type: multi-region-artifact
 spec:
-  type: multi-region-artifact
-  spec:
-    type: bamboo
-    sources:
-      - type: bamboo
-        spec:
-          connector: bamboo_connector
-          plan_key: p1
-          paths:
-            - path1
-      - type: bamboo
-        spec:
-          connector: bamboo_connector1
-          plan_key: p2
-          paths:
-            - path2
+  type: bamboo
+  sources:
+    - type: bamboo
+      spec:
+        connector: bamboo_connector
+        plan_key: p1
+        paths:
+          - path1
+    - type: bamboo
+      spec:
+        connector: bamboo_connector1
+        plan_key: p2
+        paths:
+          - path2
 # v1 trigger can be set up for a v0 pipeline, in that case, the input yaml will follow v0 structure
   inputs: |
     pipeline:

--- a/v1/examples/trigger/multi_region_artifact_trigger.yaml
+++ b/v1/examples/trigger/multi_region_artifact_trigger.yaml
@@ -1,21 +1,22 @@
 version: 1
 kind: trigger
-type: multi-region-artifact
 spec:
-  type: bamboo
-  sources:
-    - type: bamboo
-      spec:
-        connector: bamboo_connector
-        plan_key: p1
-        paths:
-          - path1
-    - type: bamboo
-      spec:
-        connector: bamboo_connector1
-        plan_key: p2
-        paths:
-          - path2
+  type: multi-region-artifact
+  spec:
+    type: bamboo
+    sources:
+      - type: bamboo
+        spec:
+          connector: bamboo_connector
+          plan_key: p1
+          paths:
+            - path1
+      - type: bamboo
+        spec:
+          connector: bamboo_connector1
+          plan_key: p2
+          paths:
+            - path2
 # v1 trigger can be set up for a v0 pipeline, in that case, the input yaml will follow v0 structure
   inputs: |
     pipeline:

--- a/v1/examples/trigger/multi_region_artifact_trigger.yaml
+++ b/v1/examples/trigger/multi_region_artifact_trigger.yaml
@@ -12,8 +12,16 @@ spec:
           artifact_paths:
             - path1
       - type: bamboo
-          spec:
-            connector: bamboo_connector1
-            plan_key: p2
-            artifact_paths:
-              - path2
+        spec:
+          connector: bamboo_connector1
+          plan_key: p2
+          artifact_paths:
+            - path2
+# v1 trigger can be set up for a v0 pipeline, in that case, the input yaml will follow v0 structure
+inputs: |
+  pipeline:
+      identifier: Test_JEXL
+      variables:
+        - name: var1
+          type: String
+          value: ""

--- a/v1/examples/trigger/scheduled_trigger.yaml
+++ b/v1/examples/trigger/scheduled_trigger.yaml
@@ -7,3 +7,6 @@ spec:
     spec:
       type: UNIX
       expression: 0/5 * * * *
+stages_to_execute:
+  - s1
+  - s2

--- a/v1/examples/trigger/scheduled_trigger.yaml
+++ b/v1/examples/trigger/scheduled_trigger.yaml
@@ -1,0 +1,9 @@
+version: 1
+kind: trigger
+spec:
+  type: scheduled
+  spec:
+    type: cron
+    spec:
+      type: UNIX
+      expression: 0/5 * * * *

--- a/v1/examples/trigger/scheduled_trigger.yaml
+++ b/v1/examples/trigger/scheduled_trigger.yaml
@@ -1,11 +1,12 @@
 version: 1
 kind: trigger
-type: scheduled
 spec:
-  type: cron
+  type: scheduled
   spec:
-    type: UNIX
-    expression: 0/5 * * * *
+    type: cron
+    spec:
+      type: UNIX
+      expression: 0/5 * * * *
   execute_stages:
     - s1
     - s2

--- a/v1/examples/trigger/scheduled_trigger.yaml
+++ b/v1/examples/trigger/scheduled_trigger.yaml
@@ -1,12 +1,11 @@
 version: 1
 kind: trigger
+type: scheduled
 spec:
-  type: scheduled
+  type: cron
   spec:
-    type: cron
-    spec:
-      type: UNIX
-      expression: 0/5 * * * *
+    type: UNIX
+    expression: 0/5 * * * *
   execute_stages:
     - s1
     - s2

--- a/v1/examples/trigger/scheduled_trigger.yaml
+++ b/v1/examples/trigger/scheduled_trigger.yaml
@@ -7,6 +7,6 @@ spec:
     spec:
       type: UNIX
       expression: 0/5 * * * *
-stages_to_execute:
-  - s1
-  - s2
+  execute_stages:
+    - s1
+    - s2

--- a/v1/examples/trigger/webhook_trigger.yaml
+++ b/v1/examples/trigger/webhook_trigger.yaml
@@ -1,13 +1,18 @@
 version: 1
 kind: trigger
+type: webhook
 spec:
-  type: webhook
+  type: github
   spec:
-    type: github
+    type: pr
     spec:
-      type: pr
-      spec:
-        actions:
-          - open
-          - close
-        connector: github_connector
+      actions:
+        - open
+        - close
+      connector: github_connector
+  interval: 10m
+  webhook: web_1
+  input_set_refs:
+    - is1
+  execute_stages:
+    - s1

--- a/v1/examples/trigger/webhook_trigger.yaml
+++ b/v1/examples/trigger/webhook_trigger.yaml
@@ -5,7 +5,7 @@ spec:
   spec:
     type: github
     spec:
-      type: pull-request
+      type: pr
       spec:
         actions:
           - open

--- a/v1/examples/trigger/webhook_trigger.yaml
+++ b/v1/examples/trigger/webhook_trigger.yaml
@@ -1,18 +1,13 @@
 version: 1
 kind: trigger
-type: webhook
 spec:
-  type: github
+  type: webhook
   spec:
-    type: pr
+    type: github
     spec:
-      actions:
-        - open
-        - close
-      connector: github_connector
-  interval: 10m
-  webhook: web_1
-  input_set_refs:
-    - is1
-  execute_stages:
-    - s1
+      type: pr
+      spec:
+        actions:
+          - open
+          - close
+        connector: github_connector

--- a/v1/examples/trigger/webhook_trigger.yaml
+++ b/v1/examples/trigger/webhook_trigger.yaml
@@ -1,0 +1,13 @@
+version: 1
+kind: trigger
+spec:
+  type: webhook
+  spec:
+    type: github
+    spec:
+      type: pull-request
+      spec:
+        actions:
+          - open
+          - close
+        connector: github_connector

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -9,7 +9,7 @@
       "enum" : [ 1 ]
     },
     "kind" : {
-      "description" : "defines the kind of yaml (pipeline/template)",
+      "description" : "defines the kind of yaml (pipeline/template/trigger)",
       "type" : "string",
       "enum" : [ "pipeline" ]
     },

--- a/v1/pipeline/pipeline.yaml
+++ b/v1/pipeline/pipeline.yaml
@@ -11,7 +11,7 @@ properties:
     enum:
       - 1
   kind:
-    description: defines the kind of yaml (pipeline/template)
+    description: defines the kind of yaml (pipeline/template/trigger)
     type: string
     enum:
       - pipeline

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -2231,7 +2231,7 @@
                 "type" : "array",
                 "items" : {
                   "type" : "string",
-                  "enum" : [ "create", "edit", "delete", "prerelease", "publish", "release", "unpublish" ]
+                  "enum" : [ "create", "edit", "delete", "pre-release", "publish", "release", "unpublish" ]
                 }
               },
               "abort_previous" : {

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -1857,6 +1857,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/aws_commit_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "connector" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
@@ -1950,7 +1951,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
           }, {
             "type" : "object",
-            "required" : [ "actions" ],
+            "required" : [ "actions", "connector" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -1999,7 +2000,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
           }, {
             "type" : "object",
-            "required" : [ "actions" ],
+            "required" : [ "actions", "connector" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2042,6 +2043,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "connector" ],
             "properties" : {
               "auto_abort_previous_executions" : {
                 "type" : "boolean"
@@ -2138,7 +2140,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
           }, {
             "type" : "object",
-            "required" : [ "actions" ],
+            "required" : [ "actions", "connector" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2187,7 +2189,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
           }, {
             "type" : "object",
-            "required" : [ "actions" ],
+            "required" : [ "actions", "connector" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2230,6 +2232,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "connector" ],
             "properties" : {
               "auto_abort_previous_executions" : {
                 "type" : "boolean"
@@ -2367,7 +2370,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
           }, {
             "type" : "object",
-            "required" : [ "actions" ],
+            "required" : [ "actions", "connector" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2416,7 +2419,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
           }, {
             "type" : "object",
-            "required" : [ "actions" ],
+            "required" : [ "actions", "connector" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2459,6 +2462,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "connector" ],
             "properties" : {
               "auto_abort_previous_executions" : {
                 "type" : "boolean"
@@ -2494,7 +2498,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
           }, {
             "type" : "object",
-            "required" : [ "actions" ],
+            "required" : [ "actions", "connector" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2598,7 +2602,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
           }, {
             "type" : "object",
-            "required" : [ "actions" ],
+            "required" : [ "actions", "connector" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2647,7 +2651,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
           }, {
             "type" : "object",
-            "required" : [ "actions" ],
+            "required" : [ "actions", "connector" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2690,6 +2694,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "connector" ],
             "properties" : {
               "auto_abort_previous_executions" : {
                 "type" : "boolean"

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -1979,7 +1979,7 @@
         },
         "azure_repo_pr_spec" : {
           "title" : "azure_repo_pr_spec",
-          "kallOf" : [ {
+          "allOf" : [ {
             "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
           }, {
             "type" : "object",

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -854,7 +854,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "pkg_name" : {
+              "pkg" : {
+                "description" : "package name",
                 "type" : "string"
               },
               "pkg_type" : {
@@ -1036,7 +1037,8 @@
               "region" : {
                 "type" : "string"
               },
-              "registry_id" : {
+              "registry" : {
+                "description" : "registry identifier",
                 "type" : "string"
               },
               "tag" : {
@@ -1112,7 +1114,8 @@
               "org" : {
                 "type" : "string"
               },
-              "pkg_name" : {
+              "pkg" : {
+                "description" : "package name",
                 "type" : "string"
               },
               "pkg_type" : {
@@ -1156,7 +1159,8 @@
               "region" : {
                 "type" : "string"
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               },
               "version" : {
@@ -1229,7 +1233,8 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "job_name" : {
+              "job" : {
+                "description" : "job name",
                 "type" : "string"
               },
               "metadata_conditions" : {
@@ -1249,7 +1254,8 @@
           }, {
             "type" : "object",
             "properties" : {
-              "artifact_id" : {
+              "artifact" : {
+                "description" : "artifact identifier",
                 "type" : "string"
               },
               "classifier" : {
@@ -1279,13 +1285,15 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "pkg_name" : {
+              "pkg" : {
+                "description" : "package name",
                 "type" : "string"
               },
               "repo_format" : {
                 "type" : "string"
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               },
               "repo_url" : {
@@ -1305,7 +1313,8 @@
           }, {
             "type" : "object",
             "properties" : {
-              "artifact_id" : {
+              "artifact" : {
+                "description" : "artifact identifier",
                 "type" : "string"
               },
               "classifier" : {
@@ -1341,10 +1350,12 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "pkg_name" : {
+              "pkg" : {
+                "description" : "package name",
                 "type" : "string"
               },
               "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               },
               "repo_format" : {
@@ -1386,7 +1397,8 @@
           }, {
             "type" : "object",
             "properties" : {
-              "chart_name" : {
+              "chart" : {
+                "description" : "chart name",
                 "type" : "string"
               },
               "chart_version" : {
@@ -1871,7 +1883,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -1981,7 +1994,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2030,7 +2044,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2066,7 +2081,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2170,7 +2186,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2219,7 +2236,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2255,7 +2273,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2400,7 +2419,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2449,7 +2469,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2485,7 +2506,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2528,7 +2550,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2632,7 +2655,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2681,7 +2705,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2717,7 +2742,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2818,7 +2844,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2864,7 +2891,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }
@@ -2896,7 +2924,8 @@
                   "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
-              "repo_name" : {
+              "repo" : {
+                "description" : "repository name",
                 "type" : "string"
               }
             }

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -19,7 +19,8 @@
         "type" : "string"
       }
     },
-    "input_yaml" : {
+    "inputs" : {
+      "description" : "input yaml for the pipeline",
       "type" : "string"
     },
     "spec" : {
@@ -40,7 +41,8 @@
         "type" : "object",
         "required" : [ "type", "spec" ],
         "properties" : {
-          "poll_interval" : {
+          "interval" : {
+            "description" : "polling interval",
             "type" : "string",
             "pattern" : "(((([1-9])+\\d*[mh])+(\\s/?\\d+[mh])*)|(^$)|(0))$"
           },
@@ -48,7 +50,8 @@
             "type" : "string",
             "enum" : [ "webhook", "artifact", "manifest", "scheduled", "multi-region-artifact" ]
           },
-          "webhook_id" : {
+          "webhook" : {
+            "description" : "webhook identifier",
             "type" : "string"
           }
         },
@@ -141,7 +144,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "gcr", "ecr", "docker-registry", "nexus3-registry", "nexus2-registry", "artifactory-registry", "acr", "amazon-s3", "jenkins", "custom-artifact", "google-artifact-registry", "github-package-registry", "azure-artifacts", "amazon-machine-image", "google-cloud-storage", "bamboo" ]
+                "enum" : [ "gcr", "ecr", "docker-registry", "nexus3-registry", "nexus2-registry", "artifactory-registry", "acr", "amazon-s3", "jenkins", "custom", "google-artifact-registry", "github-package-registry", "azure", "amazon-machine-image", "google-cloud-storage", "bamboo" ]
               }
             }
           }, {
@@ -208,7 +211,7 @@
             "if" : {
               "properties" : {
                 "type" : {
-                  "const" : "azure-artifacts"
+                  "const" : "azure"
                 }
               }
             },
@@ -238,7 +241,7 @@
             "if" : {
               "properties" : {
                 "type" : {
-                  "const" : "custom-artifact"
+                  "const" : "custom"
                 }
               }
             },
@@ -435,7 +438,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -449,7 +452,7 @@
               },
               "type" : {
                 "type" : "string",
-                "enum" : [ "gcr", "ecr", "docker-registry", "nexus3-registry", "nexus2-registry", "artifactory-registry", "acr", "amazon-s3", "jenkins", "custom-artifact", "google-artifact-registry", "github-package-registry", "azure-artifacts", "amazon-machine-image", "google-cloud-storage", "bamboo" ]
+                "enum" : [ "gcr", "ecr", "docker-registry", "nexus3-registry", "nexus2-registry", "artifactory-registry", "acr", "amazon-s3", "jenkins", "custom", "google-artifact-registry", "github-package-registry", "azure", "amazon-machine-image", "google-cloud-storage", "bamboo" ]
               }
             }
           } ],
@@ -633,7 +636,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -645,7 +648,8 @@
               "repo" : {
                 "type" : "string"
               },
-              "subscription_id" : {
+              "subscription" : {
+                "description" : "subscription identifier",
                 "type" : "string"
               },
               "tag" : {
@@ -686,7 +690,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -762,7 +766,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -803,7 +807,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -844,7 +848,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -897,7 +901,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -941,7 +945,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -988,7 +992,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -1023,7 +1027,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -1064,7 +1068,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -1099,7 +1103,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -1137,7 +1141,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -1187,7 +1191,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -1228,7 +1232,7 @@
               "job_name" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -1269,7 +1273,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -1331,7 +1335,7 @@
               "jexl_condition" : {
                 "type" : "string"
               },
-              "meta_data_conditions" : {
+              "metadata_conditions" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/trigger_event_data"
@@ -1366,7 +1370,7 @@
           },
           "operator" : {
             "type" : "string",
-            "enum" : [ "in", "equals", "not-equals", "not-in", "regex", "ends-with", "starts-with", "contains", "doesN-not-contain" ]
+            "enum" : [ "in", "equals", "not-equals", "not-in", "regex", "ends-with", "starts-with", "contains", "does-not-contain" ]
           },
           "value" : {
             "type" : "string"
@@ -1604,7 +1608,7 @@
             "if" : {
               "properties" : {
                 "type" : {
-                  "const" : "azure-artifacts"
+                  "const" : "azure"
                 }
               }
             },
@@ -1634,7 +1638,7 @@
             "if" : {
               "properties" : {
                 "type" : {
-                  "const" : "custom-artifact"
+                  "const" : "custom"
                 }
               }
             },

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -2174,7 +2174,7 @@
                 "type" : "array",
                 "items" : {
                   "type" : "string",
-                  "enum" : [ "close", "edit", "open", "reopen", "label", "unlabel", "synchronize", "ready-for-review" ]
+                  "enum" : [ "close", "edit", "open", "reopen", "label", "unlabel", "sync", "ready-for-review" ]
                 }
               },
               "abort_previous" : {
@@ -2515,7 +2515,7 @@
                 "type" : "array",
                 "items" : {
                   "type" : "string",
-                  "enum" : [ "close", "edit", "open", "reopen", "label", "unlabel", "synchronize" ]
+                  "enum" : [ "close", "edit", "open", "reopen", "label", "unlabel", "sync" ]
                 }
               },
               "abort_previous" : {

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -868,7 +868,7 @@
           }, {
             "type" : "object",
             "properties" : {
-              "artifacts_array_path" : {
+              "path" : {
                 "type" : "string"
               },
               "conditions" : {
@@ -918,10 +918,8 @@
               "conditions" : {
                 "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
-              "image_path" : {
-                "type" : "string"
-              },
-              "tag" : {
+              "location" : {
+                "description" : "image path and tag, format-> image_path:tag",
                 "type" : "string"
               }
             }
@@ -1301,13 +1299,11 @@
           }, {
             "type" : "object",
             "properties" : {
-              "bucket" : {
+              "location" : {
+                "description" : "bucket name and path to the manifest folder, format-> bucket_name:folder_path",
                 "type" : "string"
               },
               "connector" : {
-                "type" : "string"
-              },
-              "folder_path" : {
                 "type" : "string"
               }
             }
@@ -1341,13 +1337,10 @@
           }, {
             "type" : "object",
             "properties" : {
-              "bucket" : {
-                "type" : "string"
+              "location" : {
+                "description" : "bucket name and path to the manifest folder, format-> bucket_name:folder_path"
               },
               "connector" : {
-                "type" : "string"
-              },
-              "folder_path" : {
                 "type" : "string"
               },
               "region" : {

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -38,6 +38,7 @@
       "trigger_source" : {
         "title" : "trigger_source",
         "type" : "object",
+        "required" : [ "type", "spec" ],
         "properties" : {
           "poll_interval" : {
             "type" : "string",
@@ -136,6 +137,7 @@
             "$ref" : "#/definitions/trigger/trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string",
@@ -391,6 +393,7 @@
             "$ref" : "#/definitions/trigger/trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string",
@@ -421,6 +424,7 @@
             "$ref" : "#/definitions/trigger/trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "sources" ],
             "properties" : {
               "event_conditions" : {
                 "type" : "array",
@@ -457,6 +461,7 @@
             "$ref" : "#/definitions/trigger/trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string"
@@ -486,6 +491,7 @@
             "$ref" : "#/definitions/trigger/trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string",
@@ -1408,6 +1414,7 @@
         "build_store" : {
           "title" : "build_store",
           "type" : "object",
+          "required" : [ "type", "spec" ],
           "properties" : {
             "type" : {
               "type" : "string",
@@ -1531,6 +1538,7 @@
           "title" : "artifact_type_spec_wrapper",
           "type" : "object",
           "properties" : { },
+          "required" : [ "type", "spec" ],
           "$schema" : "http://json-schema.org/draft-07/schema#",
           "allOf" : [ {
             "if" : {
@@ -1782,6 +1790,7 @@
             "$ref" : "#/definitions/trigger/scheduled_trigger/scheduled_trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "expression" ],
             "properties" : {
               "expression" : {
                 "type" : "string"
@@ -1807,6 +1816,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string",
@@ -1875,6 +1885,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string",
@@ -1935,6 +1946,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -1983,6 +1995,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2060,6 +2073,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string",
@@ -2120,6 +2134,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2168,6 +2183,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2271,6 +2287,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string",
@@ -2346,6 +2363,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2394,6 +2412,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2471,6 +2490,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2513,6 +2533,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string",
@@ -2573,6 +2594,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2621,6 +2643,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2698,6 +2721,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
           }, {
             "type" : "object",
+            "required" : [ "type", "spec" ],
             "properties" : {
               "type" : {
                 "type" : "string",
@@ -2758,6 +2782,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/harness_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",
@@ -2803,6 +2828,7 @@
             "$ref" : "#/definitions/trigger/webhook_trigger/harness_event_spec"
           }, {
             "type" : "object",
+            "required" : [ "actions" ],
             "properties" : {
               "actions" : {
                 "type" : "array",

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -13,24 +13,8 @@
       "type" : "string",
       "enum" : [ "trigger" ]
     },
-    "input_set_refs" : {
-      "type" : "array",
-      "items" : {
-        "type" : "string"
-      }
-    },
-    "inputs" : {
-      "description" : "input yaml for the pipeline",
-      "type" : "string"
-    },
     "spec" : {
       "$ref" : "#/definitions/trigger/trigger_source"
-    },
-    "stages_to_execute" : {
-      "type" : "array",
-      "items" : {
-        "type" : "string"
-      }
     }
   },
   "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -41,6 +25,23 @@
         "type" : "object",
         "required" : [ "type", "spec" ],
         "properties" : {
+          "input_set_refs" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "inputs" : {
+            "description" : "input yaml for the pipeline",
+            "type" : "string"
+          },
+          "execute_stages" : {
+            "description" : "stage identifiers of the stages to be executed in the pipeline",
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
           "interval" : {
             "description" : "polling interval",
             "type" : "string",
@@ -429,20 +430,8 @@
             "type" : "object",
             "required" : [ "type", "sources" ],
             "properties" : {
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "sources" : {
                 "type" : "array",
@@ -627,20 +616,8 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "registry" : {
                 "type" : "string"
@@ -665,6 +642,27 @@
           "discriminator" : "type",
           "$schema" : "http://json-schema.org/draft-07/schema#"
         },
+        "conditions" : {
+          "title" : "conditions",
+          "description" : "conditions for artifact trigger",
+          "properties" : {
+            "event" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/trigger/trigger_event_data"
+              }
+            },
+            "jexl" : {
+              "type" : "string"
+            },
+            "metadata" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/trigger/trigger_event_data"
+              }
+            }
+          }
+        },
         "ami_registry_spec" : {
           "title" : "ami_registry_spec",
           "allOf" : [ {
@@ -675,26 +673,14 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
               "filters" : {
                 "type" : "array",
                 "items" : {
                   "$ref" : "#/definitions/trigger/artifact_trigger/ami_filter"
                 }
               },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "region" : {
                 "type" : "string"
@@ -754,23 +740,11 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
-              "file_path_regex" : {
+              "path_regex" : {
                 "type" : "string"
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
               },
               "region" : {
                 "type" : "string"
@@ -786,45 +760,41 @@
           }, {
             "type" : "object",
             "properties" : {
-              "artifact_directory" : {
+              "directory" : {
                 "type" : "string"
               },
-              "artifact_filter" : {
+              "filter" : {
                 "type" : "string"
               },
-              "artifact_path" : {
+              "path" : {
                 "type" : "string"
               },
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "repo" : {
-                "type" : "string"
-              },
-              "repo_format" : {
-                "type" : "string"
-              },
-              "repo_url" : {
-                "type" : "string"
+                "$ref" : "#/definitions/trigger/artifact_trigger/artifact repository details"
               }
             }
           } ],
           "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "artifact repository details" : {
+          "title" : "artifact repository details",
+          "properties" : {
+            "name" : {
+              "type" : "string"
+            },
+            "format" : {
+              "type" : "string"
+            },
+            "url" : {
+              "type" : "string"
+            }
+          }
         },
         "azure_artifact" : {
           "title" : "azure_artifact",
@@ -836,23 +806,11 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "feed" : {
                 "type" : "string"
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
               },
               "pkg" : {
                 "description" : "package name",
@@ -881,7 +839,7 @@
           }, {
             "type" : "object",
             "properties" : {
-              "artifact_paths" : {
+              "paths" : {
                 "type" : "array",
                 "items" : {
                   "type" : "string"
@@ -893,20 +851,8 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "plan_key" : {
                 "type" : "string"
@@ -925,11 +871,8 @@
               "artifacts_array_path" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "inputs" : {
                 "type" : "array",
@@ -941,15 +884,6 @@
                   }, {
                     "$ref" : "#/definitions/pipeline/stringVariable"
                   } ]
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
                 }
               },
               "metadata" : {
@@ -981,23 +915,11 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "image_path" : {
                 "type" : "string"
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
               },
               "tag" : {
                 "type" : "string"
@@ -1016,23 +938,11 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "image_path" : {
                 "type" : "string"
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
               },
               "region" : {
                 "type" : "string"
@@ -1058,23 +968,11 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "img_path" : {
                 "type" : "string"
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
               },
               "registry_hostname" : {
                 "type" : "string"
@@ -1096,20 +994,8 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "org" : {
                 "type" : "string"
@@ -1135,20 +1021,8 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "pkg" : {
                 "type" : "string"
@@ -1177,7 +1051,7 @@
           }, {
             "type" : "object",
             "properties" : {
-              "artifact_path" : {
+              "path" : {
                 "type" : "string"
               },
               "bucket" : {
@@ -1186,20 +1060,8 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "project" : {
                 "type" : "string"
@@ -1215,7 +1077,7 @@
           }, {
             "type" : "object",
             "properties" : {
-              "artifact_path" : {
+              "path" : {
                 "type" : "string"
               },
               "build" : {
@@ -1224,24 +1086,12 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "job" : {
                 "description" : "job name",
                 "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
               }
             }
           } ],
@@ -1264,11 +1114,8 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "extension" : {
                 "type" : "string"
@@ -1276,28 +1123,12 @@
               "group_id" : {
                 "type" : "string"
               },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
               "pkg" : {
                 "description" : "package name",
                 "type" : "string"
               },
-              "repo_format" : {
-                "type" : "string"
-              },
               "repo" : {
-                "description" : "repository name",
-                "type" : "string"
-              },
-              "repo_url" : {
-                "type" : "string"
+                "$ref" : "#/definitions/trigger/artifact_trigger/artifact repository details"
               },
               "tag" : {
                 "type" : "string"
@@ -1323,12 +1154,6 @@
               "connector" : {
                 "type" : "string"
               },
-              "event_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
               "extension" : {
                 "type" : "string"
               },
@@ -1341,28 +1166,15 @@
               "image_path" : {
                 "type" : "string"
               },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "metadata_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
               "pkg" : {
                 "description" : "package name",
                 "type" : "string"
               },
               "repo" : {
-                "description" : "repository name",
-                "type" : "string"
-              },
-              "repo_format" : {
-                "type" : "string"
-              },
-              "repo_url" : {
-                "type" : "string"
+                "$ref" : "#/definitions/trigger/artifact_trigger/artifact repository details"
               },
               "tag" : {
                 "type" : "string"
@@ -1398,10 +1210,7 @@
             "type" : "object",
             "properties" : {
               "chart" : {
-                "description" : "chart name",
-                "type" : "string"
-              },
-              "chart_version" : {
+                "description" : "chart details, format-> chart_name@version",
                 "type" : "string"
               },
               "event_conditions" : {
@@ -1874,13 +1683,15 @@
               "connector" : {
                 "type" : "string"
               },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
+              "conditions" : {
+                "jexl" : {
+                  "type" : "string"
+                },
+                "payload" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/trigger/trigger_event_data"
+                  }
                 }
               },
               "repo" : {
@@ -1907,7 +1718,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "pull-request", "push", "issue-comment" ]
+                "enum" : [ "pr", "push", "issue-comment" ]
               }
             }
           }, {
@@ -1929,7 +1740,7 @@
             "if" : {
               "properties" : {
                 "type" : {
-                  "const" : "pull-request"
+                  "const" : "pr"
                 }
               }
             },
@@ -1973,26 +1784,14 @@
                   "enum" : [ "create", "edit", "delete" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2007,6 +1806,27 @@
           "type" : "object",
           "discriminator" : "type",
           "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "conditions" : {
+          "title" : "conditions",
+          "description" : "conditions for webhook trigger",
+          "properties" : {
+            "header" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/trigger/trigger_event_data"
+              }
+            },
+            "jexl" : {
+              "type" : "string"
+            },
+            "payload" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/definitions/trigger/trigger_event_data"
+              }
+            }
+          }
         },
         "azure_repo_pr_spec" : {
           "title" : "azure_repo_pr_spec",
@@ -2023,26 +1843,15 @@
                   "enum" : [ "create", "update", "merge" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
+                "description" : "abort previous executions",
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2060,26 +1869,14 @@
             "type" : "object",
             "required" : [ "connector" ],
             "properties" : {
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2099,7 +1896,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "pull-request", "push", "pr-comment" ]
+                "enum" : [ "pr", "push", "pr-comment" ]
               }
             }
           }, {
@@ -2121,7 +1918,7 @@
             "if" : {
               "properties" : {
                 "type" : {
-                  "const" : "pull-request"
+                  "const" : "pr"
                 }
               }
             },
@@ -2165,26 +1962,14 @@
                   "enum" : [ "create", "edit", "delete" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2215,26 +2000,14 @@
                   "enum" : [ "create", "update", "merge", "decline" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2252,26 +2025,14 @@
             "type" : "object",
             "required" : [ "connector" ],
             "properties" : {
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2288,20 +2049,8 @@
           }, {
             "type" : "object",
             "properties" : {
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               }
             }
           } ],
@@ -2317,7 +2066,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "pull-request", "push", "issue-comment", "release" ]
+                "enum" : [ "pr", "push", "issue-comment", "release" ]
               }
             }
           }, {
@@ -2339,7 +2088,7 @@
             "if" : {
               "properties" : {
                 "type" : {
-                  "const" : "pull-request"
+                  "const" : "pr"
                 }
               }
             },
@@ -2398,26 +2147,14 @@
                   "enum" : [ "create", "edit", "delete" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2448,26 +2185,14 @@
                   "enum" : [ "close", "edit", "open", "reopen", "label", "unlabel", "synchronize", "ready-for-review" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2485,26 +2210,14 @@
             "type" : "object",
             "required" : [ "connector" ],
             "properties" : {
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2529,26 +2242,14 @@
                   "enum" : [ "create", "edit", "delete", "prerelease", "publish", "release", "unpublish" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2568,7 +2269,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "merge-request", "push", "mr-comment" ]
+                "enum" : [ "mr", "push", "mr-comment" ]
               }
             }
           }, {
@@ -2590,7 +2291,7 @@
             "if" : {
               "properties" : {
                 "type" : {
-                  "const" : "merge-request"
+                  "const" : "mr"
                 }
               }
             },
@@ -2634,26 +2335,14 @@
                   "enum" : [ "create" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2684,26 +2373,14 @@
                   "enum" : [ "open", "close", "reopen", "merge", "update", "sync" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2721,26 +2398,14 @@
             "type" : "object",
             "required" : [ "connector" ],
             "properties" : {
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
               "connector" : {
                 "type" : "string"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2760,7 +2425,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "pull-request", "push", "issue-comment" ]
+                "enum" : [ "pr", "push", "issue-comment" ]
               }
             }
           }, {
@@ -2782,7 +2447,7 @@
             "if" : {
               "properties" : {
                 "type" : {
-                  "const" : "pull-request"
+                  "const" : "pr"
                 }
               }
             },
@@ -2826,23 +2491,11 @@
                   "enum" : [ "create", "edit", "delete" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2873,23 +2526,11 @@
                   "enum" : [ "close", "edit", "open", "reopen", "label", "unlabel", "synchronize" ]
                 }
               },
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",
@@ -2906,23 +2547,11 @@
           }, {
             "type" : "object",
             "properties" : {
-              "auto_abort_previous_executions" : {
+              "abort_previous" : {
                 "type" : "boolean"
               },
-              "header_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
-              },
-              "jexl_condition" : {
-                "type" : "string"
-              },
-              "payload_conditions" : {
-                "type" : "array",
-                "items" : {
-                  "$ref" : "#/definitions/trigger/trigger_event_data"
-                }
+              "conditions" : {
+                "$ref" : "#/definitions/trigger/webhook_trigger/conditions"
               },
               "repo" : {
                 "description" : "repository name",

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -813,11 +813,7 @@
                 "type" : "string"
               },
               "pkg" : {
-                "description" : "package name",
-                "type" : "string"
-              },
-              "pkg_type" : {
-                "type" : "string"
+                "$ref" : "#/definitions/trigger/artifact_trigger/Package details"
               },
               "project" : {
                 "type" : "string"
@@ -831,6 +827,19 @@
             }
           } ],
           "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "Package details" : {
+          "title" : "Package details",
+          "properties" : {
+            "name" : {
+              "type" : "string",
+              "description" : "package name"
+            },
+            "type" : {
+              "type" : "string",
+              "description" : "package type"
+            }
+          }
         },
         "bamboo" : {
           "title" : "bamboo",
@@ -995,11 +1004,7 @@
                 "type" : "string"
               },
               "pkg" : {
-                "description" : "package name",
-                "type" : "string"
-              },
-              "pkg_type" : {
-                "type" : "string"
+                "$ref" : "#/definitions/trigger/artifact_trigger/Package details"
               }
             }
           } ],

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -1,0 +1,2976 @@
+{
+  "type" : "object",
+  "title" : "trigger",
+  "required" : [ "spec", "version", "kind" ],
+  "properties" : {
+    "version" : {
+      "description" : "Version defines the schema version.",
+      "type" : "number",
+      "enum" : [ 1 ]
+    },
+    "kind" : {
+      "description" : "defines the kind of yaml (pipeline/template/trigger)",
+      "type" : "string",
+      "enum" : [ "trigger" ]
+    },
+    "input_set_refs" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string"
+      }
+    },
+    "input_yaml" : {
+      "type" : "string"
+    },
+    "spec" : {
+      "$ref" : "#/definitions/trigger/trigger_source"
+    },
+    "stages_to_execute" : {
+      "type" : "array",
+      "items" : {
+        "type" : "string"
+      }
+    }
+  },
+  "$schema" : "http://json-schema.org/draft-07/schema#",
+  "definitions" : {
+    "trigger" : {
+      "trigger_source" : {
+        "title" : "trigger_source",
+        "type" : "object",
+        "properties" : {
+          "poll_interval" : {
+            "type" : "string",
+            "pattern" : "(((([1-9])+\\d*[mh])+(\\s/?\\d+[mh])*)|(^$)|(0))$"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "webhook", "artifact", "manifest", "scheduled", "multi-region-artifact" ]
+          },
+          "webhook_id" : {
+            "type" : "string"
+          }
+        },
+        "$schema" : "http://json-schema.org/draft-07/schema#",
+        "allOf" : [ {
+          "if" : {
+            "properties" : {
+              "type" : {
+                "const" : "artifact"
+              }
+            }
+          },
+          "then" : {
+            "properties" : {
+              "spec" : {
+                "$ref" : "#/definitions/trigger/trigger_type/artifact_trigger"
+              }
+            }
+          }
+        }, {
+          "if" : {
+            "properties" : {
+              "type" : {
+                "const" : "manifest"
+              }
+            }
+          },
+          "then" : {
+            "properties" : {
+              "spec" : {
+                "$ref" : "#/definitions/trigger/trigger_type/manifest_trigger"
+              }
+            }
+          }
+        }, {
+          "if" : {
+            "properties" : {
+              "type" : {
+                "const" : "multi-region-artifact"
+              }
+            }
+          },
+          "then" : {
+            "properties" : {
+              "spec" : {
+                "$ref" : "#/definitions/trigger/trigger_type/multi_region_trigger"
+              }
+            }
+          }
+        }, {
+          "if" : {
+            "properties" : {
+              "type" : {
+                "const" : "scheduled"
+              }
+            }
+          },
+          "then" : {
+            "properties" : {
+              "spec" : {
+                "$ref" : "#/definitions/trigger/trigger_type/scheduled_trigger"
+              }
+            }
+          }
+        }, {
+          "if" : {
+            "properties" : {
+              "type" : {
+                "const" : "webhook"
+              }
+            }
+          },
+          "then" : {
+            "properties" : {
+              "spec" : {
+                "$ref" : "#/definitions/trigger/trigger_type/webhook_trigger"
+              }
+            }
+          }
+        } ]
+      },
+      "trigger_type" : {
+        "artifact_trigger" : {
+          "title" : "artifact_trigger",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "gcr", "ecr", "docker-registry", "nexus3-registry", "nexus2-registry", "artifactory-registry", "acr", "amazon-s3", "jenkins", "custom-artifact", "google-artifact-registry", "github-package-registry", "azure-artifacts", "amazon-machine-image", "google-cloud-storage", "bamboo" ]
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "acr"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/acr_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "amazon-machine-image"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/ami_registry_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "amazon-s3"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/amazon_s3_registry"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "artifactory-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/artifactory_registry"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "azure-artifacts"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/azure_artifact"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "bamboo"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/bamboo"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "custom-artifact"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/custom_artifact"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "docker-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/docker_registry"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "ecr"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/ecr"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "gcr"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/gcr"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "github-package-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/github_packages"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "google-artifact-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/gar_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "google-cloud-storage"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/google_cloud"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "jenkins"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/jenkins_registry"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "nexus2-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/nexus"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "nexus3-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/nexus_registry"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "manifest_trigger" : {
+          "title" : "manifest_trigger",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "helm-chart" ]
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "helm-chart"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/manifest_trigger/helm_spec"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "multi_region_trigger" : {
+          "title" : "multi_region_trigger",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "sources" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/multi_region_artifact/artifact_type_spec_wrapper"
+                }
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "gcr", "ecr", "docker-registry", "nexus3-registry", "nexus2-registry", "artifactory-registry", "acr", "amazon-s3", "jenkins", "custom-artifact", "google-artifact-registry", "github-package-registry", "azure-artifacts", "amazon-machine-image", "google-cloud-storage", "bamboo" ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "scheduled_trigger" : {
+          "title" : "scheduled_trigger",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string"
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "cron"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/scheduled_trigger/cron_trigger_spec"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "webhook_trigger" : {
+          "title" : "webhook_trigger",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "azure-repo", "github", "gitlab", "bitbucket", "custom", "aws-code-commit", "harness" ]
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "aws-code-commit"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/aws_commit_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "azure-repo"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "bitbucket"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "custom"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/custom_trigger_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "github"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/github_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "gitlab"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "harness"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_spec"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      "trigger_spec" : {
+        "title" : "trigger_spec",
+        "type" : "object",
+        "discriminator" : "type",
+        "$schema" : "http://json-schema.org/draft-07/schema#"
+      },
+      "artifact_trigger" : {
+        "acr_spec" : {
+          "title" : "acr_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "registry" : {
+                "type" : "string"
+              },
+              "repo" : {
+                "type" : "string"
+              },
+              "subscription_id" : {
+                "type" : "string"
+              },
+              "tag" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "artifact_type_spec" : {
+          "title" : "artifact_type_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "ami_registry_spec" : {
+          "title" : "ami_registry_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "filters" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/ami_filter"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "region" : {
+                "type" : "string"
+              },
+              "tags" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/ami_tag"
+                }
+              },
+              "version" : {
+                "type" : "string"
+              },
+              "version_regex" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "ami_filter" : {
+          "title" : "ami_filter",
+          "type" : "object",
+          "properties" : {
+            "name" : {
+              "type" : "string"
+            },
+            "value" : {
+              "type" : "string"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "ami_tag" : {
+          "title" : "ami_tag",
+          "type" : "object",
+          "properties" : {
+            "name" : {
+              "type" : "string"
+            },
+            "value" : {
+              "type" : "string"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "amazon_s3_registry" : {
+          "title" : "amazon_s3_registry",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "bucket" : {
+                "type" : "string"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "file_path_regex" : {
+                "type" : "string"
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "region" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "artifactory_registry" : {
+          "title" : "artifactory_registry",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "artifact_directory" : {
+                "type" : "string"
+              },
+              "artifact_filter" : {
+                "type" : "string"
+              },
+              "artifact_path" : {
+                "type" : "string"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo" : {
+                "type" : "string"
+              },
+              "repo_format" : {
+                "type" : "string"
+              },
+              "repo_url" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_artifact" : {
+          "title" : "azure_artifact",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "feed" : {
+                "type" : "string"
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "pkg_name" : {
+                "type" : "string"
+              },
+              "pkg_type" : {
+                "type" : "string"
+              },
+              "project" : {
+                "type" : "string"
+              },
+              "version" : {
+                "type" : "string"
+              },
+              "version_regex" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "bamboo" : {
+          "title" : "bamboo",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "artifact_paths" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "build" : {
+                "type" : "string"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "plan_key" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "custom_artifact" : {
+          "title" : "custom_artifact",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "artifacts_array_path" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "inputs" : {
+                "type" : "array",
+                "items" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/numberVariable"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/secretVariable"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/stringVariable"
+                  } ]
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "metadata" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "string"
+                }
+              },
+              "script" : {
+                "type" : "string"
+              },
+              "version" : {
+                "type" : "string"
+              },
+              "version_path" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "docker_registry" : {
+          "title" : "docker_registry",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "image_path" : {
+                "type" : "string"
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "tag" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "ecr" : {
+          "title" : "ecr",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "image_path" : {
+                "type" : "string"
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "region" : {
+                "type" : "string"
+              },
+              "registry_id" : {
+                "type" : "string"
+              },
+              "tag" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "gcr" : {
+          "title" : "gcr",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "img_path" : {
+                "type" : "string"
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "registry_hostname" : {
+                "type" : "string"
+              },
+              "tag" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "github_packages" : {
+          "title" : "github_packages",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "org" : {
+                "type" : "string"
+              },
+              "pkg_name" : {
+                "type" : "string"
+              },
+              "pkg_type" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "gar_spec" : {
+          "title" : "gar_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "pkg" : {
+                "type" : "string"
+              },
+              "project" : {
+                "type" : "string"
+              },
+              "region" : {
+                "type" : "string"
+              },
+              "repo_name" : {
+                "type" : "string"
+              },
+              "version" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "google_cloud" : {
+          "title" : "google_cloud",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "artifact_path" : {
+                "type" : "string"
+              },
+              "bucket" : {
+                "type" : "string"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "project" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "jenkins_registry" : {
+          "title" : "jenkins_registry",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "artifact_path" : {
+                "type" : "string"
+              },
+              "build" : {
+                "type" : "string"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "job_name" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "nexus" : {
+          "title" : "nexus",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "artifact_id" : {
+                "type" : "string"
+              },
+              "classifier" : {
+                "type" : "string"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "extension" : {
+                "type" : "string"
+              },
+              "group_id" : {
+                "type" : "string"
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "pkg_name" : {
+                "type" : "string"
+              },
+              "repo_format" : {
+                "type" : "string"
+              },
+              "repo_name" : {
+                "type" : "string"
+              },
+              "repo_url" : {
+                "type" : "string"
+              },
+              "tag" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "nexus_registry" : {
+          "title" : "nexus_registry",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/artifact_trigger/artifact_type_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "artifact_id" : {
+                "type" : "string"
+              },
+              "classifier" : {
+                "type" : "string"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "extension" : {
+                "type" : "string"
+              },
+              "group" : {
+                "type" : "string"
+              },
+              "group_id" : {
+                "type" : "string"
+              },
+              "image_path" : {
+                "type" : "string"
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "meta_data_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "pkg_name" : {
+                "type" : "string"
+              },
+              "repo" : {
+                "type" : "string"
+              },
+              "repo_format" : {
+                "type" : "string"
+              },
+              "repo_url" : {
+                "type" : "string"
+              },
+              "tag" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      "trigger_event_data" : {
+        "title" : "trigger_event_data",
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "operator" : {
+            "type" : "string",
+            "enum" : [ "in", "equals", "not-equals", "not-in", "regex", "ends-with", "starts-with", "contains", "doesN-not-contain" ]
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "$schema" : "http://json-schema.org/draft-07/schema#"
+      },
+      "manifest_trigger" : {
+        "helm_spec" : {
+          "title" : "helm_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/manifest_trigger/manifest_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "chart_name" : {
+                "type" : "string"
+              },
+              "chart_version" : {
+                "type" : "string"
+              },
+              "event_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "helm_version" : {
+                "type" : "string",
+                "enum" : [ "v2", "v3", "v380" ]
+              },
+              "store" : {
+                "$ref" : "#/definitions/trigger/manifest_trigger/build_store"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "manifest_spec" : {
+          "title" : "manifest_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "build_store" : {
+          "title" : "build_store",
+          "type" : "object",
+          "properties" : {
+            "type" : {
+              "type" : "string",
+              "enum" : [ "http", "s3", "gcs" ]
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#",
+          "allOf" : [ {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "gcs"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/manifest_trigger/gcs_build_store_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "http"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/manifest_trigger/http_build_store_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "s3"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/manifest_trigger/s3_build_store_spec"
+                }
+              }
+            }
+          } ]
+        },
+        "gcs_build_store_spec" : {
+          "title" : "gcs_build_store_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/manifest_trigger/build_store_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "bucket" : {
+                "type" : "string"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "folder_path" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "build_store_spec" : {
+          "title" : "build_store_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "http_build_store_spec" : {
+          "title" : "http_build_store_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/manifest_trigger/build_store_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "s3_build_store_spec" : {
+          "title" : "s3_build_store_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/manifest_trigger/build_store_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "bucket" : {
+                "type" : "string"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "folder_path" : {
+                "type" : "string"
+              },
+              "region" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      "multi_region_artifact" : {
+        "artifact_type_spec_wrapper" : {
+          "title" : "artifact_type_spec_wrapper",
+          "type" : "object",
+          "properties" : { },
+          "$schema" : "http://json-schema.org/draft-07/schema#",
+          "allOf" : [ {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "acr"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/acr_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "amazon-machine-image"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/ami_registry_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "amazon-s3"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/amazon_s3_registry"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "artifactory-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/artifactory_registry"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "azure-artifacts"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/azure_artifact"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "bamboo"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/bamboo"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "custom-artifact"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/custom_artifact"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "docker-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/docker_registry"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "ecr"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/ecr"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "gcr"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/gcr"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "github-package-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/github_packages"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "google-artifact-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/gar_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "google-cloud-storage"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/google_cloud"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "jenkins"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/jenkins_registry"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "nexus2-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/nexus"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "nexus3-registry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/artifact_trigger/nexus_registry"
+                }
+              }
+            }
+          } ]
+        }
+      },
+      "scheduled_trigger" : {
+        "cron_trigger_spec" : {
+          "title" : "cron_trigger_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/scheduled_trigger/scheduled_trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "expression" : {
+                "type" : "string"
+              },
+              "type" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "scheduled_trigger_spec" : {
+          "title" : "scheduled_trigger_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        }
+      },
+      "webhook_trigger" : {
+        "aws_commit_spec" : {
+          "title" : "aws_commit_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "push" ]
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "push"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/aws_commit_push_spec"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "webhook_trigger_spec" : {
+          "title" : "webhook_trigger_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "aws_commit_push_spec" : {
+          "title" : "aws_commit_push_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/aws_commit_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "aws_commit_event_spec" : {
+          "title" : "aws_commit_event_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_repo_spec" : {
+          "title" : "azure_repo_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "pull-request", "push", "issue-comment" ]
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "issue-comment"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/azure_issue_comment_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "pull-request"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_pr_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "push"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_push_spec"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_issue_comment_spec" : {
+          "title" : "azure_issue_comment_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "create", "edit", "delete" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_repo_event_spec" : {
+          "title" : "azure_repo_event_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_repo_pr_spec" : {
+          "title" : "azure_repo_pr_spec",
+          "kallOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "create", "update", "merge" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "azure_repo_push_spec" : {
+          "title" : "azure_repo_push_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/azure_repo_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_spec" : {
+          "title" : "bitbucket_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "pull-request", "push", "pr-comment" ]
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "pr-comment"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_pr_comment_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "pull-request"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_pr_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "push"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_push_spec"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_pr_comment_spec" : {
+          "title" : "bitbucket_pr_comment_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "create", "edit", "delete" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_event_spec" : {
+          "title" : "bitbucket_event_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_pr_spec" : {
+          "title" : "bitbucket_pr_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "create", "update", "merge", "decline" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "bitbucket_push_spec" : {
+          "title" : "bitbucket_push_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/bitbucket_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "custom_trigger_spec" : {
+          "title" : "custom_trigger_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "github_spec" : {
+          "title" : "github_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "pull-request", "push", "issue-comment", "release" ]
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "issue-comment"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/github_issue_comment_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "pull-request"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/github_pr_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "push"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/github_push_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "release"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/github_release_spec"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "github_issue_comment_spec" : {
+          "title" : "github_issue_comment_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "create", "edit", "delete" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "github_event_spec" : {
+          "title" : "github_event_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "github_pr_spec" : {
+          "title" : "github_pr_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "close", "edit", "open", "reopen", "label", "unlabel", "synchronize", "ready-for-review" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "github_push_spec" : {
+          "title" : "github_push_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "github_release_spec" : {
+          "title" : "github_release_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/github_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "create", "edit", "delete", "prerelease", "publish", "release", "unpublish" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_spec" : {
+          "title" : "gitlab_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "merge-request", "push", "mr-comment" ]
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "mr-comment"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_mr_comment_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "merge-request"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_pr_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "push"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_push_spec"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_mr_comment_spec" : {
+          "title" : "gitlab_mr_comment_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "create" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_event_spec" : {
+          "title" : "gitlab_event_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_pr_spec" : {
+          "title" : "gitlab_pr_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "open", "close", "reopen", "merge", "update", "sync" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "gitlab_push_spec" : {
+          "title" : "gitlab_push_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/gitlab_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "connector" : {
+                "type" : "string"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_spec" : {
+          "title" : "harness_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/webhook_trigger_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "pull-request", "push", "issue-comment" ]
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "issue-comment"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_issue_comment_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "pull-request"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_pr_spec"
+                }
+              }
+            }
+          }, {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "push"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/trigger/webhook_trigger/harness_push_spec"
+                }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_issue_comment_spec" : {
+          "title" : "harness_issue_comment_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/harness_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "create", "edit", "delete" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_event_spec" : {
+          "title" : "harness_event_spec",
+          "type" : "object",
+          "discriminator" : "type",
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_pr_spec" : {
+          "title" : "harness_pr_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/harness_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "actions" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string",
+                  "enum" : [ "close", "edit", "open", "reopen", "label", "unlabel", "synchronize" ]
+                }
+              },
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "harness_push_spec" : {
+          "title" : "harness_push_spec",
+          "allOf" : [ {
+            "$ref" : "#/definitions/trigger/webhook_trigger/harness_event_spec"
+          }, {
+            "type" : "object",
+            "properties" : {
+              "auto_abort_previous_executions" : {
+                "type" : "boolean"
+              },
+              "header_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "jexl_condition" : {
+                "type" : "string"
+              },
+              "payload_conditions" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/trigger/trigger_event_data"
+                }
+              },
+              "repo_name" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        }
+      }
+    },
+    "pipeline" : {
+      "numberVariable" : {
+        "title" : "numberVariable",
+        "type" : "object",
+        "required" : [ "value" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
+          },
+          "default" : {
+            "type" : "number",
+            "format" : "double"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "Number" ]
+          },
+          "value" : {
+            "oneOf" : [ {
+              "type" : "number",
+              "format" : "double"
+            }, {
+              "type" : "string",
+              "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+            } ]
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "required" : {
+            "type" : "boolean"
+          },
+          "metadata" : {
+            "type" : "string"
+          }
+        },
+        "$schema" : "http://json-schema.org/draft-07/schema#"
+      },
+      "secretVariable" : {
+        "title" : "secretVariable",
+        "type" : "object",
+        "required" : [ "value" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
+          },
+          "default" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "Secret" ]
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "required" : {
+            "type" : "boolean"
+          },
+          "metadata" : {
+            "type" : "string"
+          }
+        },
+        "$schema" : "http://json-schema.org/draft-07/schema#"
+      },
+      "stringVariable" : {
+        "title" : "stringVariable",
+        "type" : "object",
+        "required" : [ "value" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
+          },
+          "default" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "String" ]
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "required" : {
+            "type" : "boolean"
+          },
+          "metadata" : {
+            "type" : "string"
+          }
+        },
+        "$schema" : "http://json-schema.org/draft-07/schema#"
+      }
+    }
+  }
+}

--- a/v1/trigger.json
+++ b/v1/trigger.json
@@ -939,9 +939,6 @@
               "conditions" : {
                 "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
-              "image_path" : {
-                "type" : "string"
-              },
               "region" : {
                 "type" : "string"
               },
@@ -949,8 +946,9 @@
                 "description" : "registry identifier",
                 "type" : "string"
               },
-              "tag" : {
-                "type" : "string"
+              "location" : {
+                "type" : "string",
+                "description" : "image path and tag, format-> image_path:tag"
               }
             }
           } ],
@@ -969,13 +967,11 @@
               "conditions" : {
                 "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
               },
-              "img_path" : {
-                "type" : "string"
+              "location" : {
+                "type" : "string",
+                "description" : "image path and tag, format-> image_path:tag"
               },
               "registry_hostname" : {
-                "type" : "string"
-              },
-              "tag" : {
                 "type" : "string"
               }
             }
@@ -1161,8 +1157,9 @@
               "group_id" : {
                 "type" : "string"
               },
-              "image_path" : {
-                "type" : "string"
+              "location" : {
+                "type" : "string",
+                "description" : "image path and tag, format-> image_path:tag"
               },
               "conditions" : {
                 "$ref" : "#/definitions/trigger/artifact_trigger/conditions"
@@ -1173,9 +1170,6 @@
               },
               "repo" : {
                 "$ref" : "#/definitions/trigger/artifact_trigger/artifact repository details"
-              },
-              "tag" : {
-                "type" : "string"
               }
             }
           } ],

--- a/v1/trigger/artifact_trigger/acr_spec.yaml
+++ b/v1/trigger/artifact_trigger/acr_spec.yaml
@@ -11,7 +11,7 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
@@ -19,7 +19,8 @@ allOf:
         type: string
       repo:
         type: string
-      subscription_id:
+      subscription:
+        description: subscription identifier
         type: string
       tag:
         type: string

--- a/v1/trigger/artifact_trigger/acr_spec.yaml
+++ b/v1/trigger/artifact_trigger/acr_spec.yaml
@@ -1,0 +1,26 @@
+title: acr_spec
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      registry:
+        type: string
+      repo:
+        type: string
+      subscription_id:
+        type: string
+      tag:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/acr_spec.yaml
+++ b/v1/trigger/artifact_trigger/acr_spec.yaml
@@ -5,16 +5,8 @@ allOf:
     properties:
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       registry:
         type: string
       repo:

--- a/v1/trigger/artifact_trigger/amazon_s3_registry.yaml
+++ b/v1/trigger/artifact_trigger/amazon_s3_registry.yaml
@@ -7,18 +7,10 @@ allOf:
         type: string
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      file_path_regex:
+      conditions:
+        $ref: ./conditions.yaml
+      path_regex:
         type: string
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
       region:
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/amazon_s3_registry.yaml
+++ b/v1/trigger/artifact_trigger/amazon_s3_registry.yaml
@@ -15,7 +15,7 @@ allOf:
         type: string
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/amazon_s3_registry.yaml
+++ b/v1/trigger/artifact_trigger/amazon_s3_registry.yaml
@@ -1,0 +1,24 @@
+title: amazon_s3_registry
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      bucket:
+        type: string
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      file_path_regex:
+        type: string
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      region:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/ami_filter.yaml
+++ b/v1/trigger/artifact_trigger/ami_filter.yaml
@@ -1,0 +1,8 @@
+title: ami_filter
+type: object
+properties:
+  name:
+    type: string
+  value:
+    type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/ami_registry_spec.yaml
+++ b/v1/trigger/artifact_trigger/ami_registry_spec.yaml
@@ -5,20 +5,12 @@ allOf:
     properties:
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
       filters:
         type: array
         items:
           "$ref": "./ami_filter.yaml"
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       region:
         type: string
       tags:

--- a/v1/trigger/artifact_trigger/ami_registry_spec.yaml
+++ b/v1/trigger/artifact_trigger/ami_registry_spec.yaml
@@ -15,7 +15,7 @@ allOf:
           "$ref": "./ami_filter.yaml"
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/ami_registry_spec.yaml
+++ b/v1/trigger/artifact_trigger/ami_registry_spec.yaml
@@ -1,0 +1,32 @@
+title: ami_registry_spec
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      filters:
+        type: array
+        items:
+          "$ref": "./ami_filter.yaml"
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      region:
+        type: string
+      tags:
+        type: array
+        items:
+          "$ref": "./ami_tag.yaml"
+      version:
+        type: string
+      version_regex:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/ami_tag.yaml
+++ b/v1/trigger/artifact_trigger/ami_tag.yaml
@@ -1,0 +1,8 @@
+title: ami_tag
+type: object
+properties:
+  name:
+    type: string
+  value:
+    type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/artifact_type_spec.yaml
+++ b/v1/trigger/artifact_trigger/artifact_type_spec.yaml
@@ -1,0 +1,4 @@
+title: artifact_type_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/artifactory_registry.yaml
+++ b/v1/trigger/artifact_trigger/artifactory_registry.yaml
@@ -1,0 +1,30 @@
+title: artifactory_registry
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      artifact_directory:
+        type: string
+      artifact_filter:
+        type: string
+      artifact_path:
+        type: string
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo:
+        type: string
+      repo_format:
+        type: string
+      repo_url:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/artifactory_registry.yaml
+++ b/v1/trigger/artifact_trigger/artifactory_registry.yaml
@@ -17,7 +17,7 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/artifactory_registry.yaml
+++ b/v1/trigger/artifact_trigger/artifactory_registry.yaml
@@ -3,28 +3,16 @@ allOf:
   - "$ref": "./artifact_type_spec.yaml"
   - type: object
     properties:
-      artifact_directory:
+      directory:
         type: string
-      artifact_filter:
+      filter:
         type: string
-      artifact_path:
+      path:
         type: string
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
-        type: string
-      repo_format:
-        type: string
-      repo_url:
-        type: string
+        $ref: ./repo.yaml
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/azure_artifact.yaml
+++ b/v1/trigger/artifact_trigger/azure_artifact.yaml
@@ -1,0 +1,30 @@
+title: azure_artifact
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      feed:
+        type: string
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      pkg_name:
+        type: string
+      pkg_type:
+        type: string
+      project:
+        type: string
+      version:
+        type: string
+      version_regex:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/azure_artifact.yaml
+++ b/v1/trigger/artifact_trigger/azure_artifact.yaml
@@ -17,7 +17,8 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      pkg_name:
+      pkg:
+        description: package name
         type: string
       pkg_type:
         type: string

--- a/v1/trigger/artifact_trigger/azure_artifact.yaml
+++ b/v1/trigger/artifact_trigger/azure_artifact.yaml
@@ -10,10 +10,7 @@ allOf:
       feed:
         type: string
       pkg:
-        description: package name
-        type: string
-      pkg_type:
-        type: string
+        $ref: ./package.yaml
       project:
         type: string
       version:

--- a/v1/trigger/artifact_trigger/azure_artifact.yaml
+++ b/v1/trigger/artifact_trigger/azure_artifact.yaml
@@ -5,18 +5,10 @@ allOf:
     properties:
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       feed:
         type: string
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
       pkg:
         description: package name
         type: string

--- a/v1/trigger/artifact_trigger/azure_artifact.yaml
+++ b/v1/trigger/artifact_trigger/azure_artifact.yaml
@@ -13,7 +13,7 @@ allOf:
         type: string
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/bamboo.yaml
+++ b/v1/trigger/artifact_trigger/bamboo.yaml
@@ -17,7 +17,7 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/bamboo.yaml
+++ b/v1/trigger/artifact_trigger/bamboo.yaml
@@ -1,0 +1,26 @@
+title: bamboo
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      artifact_paths:
+        type: array
+        items:
+          type: string
+      build:
+        type: string
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      plan_key:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/bamboo.yaml
+++ b/v1/trigger/artifact_trigger/bamboo.yaml
@@ -3,7 +3,7 @@ allOf:
   - "$ref": "./artifact_type_spec.yaml"
   - type: object
     properties:
-      artifact_paths:
+      paths:
         type: array
         items:
           type: string
@@ -11,16 +11,8 @@ allOf:
         type: string
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       plan_key:
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/conditions.yaml
+++ b/v1/trigger/artifact_trigger/conditions.yaml
@@ -1,0 +1,13 @@
+title: conditions
+description: conditions for artifact trigger
+properties:
+  event:
+    type: array
+    items:
+      "$ref": "../trigger_event_data.yaml"
+  jexl:
+    type: string
+  metadata:
+    type: array
+    items:
+      "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/custom_artifact.yaml
+++ b/v1/trigger/artifact_trigger/custom_artifact.yaml
@@ -3,7 +3,7 @@ allOf:
   - "$ref": "./artifact_type_spec.yaml"
   - type: object
     properties:
-      artifacts_array_path:
+      path:
         type: string
       conditions:
         $ref: ./conditions.yaml

--- a/v1/trigger/artifact_trigger/custom_artifact.yaml
+++ b/v1/trigger/artifact_trigger/custom_artifact.yaml
@@ -1,0 +1,35 @@
+title: custom_artifact
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      artifacts_array_path:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      inputs:
+        type: array
+        items:
+          oneOf:
+            - "$ref": "../../pipeline/number_variable.yaml"
+            - "$ref": "../../pipeline/secret_variable.yaml"
+            - "$ref": "../../pipeline/string_variable.yaml"
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
+      script:
+        type: string
+      version:
+        type: string
+      version_path:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/custom_artifact.yaml
+++ b/v1/trigger/artifact_trigger/custom_artifact.yaml
@@ -18,7 +18,7 @@ allOf:
             - "$ref": "../../pipeline/string_variable.yaml"
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/custom_artifact.yaml
+++ b/v1/trigger/artifact_trigger/custom_artifact.yaml
@@ -5,10 +5,8 @@ allOf:
     properties:
       artifacts_array_path:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       inputs:
         type: array
         items:
@@ -16,12 +14,6 @@ allOf:
             - "$ref": "../../pipeline/number_variable.yaml"
             - "$ref": "../../pipeline/secret_variable.yaml"
             - "$ref": "../../pipeline/string_variable.yaml"
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
       metadata:
         type: object
         additionalProperties:

--- a/v1/trigger/artifact_trigger/docker_registry.yaml
+++ b/v1/trigger/artifact_trigger/docker_registry.yaml
@@ -8,8 +8,7 @@ allOf:
       conditions:
         $ref: ./conditions.yaml
           # combine with tag
-      image_path:
-        type: string
-      tag:
+      location:
+        description: image path and tag, format-> image_path:tag
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/docker_registry.yaml
+++ b/v1/trigger/artifact_trigger/docker_registry.yaml
@@ -1,0 +1,22 @@
+title: docker_registry
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      image_path:
+        type: string
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      tag:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/docker_registry.yaml
+++ b/v1/trigger/artifact_trigger/docker_registry.yaml
@@ -13,7 +13,7 @@ allOf:
         type: string
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/docker_registry.yaml
+++ b/v1/trigger/artifact_trigger/docker_registry.yaml
@@ -5,18 +5,11 @@ allOf:
     properties:
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
+          # combine with tag
       image_path:
         type: string
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
       tag:
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/ecr.yaml
+++ b/v1/trigger/artifact_trigger/ecr.yaml
@@ -7,13 +7,12 @@ allOf:
         type: string
       conditions:
         $ref: ./conditions.yaml
-      image_path:
-        type: string
       region:
         type: string
       registry:
         description: registry identifier
         type: string
-      tag:
+      location:
         type: string
+        description: image path and tag, format-> image_path:tag
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/ecr.yaml
+++ b/v1/trigger/artifact_trigger/ecr.yaml
@@ -1,0 +1,26 @@
+title: ecr
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      image_path:
+        type: string
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      region:
+        type: string
+      registry_id:
+        type: string
+      tag:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/ecr.yaml
+++ b/v1/trigger/artifact_trigger/ecr.yaml
@@ -19,7 +19,8 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       region:
         type: string
-      registry_id:
+      registry:
+        description: registry identifier
         type: string
       tag:
         type: string

--- a/v1/trigger/artifact_trigger/ecr.yaml
+++ b/v1/trigger/artifact_trigger/ecr.yaml
@@ -5,18 +5,10 @@ allOf:
     properties:
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       image_path:
         type: string
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
       region:
         type: string
       registry:

--- a/v1/trigger/artifact_trigger/ecr.yaml
+++ b/v1/trigger/artifact_trigger/ecr.yaml
@@ -13,7 +13,7 @@ allOf:
         type: string
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/gar_spec.yaml
+++ b/v1/trigger/artifact_trigger/gar_spec.yaml
@@ -21,7 +21,8 @@ allOf:
         type: string
       region:
         type: string
-      repo_name:
+      repo:
+        description: repository name
         type: string
       version:
         type: string

--- a/v1/trigger/artifact_trigger/gar_spec.yaml
+++ b/v1/trigger/artifact_trigger/gar_spec.yaml
@@ -5,16 +5,8 @@ allOf:
     properties:
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       pkg:
         type: string
       project:

--- a/v1/trigger/artifact_trigger/gar_spec.yaml
+++ b/v1/trigger/artifact_trigger/gar_spec.yaml
@@ -11,7 +11,7 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/gar_spec.yaml
+++ b/v1/trigger/artifact_trigger/gar_spec.yaml
@@ -1,0 +1,28 @@
+title: gar_spec
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      pkg:
+        type: string
+      project:
+        type: string
+      region:
+        type: string
+      repo_name:
+        type: string
+      version:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/gcr.yaml
+++ b/v1/trigger/artifact_trigger/gcr.yaml
@@ -5,18 +5,10 @@ allOf:
     properties:
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       img_path:
         type: string
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
       registry_hostname:
         type: string
       tag:

--- a/v1/trigger/artifact_trigger/gcr.yaml
+++ b/v1/trigger/artifact_trigger/gcr.yaml
@@ -7,10 +7,9 @@ allOf:
         type: string
       conditions:
         $ref: ./conditions.yaml
-      img_path:
+      location:
         type: string
+        description: image path and tag, format-> image_path:tag
       registry_hostname:
-        type: string
-      tag:
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/gcr.yaml
+++ b/v1/trigger/artifact_trigger/gcr.yaml
@@ -1,0 +1,24 @@
+title: gcr
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      img_path:
+        type: string
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      registry_hostname:
+        type: string
+      tag:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/gcr.yaml
+++ b/v1/trigger/artifact_trigger/gcr.yaml
@@ -13,7 +13,7 @@ allOf:
         type: string
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/github_packages.yaml
+++ b/v1/trigger/artifact_trigger/github_packages.yaml
@@ -5,16 +5,8 @@ allOf:
     properties:
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       org:
         type: string
       pkg:

--- a/v1/trigger/artifact_trigger/github_packages.yaml
+++ b/v1/trigger/artifact_trigger/github_packages.yaml
@@ -10,8 +10,5 @@ allOf:
       org:
         type: string
       pkg:
-        description: package name
-        type: string
-      pkg_type:
-        type: string
+        $ref: ./package.yaml
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/github_packages.yaml
+++ b/v1/trigger/artifact_trigger/github_packages.yaml
@@ -11,7 +11,7 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/github_packages.yaml
+++ b/v1/trigger/artifact_trigger/github_packages.yaml
@@ -1,0 +1,24 @@
+title: github_packages
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      org:
+        type: string
+      pkg_name:
+        type: string
+      pkg_type:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/github_packages.yaml
+++ b/v1/trigger/artifact_trigger/github_packages.yaml
@@ -17,7 +17,8 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       org:
         type: string
-      pkg_name:
+      pkg:
+        description: package name
         type: string
       pkg_type:
         type: string

--- a/v1/trigger/artifact_trigger/google_cloud.yaml
+++ b/v1/trigger/artifact_trigger/google_cloud.yaml
@@ -1,0 +1,24 @@
+title: google_cloud
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      artifact_path:
+        type: string
+      bucket:
+        type: string
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      project:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/google_cloud.yaml
+++ b/v1/trigger/artifact_trigger/google_cloud.yaml
@@ -3,22 +3,14 @@ allOf:
   - "$ref": "./artifact_type_spec.yaml"
   - type: object
     properties:
-      artifact_path:
+      path:
         type: string
       bucket:
         type: string
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       project:
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/google_cloud.yaml
+++ b/v1/trigger/artifact_trigger/google_cloud.yaml
@@ -15,7 +15,7 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/jenkins_registry.yaml
+++ b/v1/trigger/artifact_trigger/jenkins_registry.yaml
@@ -17,7 +17,7 @@ allOf:
         type: string
       job_name:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/jenkins_registry.yaml
+++ b/v1/trigger/artifact_trigger/jenkins_registry.yaml
@@ -15,7 +15,8 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       jexl_condition:
         type: string
-      job_name:
+      job:
+        description: job name
         type: string
       metadata_conditions:
         type: array

--- a/v1/trigger/artifact_trigger/jenkins_registry.yaml
+++ b/v1/trigger/artifact_trigger/jenkins_registry.yaml
@@ -1,0 +1,24 @@
+title: jenkins_registry
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      artifact_path:
+        type: string
+      build:
+        type: string
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      job_name:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/jenkins_registry.yaml
+++ b/v1/trigger/artifact_trigger/jenkins_registry.yaml
@@ -3,23 +3,15 @@ allOf:
   - "$ref": "./artifact_type_spec.yaml"
   - type: object
     properties:
-      artifact_path:
+      path:
         type: string
       build:
         type: string
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
+      conditions:
+        $ref: ./conditions.yaml
       job:
         description: job name
         type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/nexus.yaml
+++ b/v1/trigger/artifact_trigger/nexus.yaml
@@ -10,30 +10,17 @@ allOf:
         type: string
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       extension:
         type: string
       group_id:
         type: string
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
       pkg:
         description: package name
         type: string
-      repo_format:
-        type: string
       repo:
-        description: repository name
-        type: string
-      repo_url:
-        type: string
+        $ref: ./repo.yaml
       tag:
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/nexus.yaml
+++ b/v1/trigger/artifact_trigger/nexus.yaml
@@ -19,7 +19,7 @@ allOf:
         type: string
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/nexus.yaml
+++ b/v1/trigger/artifact_trigger/nexus.yaml
@@ -3,7 +3,8 @@ allOf:
   - "$ref": "./artifact_type_spec.yaml"
   - type: object
     properties:
-      artifact_id:
+      artifact:
+        description: artifact identifier
         type: string
       classifier:
         type: string
@@ -23,11 +24,13 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      pkg_name:
+      pkg:
+        description: package name
         type: string
       repo_format:
         type: string
-      repo_name:
+      repo:
+        description: repository name
         type: string
       repo_url:
         type: string

--- a/v1/trigger/artifact_trigger/nexus.yaml
+++ b/v1/trigger/artifact_trigger/nexus.yaml
@@ -1,0 +1,36 @@
+title: nexus
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      artifact_id:
+        type: string
+      classifier:
+        type: string
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      extension:
+        type: string
+      group_id:
+        type: string
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      pkg_name:
+        type: string
+      repo_format:
+        type: string
+      repo_name:
+        type: string
+      repo_url:
+        type: string
+      tag:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/nexus_registry.yaml
+++ b/v1/trigger/artifact_trigger/nexus_registry.yaml
@@ -16,8 +16,9 @@ allOf:
         type: string
       group_id:
         type: string
-      image_path:
+      location:
         type: string
+        description: image path and tag, format-> image_path:tag
       conditions:
         $ref: ./conditions.yaml
       pkg:
@@ -25,6 +26,4 @@ allOf:
         type: string
       repo:
         $ref: ./repo.yaml
-      tag:
-        type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/nexus_registry.yaml
+++ b/v1/trigger/artifact_trigger/nexus_registry.yaml
@@ -10,10 +10,6 @@ allOf:
         type: string
       connector:
         type: string
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
       extension:
         type: string
       group:
@@ -22,22 +18,13 @@ allOf:
         type: string
       image_path:
         type: string
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       pkg:
         description: package name
         type: string
       repo:
-        description: repository name
-        type: string
-      repo_format:
-        type: string
-      repo_url:
-        type: string
+        $ref: ./repo.yaml
       tag:
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/nexus_registry.yaml
+++ b/v1/trigger/artifact_trigger/nexus_registry.yaml
@@ -1,0 +1,40 @@
+title: nexus_registry
+allOf:
+  - "$ref": "./artifact_type_spec.yaml"
+  - type: object
+    properties:
+      artifact_id:
+        type: string
+      classifier:
+        type: string
+      connector:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      extension:
+        type: string
+      group:
+        type: string
+      group_id:
+        type: string
+      image_path:
+        type: string
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      pkg_name:
+        type: string
+      repo:
+        type: string
+      repo_format:
+        type: string
+      repo_url:
+        type: string
+      tag:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/artifact_trigger/nexus_registry.yaml
+++ b/v1/trigger/artifact_trigger/nexus_registry.yaml
@@ -23,7 +23,7 @@ allOf:
         type: string
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/artifact_trigger/nexus_registry.yaml
+++ b/v1/trigger/artifact_trigger/nexus_registry.yaml
@@ -3,7 +3,8 @@ allOf:
   - "$ref": "./artifact_type_spec.yaml"
   - type: object
     properties:
-      artifact_id:
+      artifact:
+        description: artifact identifier
         type: string
       classifier:
         type: string
@@ -27,9 +28,11 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      pkg_name:
+      pkg:
+        description: package name
         type: string
       repo:
+        description: repository name
         type: string
       repo_format:
         type: string

--- a/v1/trigger/artifact_trigger/package.yaml
+++ b/v1/trigger/artifact_trigger/package.yaml
@@ -1,0 +1,8 @@
+title: Package details
+properties:
+  name:
+    type: string
+    description: package name
+  type:
+    type: string
+    description: package type

--- a/v1/trigger/artifact_trigger/repo.yaml
+++ b/v1/trigger/artifact_trigger/repo.yaml
@@ -1,0 +1,8 @@
+title: artifact repository details
+properties:
+  name:
+    type: string
+  format:
+    type: string
+  url:
+    type: string

--- a/v1/trigger/manifest_trigger/build_store.yaml
+++ b/v1/trigger/manifest_trigger/build_store.yaml
@@ -1,5 +1,8 @@
 title: build_store
 type: object
+required:
+  - type
+  - spec
 properties:
   type:
     type: string

--- a/v1/trigger/manifest_trigger/build_store.yaml
+++ b/v1/trigger/manifest_trigger/build_store.yaml
@@ -1,0 +1,35 @@
+title: build_store
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - http
+      - s3
+      - gcs
+"$schema": http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: gcs
+    then:
+      properties:
+        spec:
+          "$ref": "./gcs_build_store_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: http
+    then:
+      properties:
+        spec:
+          "$ref": "./http_build_store_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: s3
+    then:
+      properties:
+        spec:
+          "$ref": "./s3_build_store_spec.yaml"

--- a/v1/trigger/manifest_trigger/build_store_spec.yaml
+++ b/v1/trigger/manifest_trigger/build_store_spec.yaml
@@ -1,0 +1,4 @@
+title: build_store_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/manifest_trigger/gcs_build_store_spec.yaml
+++ b/v1/trigger/manifest_trigger/gcs_build_store_spec.yaml
@@ -3,10 +3,9 @@ allOf:
   - "$ref": "./build_store_spec.yaml"
   - type: object
     properties:
-      bucket:
+      location:
+        description: bucket name and path to the manifest folder, format-> bucket_name:folder_path
         type: string
       connector:
-        type: string
-      folder_path:
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/manifest_trigger/gcs_build_store_spec.yaml
+++ b/v1/trigger/manifest_trigger/gcs_build_store_spec.yaml
@@ -1,0 +1,12 @@
+title: gcs_build_store_spec
+allOf:
+  - "$ref": "./build_store_spec.yaml"
+  - type: object
+    properties:
+      bucket:
+        type: string
+      connector:
+        type: string
+      folder_path:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/manifest_trigger/helm_spec.yaml
+++ b/v1/trigger/manifest_trigger/helm_spec.yaml
@@ -4,9 +4,7 @@ allOf:
   - type: object
     properties:
       chart:
-        description: chart name
-        type: string
-      chart_version:
+        description: chart details, format-> chart_name@version
         type: string
       event_conditions:
         type: array

--- a/v1/trigger/manifest_trigger/helm_spec.yaml
+++ b/v1/trigger/manifest_trigger/helm_spec.yaml
@@ -3,7 +3,8 @@ allOf:
   - "$ref": "./manifest_spec.yaml"
   - type: object
     properties:
-      chart_name:
+      chart:
+        description: chart name
         type: string
       chart_version:
         type: string

--- a/v1/trigger/manifest_trigger/helm_spec.yaml
+++ b/v1/trigger/manifest_trigger/helm_spec.yaml
@@ -1,0 +1,22 @@
+title: helm_spec
+allOf:
+  - "$ref": "./manifest_spec.yaml"
+  - type: object
+    properties:
+      chart_name:
+        type: string
+      chart_version:
+        type: string
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      helm_version:
+        type: string
+        enum:
+          - v2
+          - v3
+          - v380
+      store:
+        "$ref": "./build_store.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/manifest_trigger/http_build_store_spec.yaml
+++ b/v1/trigger/manifest_trigger/http_build_store_spec.yaml
@@ -1,0 +1,8 @@
+title: http_build_store_spec
+allOf:
+  - "$ref": "./build_store_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/manifest_trigger/manifest_spec.yaml
+++ b/v1/trigger/manifest_trigger/manifest_spec.yaml
@@ -1,0 +1,4 @@
+title: manifest_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/manifest_trigger/s3_build_store_spec.yaml
+++ b/v1/trigger/manifest_trigger/s3_build_store_spec.yaml
@@ -3,11 +3,9 @@ allOf:
   - "$ref": "./build_store_spec.yaml"
   - type: object
     properties:
-      bucket:
-        type: string
+      location:
+        description: bucket name and path to the manifest folder, format-> bucket_name:folder_path
       connector:
-        type: string
-      folder_path:
         type: string
       region:
         type: string

--- a/v1/trigger/manifest_trigger/s3_build_store_spec.yaml
+++ b/v1/trigger/manifest_trigger/s3_build_store_spec.yaml
@@ -1,0 +1,14 @@
+title: s3_build_store_spec
+allOf:
+  - "$ref": "./build_store_spec.yaml"
+  - type: object
+    properties:
+      bucket:
+        type: string
+      connector:
+        type: string
+      folder_path:
+        type: string
+      region:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/multi_region_artifact/artifact_type_spec_wrapper.yaml
+++ b/v1/trigger/multi_region_artifact/artifact_type_spec_wrapper.yaml
@@ -1,6 +1,9 @@
 title: artifact_type_spec_wrapper
 type: object
 properties: {}
+required:
+  - type
+  - spec
 "$schema": http://json-schema.org/draft-07/schema#
 allOf:
   - if:

--- a/v1/trigger/multi_region_artifact/artifact_type_spec_wrapper.yaml
+++ b/v1/trigger/multi_region_artifact/artifact_type_spec_wrapper.yaml
@@ -41,7 +41,7 @@ allOf:
   - if:
       properties:
         type:
-          const: azure-artifacts
+          const: azure
     then:
       properties:
         spec:
@@ -57,7 +57,7 @@ allOf:
   - if:
       properties:
         type:
-          const: custom-artifact
+          const: custom
     then:
       properties:
         spec:

--- a/v1/trigger/multi_region_artifact/artifact_type_spec_wrapper.yaml
+++ b/v1/trigger/multi_region_artifact/artifact_type_spec_wrapper.yaml
@@ -1,0 +1,133 @@
+title: artifact_type_spec_wrapper
+type: object
+properties: {}
+"$schema": http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: acr
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/acr_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: amazon-machine-image
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/ami_registry_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: amazon-s3
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/amazon_s3_registry.yaml"
+  - if:
+      properties:
+        type:
+          const: artifactory-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/artifactory_registry.yaml"
+  - if:
+      properties:
+        type:
+          const: azure-artifacts
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/azure_artifact.yaml"
+  - if:
+      properties:
+        type:
+          const: bamboo
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/bamboo.yaml"
+  - if:
+      properties:
+        type:
+          const: custom-artifact
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/custom_artifact.yaml"
+  - if:
+      properties:
+        type:
+          const: docker-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/docker_registry.yaml"
+  - if:
+      properties:
+        type:
+          const: ecr
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/ecr.yaml"
+  - if:
+      properties:
+        type:
+          const: gcr
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/gcr.yaml"
+  - if:
+      properties:
+        type:
+          const: github-package-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/github_packages.yaml"
+  - if:
+      properties:
+        type:
+          const: google-artifact-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/gar_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: google-cloud-storage
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/google_cloud.yaml"
+  - if:
+      properties:
+        type:
+          const: jenkins
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/jenkins_registry.yaml"
+  - if:
+      properties:
+        type:
+          const: nexus2-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/nexus.yaml"
+  - if:
+      properties:
+        type:
+          const: nexus3-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/nexus_registry.yaml"

--- a/v1/trigger/scheduled_trigger/cron_trigger_spec.yaml
+++ b/v1/trigger/scheduled_trigger/cron_trigger_spec.yaml
@@ -2,6 +2,9 @@ title: cron_trigger_spec
 allOf:
   - "$ref": "./scheduled_trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - expression
     properties:
       expression:
         type: string

--- a/v1/trigger/scheduled_trigger/cron_trigger_spec.yaml
+++ b/v1/trigger/scheduled_trigger/cron_trigger_spec.yaml
@@ -1,0 +1,10 @@
+title: cron_trigger_spec
+allOf:
+  - "$ref": "./scheduled_trigger_spec.yaml"
+  - type: object
+    properties:
+      expression:
+        type: string
+      type:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/scheduled_trigger/scheduled_trigger_spec.yaml
+++ b/v1/trigger/scheduled_trigger/scheduled_trigger_spec.yaml
@@ -1,0 +1,4 @@
+title: scheduled_trigger_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_event_data.yaml
+++ b/v1/trigger/trigger_event_data.yaml
@@ -1,0 +1,20 @@
+title: trigger_event_data
+type: object
+properties:
+  key:
+    type: string
+  operator:
+    type: string
+    enum:
+      - in
+      - equals
+      - not-equals
+      - not-in
+      - regex
+      - ends-with
+      - starts-with
+      - contains
+      - doesN-not-contain
+  value:
+    type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_event_data.yaml
+++ b/v1/trigger/trigger_event_data.yaml
@@ -14,7 +14,7 @@ properties:
       - ends-with
       - starts-with
       - contains
-      - doesN-not-contain
+      - does-not-contain
   value:
     type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_root.yaml
+++ b/v1/trigger/trigger_root.yaml
@@ -15,17 +15,6 @@ properties:
     type: string
     enum:
       - trigger
-  input_set_refs:
-    type: array
-    items:
-      type: string
-  inputs:
-    description: input yaml for the pipeline
-    type: string
   spec:
     "$ref": "./trigger_source.yaml"
-  stages_to_execute:
-    type: array
-    items:
-      type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_root.yaml
+++ b/v1/trigger/trigger_root.yaml
@@ -19,7 +19,8 @@ properties:
     type: array
     items:
       type: string
-  input_yaml:
+  inputs:
+    description: input yaml for the pipeline
     type: string
   spec:
     "$ref": "./trigger_source.yaml"

--- a/v1/trigger/trigger_root.yaml
+++ b/v1/trigger/trigger_root.yaml
@@ -1,0 +1,30 @@
+type: object
+title: trigger
+required:
+  - spec
+  - version
+  - kind
+properties:
+  version:
+    description: Version defines the schema version.
+    type: number
+    enum:
+      - 1
+  kind:
+    description: defines the kind of yaml (pipeline/template/trigger)
+    type: string
+    enum:
+      - trigger
+  input_set_refs:
+    type: array
+    items:
+      type: string
+  input_yaml:
+    type: string
+  spec:
+    "$ref": "./trigger_source.yaml"
+  stages_to_execute:
+    type: array
+    items:
+      type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_source.yaml
+++ b/v1/trigger/trigger_source.yaml
@@ -1,0 +1,58 @@
+title: trigger_source
+type: object
+properties:
+  poll_interval:
+    type: string
+    pattern: "(((([1-9])+\\d*[mh])+(\\s/?\\d+[mh])*)|(^$)|(0))$"
+  type:
+    type: string
+    enum:
+      - webhook
+      - artifact
+      - manifest
+      - scheduled
+      - multi-region-artifact
+  webhook_id:
+    type: string
+"$schema": http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: artifact
+    then:
+      properties:
+        spec:
+          "$ref": "./trigger_type/artifact_trigger.yaml"
+  - if:
+      properties:
+        type:
+          const: manifest
+    then:
+      properties:
+        spec:
+          "$ref": "./trigger_type/manifest_trigger.yaml"
+  - if:
+      properties:
+        type:
+          const: multi-region-artifact
+    then:
+      properties:
+        spec:
+          "$ref": "./trigger_type/multi_region_trigger.yaml"
+  - if:
+      properties:
+        type:
+          const: scheduled
+    then:
+      properties:
+        spec:
+          "$ref": "./trigger_type/scheduled_trigger.yaml"
+  - if:
+      properties:
+        type:
+          const: webhook
+    then:
+      properties:
+        spec:
+          "$ref": "./trigger_type/webhook_trigger.yaml"

--- a/v1/trigger/trigger_source.yaml
+++ b/v1/trigger/trigger_source.yaml
@@ -4,7 +4,8 @@ required:
   - type
   - spec
 properties:
-  poll_interval:
+  interval:
+    description: polling interval
     type: string
     pattern: "(((([1-9])+\\d*[mh])+(\\s/?\\d+[mh])*)|(^$)|(0))$"
   type:
@@ -15,7 +16,8 @@ properties:
       - manifest
       - scheduled
       - multi-region-artifact
-  webhook_id:
+  webhook:
+    description: webhook identifier
     type: string
 "$schema": http://json-schema.org/draft-07/schema#
 allOf:

--- a/v1/trigger/trigger_source.yaml
+++ b/v1/trigger/trigger_source.yaml
@@ -1,5 +1,8 @@
 title: trigger_source
 type: object
+required:
+  - type
+  - spec
 properties:
   poll_interval:
     type: string

--- a/v1/trigger/trigger_source.yaml
+++ b/v1/trigger/trigger_source.yaml
@@ -4,6 +4,18 @@ required:
   - type
   - spec
 properties:
+  input_set_refs:
+    type: array
+    items:
+      type: string
+  inputs:
+    description: input yaml for the pipeline
+    type: string
+  execute_stages:
+    description: stage identifiers of the stages to be executed in the pipeline
+    type: array
+    items:
+      type: string
   interval:
     description: polling interval
     type: string

--- a/v1/trigger/trigger_spec.yaml
+++ b/v1/trigger/trigger_spec.yaml
@@ -1,0 +1,4 @@
+title: trigger_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_type/artifact_trigger.yaml
+++ b/v1/trigger/trigger_type/artifact_trigger.yaml
@@ -18,10 +18,10 @@ allOf:
           - acr
           - amazon-s3
           - jenkins
-          - custom-artifact
+          - custom
           - google-artifact-registry
           - github-package-registry
-          - azure-artifacts
+          - azure
           - amazon-machine-image
           - google-cloud-storage
           - bamboo
@@ -60,7 +60,7 @@ allOf:
   - if:
       properties:
         type:
-          const: azure-artifacts
+          const: azure
     then:
       properties:
         spec:
@@ -76,7 +76,7 @@ allOf:
   - if:
       properties:
         type:
-          const: custom-artifact
+          const: custom
     then:
       properties:
         spec:

--- a/v1/trigger/trigger_type/artifact_trigger.yaml
+++ b/v1/trigger/trigger_type/artifact_trigger.yaml
@@ -1,0 +1,153 @@
+title: artifact_trigger
+allOf:
+  - "$ref": "../trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - gcr
+          - ecr
+          - docker-registry
+          - nexus3-registry
+          - nexus2-registry
+          - artifactory-registry
+          - acr
+          - amazon-s3
+          - jenkins
+          - custom-artifact
+          - google-artifact-registry
+          - github-package-registry
+          - azure-artifacts
+          - amazon-machine-image
+          - google-cloud-storage
+          - bamboo
+  - if:
+      properties:
+        type:
+          const: acr
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/acr_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: amazon-machine-image
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/ami_registry_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: amazon-s3
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/amazon_s3_registry.yaml"
+  - if:
+      properties:
+        type:
+          const: artifactory-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/artifactory_registry.yaml"
+  - if:
+      properties:
+        type:
+          const: azure-artifacts
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/azure_artifact.yaml"
+  - if:
+      properties:
+        type:
+          const: bamboo
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/bamboo.yaml"
+  - if:
+      properties:
+        type:
+          const: custom-artifact
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/custom_artifact.yaml"
+  - if:
+      properties:
+        type:
+          const: docker-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/docker_registry.yaml"
+  - if:
+      properties:
+        type:
+          const: ecr
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/ecr.yaml"
+  - if:
+      properties:
+        type:
+          const: gcr
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/gcr.yaml"
+  - if:
+      properties:
+        type:
+          const: github-package-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/github_packages.yaml"
+  - if:
+      properties:
+        type:
+          const: google-artifact-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/gar_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: google-cloud-storage
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/google_cloud.yaml"
+  - if:
+      properties:
+        type:
+          const: jenkins
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/jenkins_registry.yaml"
+  - if:
+      properties:
+        type:
+          const: nexus2-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/nexus.yaml"
+  - if:
+      properties:
+        type:
+          const: nexus3-registry
+    then:
+      properties:
+        spec:
+          "$ref": "../artifact_trigger/nexus_registry.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_type/artifact_trigger.yaml
+++ b/v1/trigger/trigger_type/artifact_trigger.yaml
@@ -2,6 +2,9 @@ title: artifact_trigger
 allOf:
   - "$ref": "../trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/trigger_type/manifest_trigger.yaml
+++ b/v1/trigger/trigger_type/manifest_trigger.yaml
@@ -1,0 +1,18 @@
+title: manifest_trigger
+allOf:
+  - "$ref": "../trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - helm-chart
+  - if:
+      properties:
+        type:
+          const: helm-chart
+    then:
+      properties:
+        spec:
+          "$ref": "../manifest_trigger/helm_spec.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_type/manifest_trigger.yaml
+++ b/v1/trigger/trigger_type/manifest_trigger.yaml
@@ -2,6 +2,9 @@ title: manifest_trigger
 allOf:
   - "$ref": "../trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/trigger_type/multi_region_trigger.yaml
+++ b/v1/trigger/trigger_type/multi_region_trigger.yaml
@@ -1,0 +1,39 @@
+title: multi_region_trigger
+allOf:
+  - "$ref": "../trigger_spec.yaml"
+  - type: object
+    properties:
+      event_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      meta_data_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      sources:
+        type: array
+        items:
+          "$ref": "../multi_region_artifact/artifact_type_spec_wrapper.yaml"
+      type:
+        type: string
+        enum:
+          - gcr
+          - ecr
+          - docker-registry
+          - nexus3-registry
+          - nexus2-registry
+          - artifactory-registry
+          - acr
+          - amazon-s3
+          - jenkins
+          - custom-artifact
+          - google-artifact-registry
+          - github-package-registry
+          - azure-artifacts
+          - amazon-machine-image
+          - google-cloud-storage
+          - bamboo
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_type/multi_region_trigger.yaml
+++ b/v1/trigger/trigger_type/multi_region_trigger.yaml
@@ -6,16 +6,8 @@ allOf:
       - type
       - sources
     properties:
-      event_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      metadata_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ../artifact_trigger/conditions.yaml
       sources:
         type: array
         items:

--- a/v1/trigger/trigger_type/multi_region_trigger.yaml
+++ b/v1/trigger/trigger_type/multi_region_trigger.yaml
@@ -12,7 +12,7 @@ allOf:
           "$ref": "../trigger_event_data.yaml"
       jexl_condition:
         type: string
-      meta_data_conditions:
+      metadata_conditions:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
@@ -32,10 +32,10 @@ allOf:
           - acr
           - amazon-s3
           - jenkins
-          - custom-artifact
+          - custom
           - google-artifact-registry
           - github-package-registry
-          - azure-artifacts
+          - azure
           - amazon-machine-image
           - google-cloud-storage
           - bamboo

--- a/v1/trigger/trigger_type/multi_region_trigger.yaml
+++ b/v1/trigger/trigger_type/multi_region_trigger.yaml
@@ -2,6 +2,9 @@ title: multi_region_trigger
 allOf:
   - "$ref": "../trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - sources
     properties:
       event_conditions:
         type: array

--- a/v1/trigger/trigger_type/scheduled_trigger.yaml
+++ b/v1/trigger/trigger_type/scheduled_trigger.yaml
@@ -2,6 +2,9 @@ title: scheduled_trigger
 allOf:
   - "$ref": "../trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/trigger_type/scheduled_trigger.yaml
+++ b/v1/trigger/trigger_type/scheduled_trigger.yaml
@@ -1,0 +1,16 @@
+title: scheduled_trigger
+allOf:
+  - "$ref": "../trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+  - if:
+      properties:
+        type:
+          const: cron
+    then:
+      properties:
+        spec:
+          "$ref": "../scheduled_trigger/cron_trigger_spec.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/trigger_type/webhook_trigger.yaml
+++ b/v1/trigger/trigger_type/webhook_trigger.yaml
@@ -2,6 +2,9 @@ title: webhook_trigger
 allOf:
   - "$ref": "../trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/trigger_type/webhook_trigger.yaml
+++ b/v1/trigger/trigger_type/webhook_trigger.yaml
@@ -1,0 +1,72 @@
+title: webhook_trigger
+allOf:
+  - "$ref": "../trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - azure-repo
+          - github
+          - gitlab
+          - bitbucket
+          - custom
+          - aws-code-commit
+          - harness
+  - if:
+      properties:
+        type:
+          const: aws-code-commit
+    then:
+      properties:
+        spec:
+          "$ref": "../webhook_trigger/aws_commit_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: azure-repo
+    then:
+      properties:
+        spec:
+          "$ref": "../webhook_trigger/azure_repo_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: bitbucket
+    then:
+      properties:
+        spec:
+          "$ref": "../webhook_trigger/bitbucket_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: custom
+    then:
+      properties:
+        spec:
+          "$ref": "../webhook_trigger/custom_trigger_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: github
+    then:
+      properties:
+        spec:
+          "$ref": "../webhook_trigger/github_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: gitlab
+    then:
+      properties:
+        spec:
+          "$ref": "../webhook_trigger/gitlab_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: harness
+    then:
+      properties:
+        spec:
+          "$ref": "../webhook_trigger/harness_spec.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/aws_commit_event_spec.yaml
+++ b/v1/trigger/webhook_trigger/aws_commit_event_spec.yaml
@@ -1,0 +1,4 @@
+title: aws_commit_event_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/aws_commit_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/aws_commit_push_spec.yaml
@@ -7,12 +7,13 @@ allOf:
     properties:
       connector:
         type: string
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        jexl:
+          type: string
+        payload:
+          type: array
+          items:
+            "$ref": "../trigger_event_data.yaml"
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/aws_commit_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/aws_commit_push_spec.yaml
@@ -2,6 +2,8 @@ title: aws_commit_push_spec
 allOf:
   - "$ref": "./aws_commit_event_spec.yaml"
   - type: object
+    required:
+      - connector
     properties:
       connector:
         type: string

--- a/v1/trigger/webhook_trigger/aws_commit_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/aws_commit_push_spec.yaml
@@ -1,0 +1,16 @@
+title: aws_commit_push_spec
+allOf:
+  - "$ref": "./aws_commit_event_spec.yaml"
+  - type: object
+    properties:
+      connector:
+        type: string
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/aws_commit_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/aws_commit_push_spec.yaml
@@ -13,6 +13,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/aws_commit_spec.yaml
+++ b/v1/trigger/webhook_trigger/aws_commit_spec.yaml
@@ -1,0 +1,18 @@
+title: aws_commit_spec
+allOf:
+  - "$ref": "./webhook_trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - push
+  - if:
+      properties:
+        type:
+          const: push
+    then:
+      properties:
+        spec:
+          "$ref": "./aws_commit_push_spec.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/aws_commit_spec.yaml
+++ b/v1/trigger/webhook_trigger/aws_commit_spec.yaml
@@ -2,6 +2,9 @@ title: aws_commit_spec
 allOf:
   - "$ref": "./webhook_trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
@@ -1,0 +1,30 @@
+title: azure_issue_comment_spec
+allOf:
+  - "$ref": "./azure_repo_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - create
+            - edit
+            - delete
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
@@ -2,6 +2,8 @@ title: azure_issue_comment_spec
 allOf:
   - "$ref": "./azure_repo_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
@@ -28,6 +28,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
@@ -4,6 +4,7 @@ allOf:
   - type: object
     required:
       - actions
+      - connector
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_issue_comment_spec.yaml
@@ -14,20 +14,12 @@ allOf:
             - create
             - edit
             - delete
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/azure_repo_event_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_event_spec.yaml
@@ -1,0 +1,4 @@
+title: azure_repo_event_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
@@ -2,6 +2,8 @@ title: azure_repo_pr_spec
 allOf:
   - "$ref": "./azure_repo_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
@@ -28,6 +28,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
@@ -1,5 +1,5 @@
 title: azure_repo_pr_spec
-kallOf:
+allOf:
   - "$ref": "./azure_repo_event_spec.yaml"
   - type: object
     properties:

--- a/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
@@ -4,6 +4,7 @@ allOf:
   - type: object
     required:
       - actions
+      - connector
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
@@ -1,0 +1,30 @@
+title: azure_repo_pr_spec
+kallOf:
+  - "$ref": "./azure_repo_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - create
+            - update
+            - merge
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_pr_spec.yaml
@@ -14,20 +14,13 @@ allOf:
             - create
             - update
             - merge
-      auto_abort_previous_executions:
+      abort_previous:
+        description: abort previous executions
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/azure_repo_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_push_spec.yaml
@@ -2,6 +2,8 @@ title: azure_repo_push_spec
 allOf:
   - "$ref": "./azure_repo_event_spec.yaml"
   - type: object
+    required:
+      - connector
     properties:
       auto_abort_previous_executions:
         type: boolean

--- a/v1/trigger/webhook_trigger/azure_repo_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_push_spec.yaml
@@ -5,20 +5,12 @@ allOf:
     required:
       - connector
     properties:
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/azure_repo_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_push_spec.yaml
@@ -1,0 +1,22 @@
+title: azure_repo_push_spec
+allOf:
+  - "$ref": "./azure_repo_event_spec.yaml"
+  - type: object
+    properties:
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/azure_repo_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_push_spec.yaml
@@ -19,6 +19,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/azure_repo_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_spec.yaml
@@ -1,0 +1,36 @@
+title: azure_repo_spec
+allOf:
+  - "$ref": "./webhook_trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - pull-request
+          - push
+          - issue-comment
+  - if:
+      properties:
+        type:
+          const: issue-comment
+    then:
+      properties:
+        spec:
+          "$ref": "./azure_issue_comment_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: pull-request
+    then:
+      properties:
+        spec:
+          "$ref": "./azure_repo_pr_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: push
+    then:
+      properties:
+        spec:
+          "$ref": "./azure_repo_push_spec.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/azure_repo_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_spec.yaml
@@ -2,6 +2,9 @@ title: azure_repo_spec
 allOf:
   - "$ref": "./webhook_trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/webhook_trigger/azure_repo_spec.yaml
+++ b/v1/trigger/webhook_trigger/azure_repo_spec.yaml
@@ -9,7 +9,7 @@ allOf:
       type:
         type: string
         enum:
-          - pull-request
+          - pr
           - push
           - issue-comment
   - if:
@@ -23,7 +23,7 @@ allOf:
   - if:
       properties:
         type:
-          const: pull-request
+          const: pr
     then:
       properties:
         spec:

--- a/v1/trigger/webhook_trigger/bitbucket_event_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_event_spec.yaml
@@ -1,0 +1,4 @@
+title: bitbucket_event_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
@@ -1,0 +1,30 @@
+title: bitbucket_pr_comment_spec
+allOf:
+  - "$ref": "./bitbucket_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - create
+            - edit
+            - delete
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
@@ -28,6 +28,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
@@ -4,6 +4,7 @@ allOf:
   - type: object
     required:
       - actions
+      - connector
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
@@ -14,20 +14,12 @@ allOf:
             - create
             - edit
             - delete
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_comment_spec.yaml
@@ -2,6 +2,8 @@ title: bitbucket_pr_comment_spec
 allOf:
   - "$ref": "./bitbucket_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
@@ -2,6 +2,8 @@ title: bitbucket_pr_spec
 allOf:
   - "$ref": "./bitbucket_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
@@ -15,20 +15,12 @@ allOf:
             - update
             - merge
             - decline
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
@@ -29,6 +29,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
@@ -4,6 +4,7 @@ allOf:
   - type: object
     required:
       - actions
+      - connector
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_pr_spec.yaml
@@ -1,0 +1,31 @@
+title: bitbucket_pr_spec
+allOf:
+  - "$ref": "./bitbucket_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - create
+            - update
+            - merge
+            - decline
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/bitbucket_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_push_spec.yaml
@@ -5,20 +5,12 @@ allOf:
     required:
       - connector
     properties:
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/bitbucket_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_push_spec.yaml
@@ -2,6 +2,8 @@ title: bitbucket_push_spec
 allOf:
   - "$ref": "./bitbucket_event_spec.yaml"
   - type: object
+    required:
+      - connector
     properties:
       auto_abort_previous_executions:
         type: boolean

--- a/v1/trigger/webhook_trigger/bitbucket_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_push_spec.yaml
@@ -19,6 +19,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/bitbucket_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_push_spec.yaml
@@ -1,0 +1,22 @@
+title: bitbucket_push_spec
+allOf:
+  - "$ref": "./bitbucket_event_spec.yaml"
+  - type: object
+    properties:
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/bitbucket_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_spec.yaml
@@ -2,6 +2,9 @@ title: bitbucket_spec
 allOf:
   - "$ref": "./webhook_trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/webhook_trigger/bitbucket_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_spec.yaml
@@ -1,0 +1,36 @@
+title: bitbucket_spec
+allOf:
+  - "$ref": "./webhook_trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - pull-request
+          - push
+          - pr-comment
+  - if:
+      properties:
+        type:
+          const: pr-comment
+    then:
+      properties:
+        spec:
+          "$ref": "./bitbucket_pr_comment_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: pull-request
+    then:
+      properties:
+        spec:
+          "$ref": "./bitbucket_pr_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: push
+    then:
+      properties:
+        spec:
+          "$ref": "./bitbucket_push_spec.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/bitbucket_spec.yaml
+++ b/v1/trigger/webhook_trigger/bitbucket_spec.yaml
@@ -9,7 +9,7 @@ allOf:
       type:
         type: string
         enum:
-          - pull-request
+          - pr
           - push
           - pr-comment
   - if:
@@ -23,7 +23,7 @@ allOf:
   - if:
       properties:
         type:
-          const: pull-request
+          const: pr
     then:
       properties:
         spec:

--- a/v1/trigger/webhook_trigger/conditions.yaml
+++ b/v1/trigger/webhook_trigger/conditions.yaml
@@ -1,0 +1,13 @@
+title: conditions
+description: conditions for webhook trigger
+properties:
+  header:
+    type: array
+    items:
+      "$ref": "../trigger_event_data.yaml"
+  jexl:
+    type: string
+  payload:
+    type: array
+    items:
+      "$ref": "../trigger_event_data.yaml"

--- a/v1/trigger/webhook_trigger/custom_trigger_spec.yaml
+++ b/v1/trigger/webhook_trigger/custom_trigger_spec.yaml
@@ -3,14 +3,6 @@ allOf:
   - "$ref": "./webhook_trigger_spec.yaml"
   - type: object
     properties:
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/custom_trigger_spec.yaml
+++ b/v1/trigger/webhook_trigger/custom_trigger_spec.yaml
@@ -1,0 +1,16 @@
+title: custom_trigger_spec
+allOf:
+  - "$ref": "./webhook_trigger_spec.yaml"
+  - type: object
+    properties:
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_event_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_event_spec.yaml
@@ -1,0 +1,4 @@
+title: github_event_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
@@ -1,0 +1,30 @@
+title: github_issue_comment_spec
+allOf:
+  - "$ref": "./github_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - create
+            - edit
+            - delete
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
@@ -28,6 +28,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
@@ -4,6 +4,7 @@ allOf:
   - type: object
     required:
       - actions
+      - connector
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
@@ -14,20 +14,12 @@ allOf:
             - create
             - edit
             - delete
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_issue_comment_spec.yaml
@@ -2,6 +2,8 @@ title: github_issue_comment_spec
 allOf:
   - "$ref": "./github_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/github_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_pr_spec.yaml
@@ -19,20 +19,12 @@ allOf:
             - unlabel
             - synchronize
             - ready-for-review
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/github_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_pr_spec.yaml
@@ -33,6 +33,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_pr_spec.yaml
@@ -1,0 +1,35 @@
+title: github_pr_spec
+allOf:
+  - "$ref": "./github_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - close
+            - edit
+            - open
+            - reopen
+            - label
+            - unlabel
+            - synchronize
+            - ready-for-review
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_pr_spec.yaml
@@ -4,6 +4,7 @@ allOf:
   - type: object
     required:
       - actions
+      - connector
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/github_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_pr_spec.yaml
@@ -17,7 +17,7 @@ allOf:
             - reopen
             - label
             - unlabel
-            - synchronize
+            - sync
             - ready-for-review
       abort_previous:
         type: boolean

--- a/v1/trigger/webhook_trigger/github_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_pr_spec.yaml
@@ -2,6 +2,8 @@ title: github_pr_spec
 allOf:
   - "$ref": "./github_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/github_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_push_spec.yaml
@@ -1,0 +1,22 @@
+title: github_push_spec
+allOf:
+  - "$ref": "./github_event_spec.yaml"
+  - type: object
+    properties:
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_push_spec.yaml
@@ -5,20 +5,12 @@ allOf:
     required:
       - connector
     properties:
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/github_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_push_spec.yaml
@@ -2,6 +2,8 @@ title: github_push_spec
 allOf:
   - "$ref": "./github_event_spec.yaml"
   - type: object
+    required:
+      - connector
     properties:
       auto_abort_previous_executions:
         type: boolean

--- a/v1/trigger/webhook_trigger/github_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_push_spec.yaml
@@ -19,6 +19,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_release_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_release_spec.yaml
@@ -2,6 +2,8 @@ title: github_release_spec
 allOf:
   - "$ref": "./github_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/github_release_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_release_spec.yaml
@@ -14,7 +14,7 @@ allOf:
             - create
             - edit
             - delete
-            - prerelease
+            - pre-release
             - publish
             - release
             - unpublish

--- a/v1/trigger/webhook_trigger/github_release_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_release_spec.yaml
@@ -32,6 +32,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_release_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_release_spec.yaml
@@ -1,0 +1,34 @@
+title: github_release_spec
+allOf:
+  - "$ref": "./github_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - create
+            - edit
+            - delete
+            - prerelease
+            - publish
+            - release
+            - unpublish
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/github_release_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_release_spec.yaml
@@ -4,6 +4,7 @@ allOf:
   - type: object
     required:
       - actions
+      - connector
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/github_release_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_release_spec.yaml
@@ -18,20 +18,12 @@ allOf:
             - publish
             - release
             - unpublish
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/github_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_spec.yaml
@@ -2,6 +2,9 @@ title: github_spec
 allOf:
   - "$ref": "./webhook_trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/webhook_trigger/github_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_spec.yaml
@@ -9,7 +9,7 @@ allOf:
       type:
         type: string
         enum:
-          - pull-request
+          - pr
           - push
           - issue-comment
           - release
@@ -24,7 +24,7 @@ allOf:
   - if:
       properties:
         type:
-          const: pull-request
+          const: pr
     then:
       properties:
         spec:

--- a/v1/trigger/webhook_trigger/github_spec.yaml
+++ b/v1/trigger/webhook_trigger/github_spec.yaml
@@ -1,0 +1,45 @@
+title: github_spec
+allOf:
+  - "$ref": "./webhook_trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - pull-request
+          - push
+          - issue-comment
+          - release
+  - if:
+      properties:
+        type:
+          const: issue-comment
+    then:
+      properties:
+        spec:
+          "$ref": "./github_issue_comment_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: pull-request
+    then:
+      properties:
+        spec:
+          "$ref": "./github_pr_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: push
+    then:
+      properties:
+        spec:
+          "$ref": "./github_push_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: release
+    then:
+      properties:
+        spec:
+          "$ref": "./github_release_spec.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/gitlab_event_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_event_spec.yaml
@@ -1,0 +1,4 @@
+title: gitlab_event_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
@@ -12,20 +12,12 @@ allOf:
           type: string
           enum:
             - create
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
@@ -2,6 +2,8 @@ title: gitlab_mr_comment_spec
 allOf:
   - "$ref": "./gitlab_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
@@ -26,6 +26,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
@@ -4,6 +4,7 @@ allOf:
   - type: object
     required:
       - actions
+      - connector
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_mr_comment_spec.yaml
@@ -1,0 +1,28 @@
+title: gitlab_mr_comment_spec
+allOf:
+  - "$ref": "./gitlab_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - create
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
@@ -31,6 +31,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
@@ -17,20 +17,12 @@ allOf:
             - merge
             - update
             - sync
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
@@ -2,6 +2,8 @@ title: gitlab_pr_spec
 allOf:
   - "$ref": "./gitlab_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
@@ -1,0 +1,33 @@
+title: gitlab_pr_spec
+allOf:
+  - "$ref": "./gitlab_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - open
+            - close
+            - reopen
+            - merge
+            - update
+            - sync
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_pr_spec.yaml
@@ -4,6 +4,7 @@ allOf:
   - type: object
     required:
       - actions
+      - connector
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/gitlab_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_push_spec.yaml
@@ -1,0 +1,22 @@
+title: gitlab_push_spec
+allOf:
+  - "$ref": "./gitlab_event_spec.yaml"
+  - type: object
+    properties:
+      auto_abort_previous_executions:
+        type: boolean
+      connector:
+        type: string
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/gitlab_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_push_spec.yaml
@@ -5,20 +5,12 @@ allOf:
     required:
       - connector
     properties:
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
       connector:
         type: string
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/gitlab_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_push_spec.yaml
@@ -2,6 +2,8 @@ title: gitlab_push_spec
 allOf:
   - "$ref": "./gitlab_event_spec.yaml"
   - type: object
+    required:
+      - connector
     properties:
       auto_abort_previous_executions:
         type: boolean

--- a/v1/trigger/webhook_trigger/gitlab_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_push_spec.yaml
@@ -19,6 +19,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/gitlab_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_spec.yaml
@@ -2,6 +2,9 @@ title: gitlab_spec
 allOf:
   - "$ref": "./webhook_trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/webhook_trigger/gitlab_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_spec.yaml
@@ -9,7 +9,7 @@ allOf:
       type:
         type: string
         enum:
-          - merge-request
+          - mr
           - push
           - mr-comment
   - if:
@@ -23,7 +23,7 @@ allOf:
   - if:
       properties:
         type:
-          const: merge-request
+          const: mr
     then:
       properties:
         spec:

--- a/v1/trigger/webhook_trigger/gitlab_spec.yaml
+++ b/v1/trigger/webhook_trigger/gitlab_spec.yaml
@@ -1,0 +1,36 @@
+title: gitlab_spec
+allOf:
+  - "$ref": "./webhook_trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - merge-request
+          - push
+          - mr-comment
+  - if:
+      properties:
+        type:
+          const: mr-comment
+    then:
+      properties:
+        spec:
+          "$ref": "./gitlab_mr_comment_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: merge-request
+    then:
+      properties:
+        spec:
+          "$ref": "./gitlab_pr_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: push
+    then:
+      properties:
+        spec:
+          "$ref": "./gitlab_push_spec.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/harness_event_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_event_spec.yaml
@@ -1,0 +1,4 @@
+title: harness_event_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/harness_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_issue_comment_spec.yaml
@@ -1,0 +1,28 @@
+title: harness_issue_comment_spec
+allOf:
+  - "$ref": "./harness_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - create
+            - edit
+            - delete
+      auto_abort_previous_executions:
+        type: boolean
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/harness_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_issue_comment_spec.yaml
@@ -13,18 +13,10 @@ allOf:
             - create
             - edit
             - delete
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/harness_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_issue_comment_spec.yaml
@@ -2,6 +2,8 @@ title: harness_issue_comment_spec
 allOf:
   - "$ref": "./harness_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/harness_issue_comment_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_issue_comment_spec.yaml
@@ -25,6 +25,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/harness_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_pr_spec.yaml
@@ -17,18 +17,10 @@ allOf:
             - label
             - unlabel
             - synchronize
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/harness_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_pr_spec.yaml
@@ -1,0 +1,32 @@
+title: harness_pr_spec
+allOf:
+  - "$ref": "./harness_event_spec.yaml"
+  - type: object
+    properties:
+      actions:
+        type: array
+        items:
+          type: string
+          enum:
+            - close
+            - edit
+            - open
+            - reopen
+            - label
+            - unlabel
+            - synchronize
+      auto_abort_previous_executions:
+        type: boolean
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/harness_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_pr_spec.yaml
@@ -29,6 +29,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/harness_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_pr_spec.yaml
@@ -16,7 +16,7 @@ allOf:
             - reopen
             - label
             - unlabel
-            - synchronize
+            - sync
       abort_previous:
         type: boolean
       conditions:

--- a/v1/trigger/webhook_trigger/harness_pr_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_pr_spec.yaml
@@ -2,6 +2,8 @@ title: harness_pr_spec
 allOf:
   - "$ref": "./harness_event_spec.yaml"
   - type: object
+    required:
+      - actions
     properties:
       actions:
         type: array

--- a/v1/trigger/webhook_trigger/harness_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_push_spec.yaml
@@ -3,18 +3,10 @@ allOf:
   - "$ref": "./harness_event_spec.yaml"
   - type: object
     properties:
-      auto_abort_previous_executions:
+      abort_previous:
         type: boolean
-      header_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
-      jexl_condition:
-        type: string
-      payload_conditions:
-        type: array
-        items:
-          "$ref": "../trigger_event_data.yaml"
+      conditions:
+        $ref: ./conditions.yaml
       repo:
         description: repository name
         type: string

--- a/v1/trigger/webhook_trigger/harness_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_push_spec.yaml
@@ -15,6 +15,7 @@ allOf:
         type: array
         items:
           "$ref": "../trigger_event_data.yaml"
-      repo_name:
+      repo:
+        description: repository name
         type: string
 "$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/harness_push_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_push_spec.yaml
@@ -1,0 +1,20 @@
+title: harness_push_spec
+allOf:
+  - "$ref": "./harness_event_spec.yaml"
+  - type: object
+    properties:
+      auto_abort_previous_executions:
+        type: boolean
+      header_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      jexl_condition:
+        type: string
+      payload_conditions:
+        type: array
+        items:
+          "$ref": "../trigger_event_data.yaml"
+      repo_name:
+        type: string
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/harness_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_spec.yaml
@@ -1,0 +1,36 @@
+title: harness_spec
+allOf:
+  - "$ref": "./webhook_trigger_spec.yaml"
+  - type: object
+    properties:
+      type:
+        type: string
+        enum:
+          - pull-request
+          - push
+          - issue-comment
+  - if:
+      properties:
+        type:
+          const: issue-comment
+    then:
+      properties:
+        spec:
+          "$ref": "./harness_issue_comment_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: pull-request
+    then:
+      properties:
+        spec:
+          "$ref": "./harness_pr_spec.yaml"
+  - if:
+      properties:
+        type:
+          const: push
+    then:
+      properties:
+        spec:
+          "$ref": "./harness_push_spec.yaml"
+"$schema": http://json-schema.org/draft-07/schema#

--- a/v1/trigger/webhook_trigger/harness_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_spec.yaml
@@ -2,6 +2,9 @@ title: harness_spec
 allOf:
   - "$ref": "./webhook_trigger_spec.yaml"
   - type: object
+    required:
+      - type
+      - spec
     properties:
       type:
         type: string

--- a/v1/trigger/webhook_trigger/harness_spec.yaml
+++ b/v1/trigger/webhook_trigger/harness_spec.yaml
@@ -9,7 +9,7 @@ allOf:
       type:
         type: string
         enum:
-          - pull-request
+          - pr
           - push
           - issue-comment
   - if:
@@ -23,7 +23,7 @@ allOf:
   - if:
       properties:
         type:
-          const: pull-request
+          const: pr
     then:
       properties:
         spec:

--- a/v1/trigger/webhook_trigger/webhook_trigger_spec.yaml
+++ b/v1/trigger/webhook_trigger/webhook_trigger_spec.yaml
@@ -1,0 +1,4 @@
+title: webhook_trigger_spec
+type: object
+discriminator: type
+"$schema": http://json-schema.org/draft-07/schema#


### PR DESCRIPTION
Schema changes include:

- conditions in artifact and webhook trigger specs(structural change to have a key conditions and then inside properties header, payload and jexl, earlier those fields were header_conditions, jexl_condition and payload_conditions) **_v1/trigger/webhook_trigger/harness_issue_comment_spec.yaml_**
- enum (pullRequest -> pr, mergeRequest -> mr) **_v1/trigger/webhook_trigger/harness_spec.yaml_**
- enum (customArtifact -> custom, azureArtifact -> azure) **_v1/trigger/trigger_type/artifact_trigger.yaml_**
- removed artifacts prefix from fields in artifact trigger 
**_v1/trigger/artifact_trigger/artifactory_registry.yaml_**
- repo(**_nexus_registry.yaml, nexus.yaml, artifactory_registry.yaml_**), packages (**_github_packages.yaml, azure_artifact.yaml_**) field name structural changes 
-->repo_name, repo_url and repo_format changes to url, name and format inside repo field, same for packages
- bucket name and folder path in gcs and s3 manifest store type spec combined as location with format (bucket_name:folder_path) **_v1/trigger/manifest_trigger/gcs_build_store_spec.yaml_**
- image path and tag also combined as location with format (image_path:tag) **_v1/trigger/artifact_trigger/docker_registry.yaml_**
- chart name and version combined as chart with format (chart_name@version) **_v1/trigger/manifest_trigger/helm_spec.yaml_**