### PR TITLE
[feat]: [CDS-87898] : added environments yaml v1 schema

### DIFF
--- a/v1/examples/cd_entities/environment-entity.yaml
+++ b/v1/examples/cd_entities/environment-entity.yaml
@@ -1,0 +1,2 @@
+version: 1    # all logical subfields has been moved to metadata i.e. type,tags
+kind: environment

--- a/v1/examples/cd_entities/infra-def-entity.yaml
+++ b/v1/examples/cd_entities/infra-def-entity.yaml
@@ -1,0 +1,12 @@
+version: 1
+kind: infra-def
+type: KubernetesGcp
+spec:
+  connector: account.k8s_gcp
+  cluster: prod2
+  namespace: default
+  release: release-<+INFRA_KEY_SHORT_ID>
+variables:
+  tag:
+    type: String
+    value: 1.9.0

--- a/v1/examples/cd_entities/service-entity.yaml
+++ b/v1/examples/cd_entities/service-entity.yaml
@@ -1,0 +1,48 @@
+version: 1
+kind: service
+type: native-helm
+spec:
+  manifests:
+    primary: <+inputs.primary_manifest>
+    sources:
+      - type: HelmChart
+        id: mongo-manifest
+        spec:
+          type: Github
+          spec:
+            connector: harness-automation
+            repo:  helm-charts          # optional
+            location: refs/heads/main:/charts
+          values:                       # optional
+            - /abc/xyz.yaml
+          skip_versioning: false        # optional
+          declarative_rollback: false   # optional
+  artifacts:
+    primary:  <+inputs.primary_artifact>
+    sources:
+      - id: nginx
+        type: DockerRegistry
+        spec:
+          connector: harness-docker
+          location: /library/nginx:<+inputs.nginx_tag>
+      - id: mongo
+        type: DockerRegistry
+        spec:
+          connector: harness-docker
+          location: /library/mongo:<+inputs.mongo_tag>
+      - id: prometheus
+        sidecar: true                   # optional
+        type: DockerRegistry
+        spec:
+          connector: harness-docker
+        location: /homecentr/prometheus:<+inputs.prometheus_tag>
+  config_files:
+    - id: values
+      type: Harness
+      spec:
+        files:
+          - /configs.yaml
+  variables:
+    tag:
+      type: String
+      value: 1.9.0

--- a/v1/examples/pipeline/stages/cd/service_env_variations/env-with-deploy-all-filter.yaml
+++ b/v1/examples/pipeline/stages/cd/service_env_variations/env-with-deploy-all-filter.yaml
@@ -1,0 +1,28 @@
+version: 1
+kind: pipeline
+spec:
+  stages:
+    - type: deployment
+      failure:
+        - errors:
+            - all
+          action:
+            type: fail
+      spec:
+        services:
+          inherit:
+            stage: pre-qa
+          sequential : true
+        environments:
+          filters:
+            envs:
+              - tags: {}
+            infra_defs:
+              - tags: {}
+          sequential: true    # optional
+        steps:
+          - type: helm-deploy
+            spec: {}
+        rollback_steps:
+          - type: helm-rollback
+            spec: {}

--- a/v1/examples/pipeline/stages/cd/service_env_variations/env-with-deploy-all-filter.yaml
+++ b/v1/examples/pipeline/stages/cd/service_env_variations/env-with-deploy-all-filter.yaml
@@ -11,7 +11,7 @@ spec:
       spec:
         services:
           inherit:
-            stage: pre-qa
+            stage: pre-qa  # a previous stage in pipeline
           sequential : true
         environments:
           filters:

--- a/v1/examples/pipeline/stages/cd/service_env_variations/env-with-tag-filters.yaml
+++ b/v1/examples/pipeline/stages/cd/service_env_variations/env-with-tag-filters.yaml
@@ -1,0 +1,34 @@
+version: 1
+kind: pipeline
+spec:
+  stages:
+    - type: deployment
+      failure:
+        - errors:
+            - all
+          action:
+            type: fail
+      spec:
+        services:
+          inherit:
+            stage: pre-qa
+          sequential : true
+        environments:
+          filters:
+            envs:
+              - tags:
+                  a:b
+                  c:d
+                condition: or  # optional | Default value and
+            infra_defs:
+              - tags:
+                  a:b
+                  c:d
+                condition: and     # optional | Default value and
+          sequential: true    # optional
+        steps:
+          - type: helm-deploy
+            spec: {}
+        rollback_steps:
+          - type: helm-rollback
+            spec: {}

--- a/v1/examples/pipeline/stages/cd/service_env_variations/inherit-service-env.yaml
+++ b/v1/examples/pipeline/stages/cd/service_env_variations/inherit-service-env.yaml
@@ -11,11 +11,11 @@ spec:
       spec:
         services:
           inherit:
-            stage: pre-qa
+            stage: pre-qa # a previous stage in pipeline
           sequential : true
         environments:
           inherit:
-            stage: pre-qa
+            stage: pre-qa # a previous stage in pipeline
             with:       # optional
               - env: preqa-environment
                 infra: infra-us-east

--- a/v1/examples/pipeline/stages/cd/service_env_variations/inherit-service-env.yaml
+++ b/v1/examples/pipeline/stages/cd/service_env_variations/inherit-service-env.yaml
@@ -1,0 +1,30 @@
+version: 1
+kind: pipeline
+spec:
+  stages:
+    - type: deployment
+      failure:
+        - errors:
+            - all
+          action:
+            type: fail
+      spec:
+        services:
+          inherit:
+            stage: pre-qa
+          sequential : true
+        environments:
+          inherit:
+            stage: pre-qa
+            with:       # optional
+              - env: preqa-environment
+                infra: infra-us-east
+                inputs:
+                  cluster: us-east
+          sequential: true    # optional
+        steps:
+          - type: helm-deploy
+            spec: {}
+        rollback_steps:
+          - type: helm-rollback
+            spec: {}

--- a/v1/examples/pipeline/stages/cd/service_env_variations/multi-service-env.yaml
+++ b/v1/examples/pipeline/stages/cd/service_env_variations/multi-service-env.yaml
@@ -1,0 +1,43 @@
+version: 1
+kind: pipeline
+spec:
+  stages:
+    - type: deployment
+      failure:
+        - errors:
+            - all
+          action:
+            type: fail
+      spec:
+        services:
+          values:
+            - ref: acc.k8s-prod
+              inputs:
+                tag: latest
+            - ref: k8s-qa
+              inputs:
+                tag: latest
+          sequential : true # Optional
+        environments:
+          values:
+            - ref: QA
+              inputs:
+                replica: 3
+              infra:
+                - id: k8s-us-east
+                  inputs:
+                    namespace: default
+            - ref: PROD
+              inputs:
+                replica: 3
+              infra:
+                - id: k8s-us-west
+                  inputs:
+                    namespace: default
+          sequential: true  # Optional
+        steps:
+          - type: helm-deploy
+            spec: {}
+        rollback_steps:
+          - type: helm-rollback
+            spec: {}

--- a/v1/examples/pipeline/stages/cd/service_env_variations/runitme-infra.yaml
+++ b/v1/examples/pipeline/stages/cd/service_env_variations/runitme-infra.yaml
@@ -1,0 +1,32 @@
+version: 1
+kind: pipeline
+spec:
+  stages:
+    - type: deployment
+      failure:
+        - errors:
+            - all
+          action:
+            type: fail
+      spec:
+        services:
+          values:
+            - ref: acc.k8sProd
+              inputs:
+                tag: latest
+          sequential : true # Optional
+        environments:
+          values:
+            - ref: prod-3
+              inputs:
+                replica: 3
+              infra:
+                - id: <+inputs.infra_id>
+                  inputs: <+inputs.infra_inputs>
+          sequential: true  # Optional
+        steps:
+          - type: helm-deploy
+            spec: {}
+        rollback_steps:
+          - type: helm-rollback
+            spec: {}

--- a/v1/examples/pipeline/stages/cd/service_env_variations/runtime-service-env.yaml
+++ b/v1/examples/pipeline/stages/cd/service_env_variations/runtime-service-env.yaml
@@ -1,0 +1,23 @@
+version: 1
+kind: pipeline
+spec:
+  stages:
+    - type: deployment
+      failure:
+        - errors:
+            - all
+          action:
+            type: fail
+      spec:
+        services:
+          values: <+inputs.services_values>
+          sequential : true # Optional
+        environments:
+          values: <+inputs.environments_values>
+          sequential: true  # Optional
+        steps:
+          - type: helm-deploy
+            spec: {}
+        rollback_steps:
+          - type: helm-rollback
+            spec: {}

--- a/v1/examples/pipeline/stages/cd/service_env_variations/single-service-env.yaml
+++ b/v1/examples/pipeline/stages/cd/service_env_variations/single-service-env.yaml
@@ -1,0 +1,33 @@
+version: 1
+kind: pipeline
+spec:
+  stages:
+    - type: deployment
+      failure:
+        - errors:
+            - all
+          action:
+            type: fail
+      spec:
+        services:
+          values:
+            - ref: acc.k8sProd
+              inputs:
+                tag: latest
+          sequential : true # Optional
+        environments:
+          values:
+            - ref: prod-3
+              inputs:
+                replica: 3
+              infra:
+                - id: k8s-us
+                  inputs:
+                    namespace: default
+          sequential: true  # Optional
+        steps:
+          - type: helm-deploy
+            spec: {}
+        rollback_steps:
+          - type: helm-rollback
+            spec: {}

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -1540,7 +1540,7 @@
               },
               "condition" : {
                 "type" : "string",
-                "enum" : [ "AND", "OR" ]
+                "enum" : [ "and", "or" ]
               },
               "desc" : {
                 "description" : "This is the description for TagsTypeFilter"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -1046,9 +1046,6 @@
                 "maxItems" : 256,
                 "minItems" : 1
               },
-              "environment" : {
-                "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedEnvironmentYaml"
-              },
               "environmentGroup" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupYaml"
               },
@@ -1353,6 +1350,60 @@
               }
             }
           },
+          "EnvironmentGroupYaml" : {
+            "title" : "EnvironmentGroupYaml",
+            "type" : "object",
+            "required" : [ "envGroupRef" ],
+            "properties" : {
+              "__uuid" : {
+                "type" : "string"
+              },
+              "deployToAll" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^(?=\\s*\\S).*$"
+              },
+              "environments" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedEnvironmentYaml"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "filters" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "metadata" : {
+                "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupMetadata"
+              },
+              "description" : {
+                "desc" : "This is the description for EnvironmentGroupYaml"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
           "SimplifiedEnvironmentYaml" : {
             "title" : "SimplifiedEnvironmentYaml",
             "type" : "object",
@@ -1409,7 +1460,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedInfraDefYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/InfraDefYaml"
                   }
                 }, {
                   "type" : "string",
@@ -1460,42 +1511,42 @@
           "FilterYaml" : {
             "title" : "FilterYaml",
             "type" : "object",
-            "required" : [ "entities", "identifier", "spec", "type" ],
+            "required" : [ "envs", "infra" ],
             "properties" : {
-              "entities" : {
+              "envs" : {
                 "type" : "array",
-                "uniqueItems" : true,
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "infrastructures", "gitOpsClusters", "environments" ]
-                }
+                "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
               },
-              "identifier" : {
-                "type" : "string"
+              "infra_defs" : {
+                "type" : "array",
+                "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
               },
-              "spec" : {
-                "$ref" : "#/definitions/pipeline/stages/cd/FilterSpec"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "tags", "all" ]
-              },
-              "description" : {
-                "desc" : "This is the description for FilterYaml"
+              "desc" : {
+                "description" : "This is the description for FilterYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "FilterSpec" : {
-            "title" : "FilterSpec",
+          "TagsTypeFilter" : {
+            "title" : "TagsTypeFilter",
             "type" : "object",
-            "discriminator" : "type",
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "required" : [ "tags" ],
             "properties" : {
-              "description" : {
-                "desc" : "This is the description for FilterSpec"
+              "tags" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "string"
+                }
+              },
+              "condition" : {
+                "type" : "string",
+                "enum" : [ "AND", "OR" ]
+              },
+              "desc" : {
+                "description" : "This is the description for TagsTypeFilter"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "ClusterYaml" : {
             "title" : "ClusterYaml",
@@ -1514,29 +1565,24 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "SimplifiedInfraDefYaml" : {
-            "title" : "SimplifiedInfraDefYaml",
+          "InfraDefYaml" : {
+            "title" : "InfraDefYaml",
             "type" : "object",
             "required" : [ "id" ],
             "properties" : {
               "id" : {
-                "type" : "string",
-                "pattern" : "^(?=\\s*\\S).*$"
+                "type" : "string"
               },
               "inputs" : {
                 "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/JsonNode"
+                  "$ref" : "#/definitions/pipeline/common/Inputs"
                 }, {
                   "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
+                  "pattern" : "^<\\+inputs\\..*>$"
                 } ]
               },
-              "metadata" : {
-                "type" : "string"
-              },
               "desc" : {
-                "description" : "This is the description for SimplifiedInfraDefYaml"
+                "description" : "This is the description for InfraDefYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -2543,60 +2589,6 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "EnvironmentGroupYaml" : {
-            "title" : "EnvironmentGroupYaml",
-            "type" : "object",
-            "required" : [ "envGroupRef" ],
-            "properties" : {
-              "__uuid" : {
-                "type" : "string"
-              },
-              "deployToAll" : {
-                "oneOf" : [ {
-                  "type" : "boolean"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^(?=\\s*\\S).*$"
-              },
-              "environments" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedEnvironmentYaml"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "filters" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "metadata" : {
-                "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupMetadata"
-              },
-              "description" : {
-                "desc" : "This is the description for EnvironmentGroupYaml"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
           "EnvironmentGroupMetadata" : {
             "title" : "EnvironmentGroupMetadata",
             "type" : "object",
@@ -2614,49 +2606,107 @@
             "title" : "EnvironmentsYaml",
             "type" : "object",
             "properties" : {
-              "filters" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "metadata" : {
-                "readOnly" : true,
-                "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentsMetadata"
-              },
               "values" : {
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedEnvironmentYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentYaml"
                   }
                 }, {
                   "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
+                  "pattern" : "^<\\+inputs\\..*>$"
                 } ]
               },
-              "description" : {
-                "desc" : "This is the description for EnvironmentsYaml"
+              "inherit" : {
+                "$ref" : "#/definitions/pipeline/stages/cd/InheritEnvironment"
+              },
+              "filters" : {
+                "oneOf" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                  }
+                }
+              },
+              "sequential" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "desc" : {
+                "description" : "This is the description for EnvironmentsYaml"
+              }
+            },
+            "anyOf" : [ "values", "inherit", "filters" ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "EnvironmentYaml" : {
+            "title" : "EnvironmentYaml",
+            "type" : "object",
+            "required" : [ "ref", "infra" ],
+            "properties" : {
+              "ref" : {
+                "type" : "string"
+              },
+              "inputs" : {
+                "$ref" : "#/definitions/pipeline/common/Inputs"
+              },
+              "infra" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/InfraDefYaml"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+inputs\\..*>$"
+                } ]
+              },
+              "desc" : {
+                "description" : "This is the description for EnvironmentYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "EnvironmentsMetadata" : {
-            "title" : "EnvironmentsMetadata",
+          "InheritEnvironment" : {
+            "title" : "InheritEnvironment",
             "type" : "object",
+            "required" : [ "stage" ],
             "properties" : {
-              "parallel" : {
-                "type" : "boolean"
+              "stage" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
               },
-              "description" : {
-                "desc" : "This is the description for EnvironmentsMetadata"
+              "with" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/pipeline/stages/cd/InheritEnvironmentWithConfig"
+                }
+              },
+              "desc" : {
+                "description" : "This is the description for InheritEnvironment"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "InheritEnvironmentWithConfig" : {
+            "title" : "InheritEnvironmentWithConfig",
+            "type" : "object",
+            "required" : [ "env", "infra" ],
+            "properties" : {
+              "env" : {
+                "type" : "string"
+              },
+              "infra" : {
+                "type" : "string"
+              },
+              "inputs" : {
+                "$ref" : "#/definitions/pipeline/common/Inputs"
+              },
+              "desc" : {
+                "description" : "This is the description for InheritEnvironmentWithConfig"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -6683,6 +6733,17 @@
           },
           "$schema" : "http://json-schema.org/draft-07/schema#"
         },
+        "Inputs" : {
+          "title" : "Inputs",
+          "type" : "object",
+          "description" : "inputs to be used for entities",
+          "additionalProperties" : {
+            "anyOf" : [ "string", "array", "number", "object", "boolean" ]
+          },
+          "propertyNames" : {
+            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0, 127}$"
+          }
+        },
         "K8sDirectInfra" : {
           "title" : "K8sDirectInfra",
           "allOf" : [ {
@@ -6721,17 +6782,6 @@
             }
           },
           "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "Inputs" : {
-          "title" : "Inputs",
-          "type" : "object",
-          "description" : "inputs to be used for entities",
-          "additionalProperties" : {
-            "anyOf" : [ "string", "array", "number", "object", "boolean" ]
-          },
-          "propertyNames" : {
-            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0, 127}$"
-          }
         },
         "StringInput" : {
           "title" : "StringInput",

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -2628,7 +2628,8 @@
                 "oneOf" : [ {
                   "type" : "boolean"
                 }, {
-                  "type" : "string"
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)"
                 } ]
               },
               "desc" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -1387,7 +1387,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
                   }
                 }, {
                   "type" : "string",
@@ -1436,7 +1436,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
                   }
                 }, {
                   "type" : "string",
@@ -1508,8 +1508,8 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "FilterYaml" : {
-            "title" : "FilterYaml",
+          "EnvInfraFilterYaml" : {
+            "title" : "EnvInfraFilterYaml",
             "type" : "object",
             "required" : [ "envs", "infra" ],
             "properties" : {
@@ -2624,7 +2624,7 @@
                 "oneOf" : {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
                   }
                 }
               },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -1514,11 +1514,9 @@
             "required" : [ "envs", "infra_defs" ],
             "properties" : {
               "envs" : {
-                "type" : "array",
                 "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
               },
               "infra_defs" : {
-                "type" : "array",
                 "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
               },
               "desc" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -1518,9 +1518,6 @@
               },
               "infra_defs" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
-              },
-              "desc" : {
-                "description" : "This is the description for FilterYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -1539,9 +1536,6 @@
               "condition" : {
                 "type" : "string",
                 "enum" : [ "and", "or" ]
-              },
-              "desc" : {
-                "description" : "This is the description for TagsTypeFilter"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -1578,9 +1572,6 @@
                   "type" : "string",
                   "pattern" : "^<\\+inputs\\..*>$"
                 } ]
-              },
-              "desc" : {
-                "description" : "This is the description for InfraDefYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -2631,9 +2622,6 @@
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)"
                 } ]
-              },
-              "desc" : {
-                "description" : "This is the description for EnvironmentsYaml"
               }
             },
             "anyOf" : [ "values", "inherit", "filters" ],
@@ -2660,9 +2648,6 @@
                   "type" : "string",
                   "pattern" : "^<\\+inputs\\..*>$"
                 } ]
-              },
-              "desc" : {
-                "description" : "This is the description for EnvironmentYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -2680,9 +2665,6 @@
                 "items" : {
                   "$ref" : "#/definitions/pipeline/stages/cd/InheritEnvironmentWithConfig"
                 }
-              },
-              "desc" : {
-                "description" : "This is the description for InheritEnvironment"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -2700,9 +2682,6 @@
               },
               "inputs" : {
                 "$ref" : "#/definitions/pipeline/common/Inputs"
-              },
-              "desc" : {
-                "description" : "This is the description for InheritEnvironmentWithConfig"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -2621,11 +2621,9 @@
                 "$ref" : "#/definitions/pipeline/stages/cd/InheritEnvironment"
               },
               "filters" : {
-                "oneOf" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
-                  }
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
                 }
               },
               "sequential" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -1511,7 +1511,7 @@
           "EnvInfraFilterYaml" : {
             "title" : "EnvInfraFilterYaml",
             "type" : "object",
-            "required" : [ "envs", "infra" ],
+            "required" : [ "envs", "infra_defs" ],
             "properties" : {
               "envs" : {
                 "type" : "array",
@@ -2676,8 +2676,7 @@
             "required" : [ "stage" ],
             "properties" : {
               "stage" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+                "type" : "string"
               },
               "with" : {
                 "type" : "array",

--- a/v1/pipeline/stages/cd/deployment-stage-config.yaml
+++ b/v1/pipeline/stages/cd/deployment-stage-config.yaml
@@ -18,8 +18,6 @@ properties:
       configRef: ./deployment-stage-spec-element-wrapper-config.yaml/steps
     maxItems: 256
     minItems: 1
-  environment:
-    $ref: environment-yaml-v2.yaml
   environmentGroup:
     $ref: environment-group-yaml.yaml
   environments:

--- a/v1/pipeline/stages/cd/env-infra-filter-yaml.yaml
+++ b/v1/pipeline/stages/cd/env-infra-filter-yaml.yaml
@@ -1,4 +1,4 @@
-title: FilterYaml
+title: EnvInfraFilterYaml
 type: object
 required:
 - envs

--- a/v1/pipeline/stages/cd/env-infra-filter-yaml.yaml
+++ b/v1/pipeline/stages/cd/env-infra-filter-yaml.yaml
@@ -5,10 +5,8 @@ required:
 - infra_defs
 properties:
   envs:
-    type: array
     $ref: tags-type-filter.yaml
   infra_defs:
-    type: array
     $ref: tags-type-filter.yaml
   desc:
     description: This is the description for FilterYaml

--- a/v1/pipeline/stages/cd/env-infra-filter-yaml.yaml
+++ b/v1/pipeline/stages/cd/env-infra-filter-yaml.yaml
@@ -8,6 +8,4 @@ properties:
     $ref: tags-type-filter.yaml
   infra_defs:
     $ref: tags-type-filter.yaml
-  desc:
-    description: This is the description for FilterYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/env-infra-filter-yaml.yaml
+++ b/v1/pipeline/stages/cd/env-infra-filter-yaml.yaml
@@ -2,7 +2,7 @@ title: EnvInfraFilterYaml
 type: object
 required:
 - envs
-- infra
+- infra_defs
 properties:
   envs:
     type: array

--- a/v1/pipeline/stages/cd/environment-group-yaml.yaml
+++ b/v1/pipeline/stages/cd/environment-group-yaml.yaml
@@ -26,7 +26,7 @@ properties:
     oneOf:
     - type: array
       items:
-        $ref: filter-yaml.yaml
+        $ref: env-infra-filter-yaml.yaml
     - type: string
       pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
       minLength: 1

--- a/v1/pipeline/stages/cd/environment-yaml-v2.yaml
+++ b/v1/pipeline/stages/cd/environment-yaml-v2.yaml
@@ -21,7 +21,7 @@ properties:
     oneOf:
     - type: array
       items:
-        $ref: filter-yaml.yaml
+        $ref: env-infra-filter-yaml.yaml
     - type: string
       pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
       minLength: 1

--- a/v1/pipeline/stages/cd/environment-yaml.yaml
+++ b/v1/pipeline/stages/cd/environment-yaml.yaml
@@ -15,6 +15,4 @@ properties:
           $ref: infra-structure-definition-yaml.yaml
       - type: string
         pattern: ^<\+inputs\..*>$
-  desc:
-    description: This is the description for EnvironmentYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/environment-yaml.yaml
+++ b/v1/pipeline/stages/cd/environment-yaml.yaml
@@ -1,24 +1,20 @@
 title: EnvironmentYaml
 type: object
 required:
-- identifier
-- name
-- type
+  - ref
+  - infra
 properties:
-  description:
+  ref:
     type: string
-    desc: This is the description for EnvironmentYaml
-  identifier:
-    type: string
-  name:
-    type: string
-  tags:
-    type: object
-    additionalProperties:
-      type: string
-  type:
-    type: string
-    enum:
-    - PreProduction
-    - Production
+  inputs:
+    $ref: ../../common/inputs.yaml
+  infra:
+    oneOf:
+      - type: array
+        items:
+          $ref: infra-structure-definition-yaml.yaml
+      - type: string
+        pattern: ^<\+inputs\..*>$
+  desc:
+    description: This is the description for EnvironmentYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/environments-yaml.yaml
+++ b/v1/pipeline/stages/cd/environments-yaml.yaml
@@ -18,6 +18,7 @@ properties:
     oneOf:
       - type: boolean
       - type: string
+        pattern: (<\+.+>.*)
   desc:
     description: This is the description for EnvironmentsYaml
 anyOf:

--- a/v1/pipeline/stages/cd/environments-yaml.yaml
+++ b/v1/pipeline/stages/cd/environments-yaml.yaml
@@ -11,9 +11,9 @@ properties:
   inherit:
     $ref: inherit-environment.yaml
   filters:
-      type: array
-      items:
-        $ref: env-infra-filter-yaml.yaml
+    type: array
+    items:
+      $ref: env-infra-filter-yaml.yaml
   sequential:
     oneOf:
       - type: boolean

--- a/v1/pipeline/stages/cd/environments-yaml.yaml
+++ b/v1/pipeline/stages/cd/environments-yaml.yaml
@@ -11,7 +11,6 @@ properties:
   inherit:
     $ref: inherit-environment.yaml
   filters:
-    oneOf:
       type: array
       items:
         $ref: env-infra-filter-yaml.yaml

--- a/v1/pipeline/stages/cd/environments-yaml.yaml
+++ b/v1/pipeline/stages/cd/environments-yaml.yaml
@@ -14,7 +14,7 @@ properties:
     oneOf:
       type: array
       items:
-        $ref: filter-yaml.yaml
+        $ref: env-infra-filter-yaml.yaml
   sequential:
     oneOf:
       - type: boolean

--- a/v1/pipeline/stages/cd/environments-yaml.yaml
+++ b/v1/pipeline/stages/cd/environments-yaml.yaml
@@ -1,25 +1,28 @@
 title: EnvironmentsYaml
 type: object
 properties:
-  filters:
-    oneOf:
-    - type: array
-      items:
-        $ref: filter-yaml.yaml
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
-  metadata:
-    readOnly: true
-    $ref: environments-metadata.yaml
   values:
     oneOf:
-    - type: array
+      - type: array
+        items:
+          $ref: environment-yaml.yaml
+      - type: string
+        pattern: ^<\+inputs\..*>$
+  inherit:
+    $ref: inherit-environment.yaml
+  filters:
+    oneOf:
+      type: array
       items:
-        $ref: environment-yaml-v2.yaml
-    - type: string
-      pattern: (<\+.+>.*)
-      minLength: 1
-  description:
-    desc: This is the description for EnvironmentsYaml
+        $ref: filter-yaml.yaml
+  sequential:
+    oneOf:
+      - type: boolean
+      - type: string
+  desc:
+    description: This is the description for EnvironmentsYaml
+anyOf:
+  - values
+  - inherit
+  - filters
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/environments-yaml.yaml
+++ b/v1/pipeline/stages/cd/environments-yaml.yaml
@@ -19,8 +19,6 @@ properties:
       - type: boolean
       - type: string
         pattern: (<\+.+>.*)
-  desc:
-    description: This is the description for EnvironmentsYaml
 anyOf:
   - values
   - inherit

--- a/v1/pipeline/stages/cd/filter-yaml.yaml
+++ b/v1/pipeline/stages/cd/filter-yaml.yaml
@@ -1,29 +1,15 @@
 title: FilterYaml
 type: object
 required:
-- entities
-- identifier
-- spec
-- type
+- envs
+- infra
 properties:
-  entities:
+  envs:
     type: array
-    uniqueItems: true
-    items:
-      type: string
-      enum:
-      - infrastructures
-      - gitOpsClusters
-      - environments
-  identifier:
-    type: string
-  spec:
-    $ref: filter-spec.yaml
-  type:
-    type: string
-    enum:
-    - tags
-    - all
-  description:
-    desc: This is the description for FilterYaml
+    $ref: tags-type-filter.yaml
+  infra_defs:
+    type: array
+    $ref: tags-type-filter.yaml
+  desc:
+    description: This is the description for FilterYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/infra-structure-definition-yaml.yaml
+++ b/v1/pipeline/stages/cd/infra-structure-definition-yaml.yaml
@@ -10,6 +10,4 @@ properties:
     - $ref: ../../common/inputs.yaml
     - type: string
       pattern: ^<\+inputs\..*>$
-  desc:
-    description: This is the description for InfraDefYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/infra-structure-definition-yaml.yaml
+++ b/v1/pipeline/stages/cd/infra-structure-definition-yaml.yaml
@@ -1,19 +1,15 @@
-title: SimplifiedInfraDefYaml
+title: InfraDefYaml
 type: object
 required:
 - id
 properties:
   id:
     type: string
-    pattern: ^(?=\s*\S).*$
   inputs:
     oneOf:
-    - $ref: ../../common/json-node.yaml
+    - $ref: ../../common/inputs.yaml
     - type: string
-      pattern: (<\+.+>.*)
-      minLength: 1
-  metadata:
-    type: string
+      pattern: ^<\+inputs\..*>$
   desc:
-    description: This is the description for SimplifiedInfraDefYaml
+    description: This is the description for InfraDefYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/inherit-env-with-config.yaml
+++ b/v1/pipeline/stages/cd/inherit-env-with-config.yaml
@@ -10,6 +10,4 @@ properties:
     type: string
   inputs:
     $ref: ../../common/inputs.yaml
-  desc:
-    description: This is the description for InheritEnvironmentWithConfig
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/inherit-env-with-config.yaml
+++ b/v1/pipeline/stages/cd/inherit-env-with-config.yaml
@@ -1,0 +1,15 @@
+title: InheritEnvironmentWithConfig
+type: object
+required:
+  - env
+  - infra
+properties:
+  env:
+    type: string
+  infra:
+    type: string
+  inputs:
+    $ref: ../../common/inputs.yaml
+  desc:
+    description: This is the description for InheritEnvironmentWithConfig
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/inherit-environment.yaml
+++ b/v1/pipeline/stages/cd/inherit-environment.yaml
@@ -9,6 +9,4 @@ properties:
     type: array
     items:
       $ref: inherit-env-with-config.yaml
-  desc:
-    description: This is the description for InheritEnvironment
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/inherit-environment.yaml
+++ b/v1/pipeline/stages/cd/inherit-environment.yaml
@@ -1,0 +1,15 @@
+title: InheritEnvironment
+type: object
+required:
+  - stage
+properties:
+  stage:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  with:
+    type: array
+    items:
+      $ref: inherit-env-with-config.yaml
+  desc:
+    description: This is the description for InheritEnvironment
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/inherit-environment.yaml
+++ b/v1/pipeline/stages/cd/inherit-environment.yaml
@@ -5,7 +5,6 @@ required:
 properties:
   stage:
     type: string
-    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
   with:
     type: array
     items:

--- a/v1/pipeline/stages/cd/tags-type-filter.yaml
+++ b/v1/pipeline/stages/cd/tags-type-filter.yaml
@@ -10,8 +10,8 @@ properties:
   condition:
     type: string
     enum:
-      - AND
-      - OR
+      - and
+      - or
   desc:
     description: This is the description for TagsTypeFilter
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/tags-type-filter.yaml
+++ b/v1/pipeline/stages/cd/tags-type-filter.yaml
@@ -12,6 +12,4 @@ properties:
     enum:
       - and
       - or
-  desc:
-    description: This is the description for TagsTypeFilter
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/tags-type-filter.yaml
+++ b/v1/pipeline/stages/cd/tags-type-filter.yaml
@@ -1,0 +1,17 @@
+title: TagsTypeFilter
+type: object
+required:
+  - tags
+properties:
+  tags:
+    type: object
+    additionalProperties:
+      type: string
+  condition:
+    type: string
+    enum:
+      - AND
+      - OR
+  desc:
+    description: This is the description for TagsTypeFilter
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/template.json
+++ b/v1/template.json
@@ -59411,11 +59411,9 @@
             "required" : [ "envs", "infra_defs" ],
             "properties" : {
               "envs" : {
-                "type" : "array",
                 "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
               },
               "infra_defs" : {
-                "type" : "array",
                 "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
               },
               "desc" : {

--- a/v1/template.json
+++ b/v1/template.json
@@ -59437,7 +59437,7 @@
               },
               "condition" : {
                 "type" : "string",
-                "enum" : [ "AND", "OR" ]
+                "enum" : [ "and", "or" ]
               },
               "desc" : {
                 "description" : "This is the description for TagsTypeFilter"

--- a/v1/template.json
+++ b/v1/template.json
@@ -59415,9 +59415,6 @@
               },
               "infra_defs" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
-              },
-              "desc" : {
-                "description" : "This is the description for FilterYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -59436,9 +59433,6 @@
               "condition" : {
                 "type" : "string",
                 "enum" : [ "and", "or" ]
-              },
-              "desc" : {
-                "description" : "This is the description for TagsTypeFilter"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -59475,9 +59469,6 @@
                   "type" : "string",
                   "pattern" : "^<\\+inputs\\..*>$"
                 } ]
-              },
-              "desc" : {
-                "description" : "This is the description for InfraDefYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -60528,9 +60519,6 @@
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)"
                 } ]
-              },
-              "desc" : {
-                "description" : "This is the description for EnvironmentsYaml"
               }
             },
             "anyOf" : [ "values", "inherit", "filters" ],
@@ -60557,9 +60545,6 @@
                   "type" : "string",
                   "pattern" : "^<\\+inputs\\..*>$"
                 } ]
-              },
-              "desc" : {
-                "description" : "This is the description for EnvironmentYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -60577,9 +60562,6 @@
                 "items" : {
                   "$ref" : "#/definitions/pipeline/stages/cd/InheritEnvironmentWithConfig"
                 }
-              },
-              "desc" : {
-                "description" : "This is the description for InheritEnvironment"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -60597,9 +60579,6 @@
               },
               "inputs" : {
                 "$ref" : "#/definitions/pipeline/common/Inputs"
-              },
-              "desc" : {
-                "description" : "This is the description for InheritEnvironmentWithConfig"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"

--- a/v1/template.json
+++ b/v1/template.json
@@ -59284,7 +59284,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
                   }
                 }, {
                   "type" : "string",
@@ -59333,7 +59333,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
                   }
                 }, {
                   "type" : "string",
@@ -59405,8 +59405,8 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "FilterYaml" : {
-            "title" : "FilterYaml",
+          "EnvInfraFilterYaml" : {
+            "title" : "EnvInfraFilterYaml",
             "type" : "object",
             "required" : [ "envs", "infra" ],
             "properties" : {
@@ -60521,7 +60521,7 @@
                 "oneOf" : {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
                   }
                 }
               },

--- a/v1/template.json
+++ b/v1/template.json
@@ -60518,11 +60518,9 @@
                 "$ref" : "#/definitions/pipeline/stages/cd/InheritEnvironment"
               },
               "filters" : {
-                "oneOf" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
-                  }
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/pipeline/stages/cd/EnvInfraFilterYaml"
                 }
               },
               "sequential" : {

--- a/v1/template.json
+++ b/v1/template.json
@@ -2994,6 +2994,17 @@
           "$schema" : "http://json-schema.org/draft-07/schema#",
           "allOf" : [ ]
         },
+        "Inputs" : {
+          "title" : "Inputs",
+          "type" : "object",
+          "description" : "inputs to be used for entities",
+          "additionalProperties" : {
+            "anyOf" : [ "string", "array", "number", "object", "boolean" ]
+          },
+          "propertyNames" : {
+            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0, 127}$"
+          }
+        },
         "K8sDirectInfra" : {
           "title" : "K8sDirectInfra",
           "allOf" : [ {
@@ -3032,17 +3043,6 @@
             }
           },
           "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "Inputs" : {
-          "title" : "Inputs",
-          "type" : "object",
-          "description" : "inputs to be used for entities",
-          "additionalProperties" : {
-            "anyOf" : [ "string", "array", "number", "object", "boolean" ]
-          },
-          "propertyNames" : {
-            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0, 127}$"
-          }
         }
       },
       "steps" : {
@@ -59177,9 +59177,6 @@
                 "maxItems" : 256,
                 "minItems" : 1
               },
-              "environment" : {
-                "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedEnvironmentYaml"
-              },
               "environmentGroup" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupYaml"
               },
@@ -59250,6 +59247,60 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
+          "EnvironmentGroupYaml" : {
+            "title" : "EnvironmentGroupYaml",
+            "type" : "object",
+            "required" : [ "envGroupRef" ],
+            "properties" : {
+              "__uuid" : {
+                "type" : "string"
+              },
+              "deployToAll" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^(?=\\s*\\S).*$"
+              },
+              "environments" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedEnvironmentYaml"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "filters" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "metadata" : {
+                "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupMetadata"
+              },
+              "description" : {
+                "desc" : "This is the description for EnvironmentGroupYaml"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
           "SimplifiedEnvironmentYaml" : {
             "title" : "SimplifiedEnvironmentYaml",
             "type" : "object",
@@ -59306,7 +59357,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedInfraDefYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/InfraDefYaml"
                   }
                 }, {
                   "type" : "string",
@@ -59357,42 +59408,42 @@
           "FilterYaml" : {
             "title" : "FilterYaml",
             "type" : "object",
-            "required" : [ "entities", "identifier", "spec", "type" ],
+            "required" : [ "envs", "infra" ],
             "properties" : {
-              "entities" : {
+              "envs" : {
                 "type" : "array",
-                "uniqueItems" : true,
-                "items" : {
-                  "type" : "string",
-                  "enum" : [ "infrastructures", "gitOpsClusters", "environments" ]
-                }
+                "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
               },
-              "identifier" : {
-                "type" : "string"
+              "infra_defs" : {
+                "type" : "array",
+                "$ref" : "#/definitions/pipeline/stages/cd/TagsTypeFilter"
               },
-              "spec" : {
-                "$ref" : "#/definitions/pipeline/stages/cd/FilterSpec"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "tags", "all" ]
-              },
-              "description" : {
-                "desc" : "This is the description for FilterYaml"
+              "desc" : {
+                "description" : "This is the description for FilterYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "FilterSpec" : {
-            "title" : "FilterSpec",
+          "TagsTypeFilter" : {
+            "title" : "TagsTypeFilter",
             "type" : "object",
-            "discriminator" : "type",
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "required" : [ "tags" ],
             "properties" : {
-              "description" : {
-                "desc" : "This is the description for FilterSpec"
+              "tags" : {
+                "type" : "object",
+                "additionalProperties" : {
+                  "type" : "string"
+                }
+              },
+              "condition" : {
+                "type" : "string",
+                "enum" : [ "AND", "OR" ]
+              },
+              "desc" : {
+                "description" : "This is the description for TagsTypeFilter"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "ClusterYaml" : {
             "title" : "ClusterYaml",
@@ -59411,29 +59462,24 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "SimplifiedInfraDefYaml" : {
-            "title" : "SimplifiedInfraDefYaml",
+          "InfraDefYaml" : {
+            "title" : "InfraDefYaml",
             "type" : "object",
             "required" : [ "id" ],
             "properties" : {
               "id" : {
-                "type" : "string",
-                "pattern" : "^(?=\\s*\\S).*$"
+                "type" : "string"
               },
               "inputs" : {
                 "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/JsonNode"
+                  "$ref" : "#/definitions/pipeline/common/Inputs"
                 }, {
                   "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
+                  "pattern" : "^<\\+inputs\\..*>$"
                 } ]
               },
-              "metadata" : {
-                "type" : "string"
-              },
               "desc" : {
-                "description" : "This is the description for SimplifiedInfraDefYaml"
+                "description" : "This is the description for InfraDefYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -60440,60 +60486,6 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "EnvironmentGroupYaml" : {
-            "title" : "EnvironmentGroupYaml",
-            "type" : "object",
-            "required" : [ "envGroupRef" ],
-            "properties" : {
-              "__uuid" : {
-                "type" : "string"
-              },
-              "deployToAll" : {
-                "oneOf" : [ {
-                  "type" : "boolean"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^(?=\\s*\\S).*$"
-              },
-              "environments" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedEnvironmentYaml"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "filters" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "metadata" : {
-                "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupMetadata"
-              },
-              "description" : {
-                "desc" : "This is the description for EnvironmentGroupYaml"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
           "EnvironmentGroupMetadata" : {
             "title" : "EnvironmentGroupMetadata",
             "type" : "object",
@@ -60511,49 +60503,107 @@
             "title" : "EnvironmentsYaml",
             "type" : "object",
             "properties" : {
-              "filters" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
-              },
-              "metadata" : {
-                "readOnly" : true,
-                "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentsMetadata"
-              },
               "values" : {
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/stages/cd/SimplifiedEnvironmentYaml"
+                    "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentYaml"
                   }
                 }, {
                   "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
+                  "pattern" : "^<\\+inputs\\..*>$"
                 } ]
               },
-              "description" : {
-                "desc" : "This is the description for EnvironmentsYaml"
+              "inherit" : {
+                "$ref" : "#/definitions/pipeline/stages/cd/InheritEnvironment"
+              },
+              "filters" : {
+                "oneOf" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/FilterYaml"
+                  }
+                }
+              },
+              "sequential" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "desc" : {
+                "description" : "This is the description for EnvironmentsYaml"
+              }
+            },
+            "anyOf" : [ "values", "inherit", "filters" ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "EnvironmentYaml" : {
+            "title" : "EnvironmentYaml",
+            "type" : "object",
+            "required" : [ "ref", "infra" ],
+            "properties" : {
+              "ref" : {
+                "type" : "string"
+              },
+              "inputs" : {
+                "$ref" : "#/definitions/pipeline/common/Inputs"
+              },
+              "infra" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/InfraDefYaml"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+inputs\\..*>$"
+                } ]
+              },
+              "desc" : {
+                "description" : "This is the description for EnvironmentYaml"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
-          "EnvironmentsMetadata" : {
-            "title" : "EnvironmentsMetadata",
+          "InheritEnvironment" : {
+            "title" : "InheritEnvironment",
             "type" : "object",
+            "required" : [ "stage" ],
             "properties" : {
-              "parallel" : {
-                "type" : "boolean"
+              "stage" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
               },
-              "description" : {
-                "desc" : "This is the description for EnvironmentsMetadata"
+              "with" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/pipeline/stages/cd/InheritEnvironmentWithConfig"
+                }
+              },
+              "desc" : {
+                "description" : "This is the description for InheritEnvironment"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "InheritEnvironmentWithConfig" : {
+            "title" : "InheritEnvironmentWithConfig",
+            "type" : "object",
+            "required" : [ "env", "infra" ],
+            "properties" : {
+              "env" : {
+                "type" : "string"
+              },
+              "infra" : {
+                "type" : "string"
+              },
+              "inputs" : {
+                "$ref" : "#/definitions/pipeline/common/Inputs"
+              },
+              "desc" : {
+                "description" : "This is the description for InheritEnvironmentWithConfig"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"

--- a/v1/template.json
+++ b/v1/template.json
@@ -59408,7 +59408,7 @@
           "EnvInfraFilterYaml" : {
             "title" : "EnvInfraFilterYaml",
             "type" : "object",
-            "required" : [ "envs", "infra" ],
+            "required" : [ "envs", "infra_defs" ],
             "properties" : {
               "envs" : {
                 "type" : "array",
@@ -60573,8 +60573,7 @@
             "required" : [ "stage" ],
             "properties" : {
               "stage" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+                "type" : "string"
               },
               "with" : {
                 "type" : "array",

--- a/v1/template.json
+++ b/v1/template.json
@@ -60525,7 +60525,8 @@
                 "oneOf" : [ {
                   "type" : "boolean"
                 }, {
-                  "type" : "string"
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)"
                 } ]
               },
               "desc" : {


### PR DESCRIPTION
Env config
First
```
        environments:
          values:
            - ref: prod-3
              inputs:
              infra:         ##### infras - not suitable
                - id: k8s-us   ##### ref vs id 
                  inputs: 
          sequential: true   ##### replaced parallel
```

Second
```
environments:
  inherit:
    stage: pre-qa   
    with:      ##### would be optional/ open via checkbox
      - env: preqa-environment  ##### single env user need to give env again in yaml
        infra: infra-us-east
        inputs:
  sequential: true    ##### optional
```

Third
```
environments:
  filters:
    envs: 
      - tags:
         a:b
         c:d
        condition: OR      ###### Optional | Default value AND
    infra_defs:
      - tags:
          a:b
          c:d
        condition: AND      ###### Optional | Default value AND
  sequential: true    ##### this field is not available in v0
  
##### v1 enviornment with deploy all env
environments:
  filters:
    envs: 
      - tags: {}
    infra_defs:
      - tags:
          a:b
          c:d
        condition: OR      ###### Optional | Default value AND
  sequential: true    ##### this field is not available in v0
```