### PR TITLE
feat: [SSCA-1245]: Added Repository Source in SSCA Orchestration Step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11242,7 +11242,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "image" ]
+                "enum" : [ "image", "repository" ]
               },
               "description" : {
                 "desc" : "This is the description for SbomSource"
@@ -11261,6 +11261,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/ImageSbomSource"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "repository"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySbomSource"
                   }
                 }
               }
@@ -11296,6 +11311,39 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for SbomSourceSpec"
+              }
+            }
+          },
+          "RepositorySbomSource" : {
+            "title" : "RepositorySbomSource",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "url", "path", "variant_type", "variant" ],
+              "properties" : {
+                "url" : {
+                  "type" : "string"
+                },
+                "path" : {
+                  "type" : "string"
+                },
+                "variant_type" : {
+                  "type" : "string",
+                  "enum" : [ "branch", "git_tag", "commit" ]
+                },
+                "variant" : {
+                  "type" : "string"
+                },
+                "cloned_codebase" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for RepositorySbomSource"
               }
             }
           },
@@ -11595,10 +11643,60 @@
             "properties" : {
               "base" : {
                 "type" : "string",
-                "enum" : [ "baseline", "last_generated_sbom" ]
+                "enum" : [ "baseline", "last_generated_sbom", "repository" ]
               },
               "description" : {
                 "desc" : "This is the description for SbomOrchestrationTool"
+              }
+            },
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "base" : {
+                    "const" : "repository"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySbomDrift"
+                  }
+                }
+              }
+            } ]
+          },
+          "RepositorySbomDrift" : {
+            "title" : "RepositorySbomDrift",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomDriftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "variant_type", "variant" ],
+              "properties" : {
+                "variant_type" : {
+                  "type" : "string",
+                  "enum" : [ "branch", "git_tag", "commit" ]
+                },
+                "variant" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for RepositorySbomDrift"
+              }
+            }
+          },
+          "SbomDriftSpec" : {
+            "title" : "SbomDriftSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SbomSourceDriftSpec"
               }
             }
           },

--- a/v0/pipeline/steps/custom/repository-sbom-drift.yaml
+++ b/v0/pipeline/steps/custom/repository-sbom-drift.yaml
@@ -1,0 +1,28 @@
+title: RepositorySbomDrift
+allOf:
+  - $ref: sbom-source-spec.yaml
+  - type: object
+    required:
+      - url
+      - path
+      - variant_type
+      - variant
+    properties:
+      url:
+        type: string
+      path:
+        type: string
+      variant_type:
+        type: string
+        enum:
+          - branch
+          - git_tag
+          - commit
+      variant:
+        type: string
+      cloned_codebase:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for RepositorySbomSource

--- a/v0/pipeline/steps/custom/repository-sbom-drift.yaml
+++ b/v0/pipeline/steps/custom/repository-sbom-drift.yaml
@@ -1,28 +1,20 @@
 title: RepositorySbomDrift
 allOf:
-  - $ref: sbom-source-spec.yaml
-  - type: object
-    required:
-      - url
-      - path
-      - variant_type
-      - variant
-    properties:
-      url:
-        type: string
-      path:
-        type: string
-      variant_type:
-        type: string
-        enum:
-          - branch
-          - git_tag
-          - commit
-      variant:
-        type: string
-      cloned_codebase:
-        type: string
+- $ref: sbom-drift-spec.yaml
+- type: object
+  required:
+  - variant_type
+  - variant
+  properties:
+    variant_type:
+      type: string
+      enum:
+      - branch
+      - git_tag
+      - commit
+    variant:
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:
-    desc: This is the description for RepositorySbomSource
+    desc: This is the description for RepositorySbomDrift

--- a/v0/pipeline/steps/custom/repository-sbom-source.yaml
+++ b/v0/pipeline/steps/custom/repository-sbom-source.yaml
@@ -1,0 +1,20 @@
+title: RepositorySbomDrift
+allOf:
+  - $ref: sbom-drift-spec.yaml
+  - type: object
+    required:
+      - variant_type
+      - variant
+    properties:
+      variant_type:
+        type: string
+        enum:
+        - branch
+        - git_tag
+        - commit
+      variant:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for RepositorySbomDrift

--- a/v0/pipeline/steps/custom/repository-sbom-source.yaml
+++ b/v0/pipeline/steps/custom/repository-sbom-source.yaml
@@ -1,20 +1,28 @@
-title: RepositorySbomDrift
+title: RepositorySbomSource
 allOf:
-  - $ref: sbom-drift-spec.yaml
-  - type: object
-    required:
-      - variant_type
-      - variant
-    properties:
-      variant_type:
-        type: string
-        enum:
-        - branch
-        - git_tag
-        - commit
-      variant:
-        type: string
+- $ref: sbom-source-spec.yaml
+- type: object
+  required:
+  - url
+  - path
+  - variant_type
+  - variant
+  properties:
+    url:
+      type: string
+    path:
+      type: string
+    variant_type:
+      type: string
+      enum:
+      - branch
+      - git_tag
+      - commit
+    variant:
+      type: string
+    cloned_codebase:
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:
-    desc: This is the description for RepositorySbomDrift
+    desc: This is the description for RepositorySbomSource

--- a/v0/pipeline/steps/custom/sbom-drift-spec.yaml
+++ b/v0/pipeline/steps/custom/sbom-drift-spec.yaml
@@ -3,4 +3,4 @@ type: object
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:
-    desc: This is the description for SbomSourceriftSpec
+    desc: This is the description for SbomSourceDriftSpec

--- a/v0/pipeline/steps/custom/sbom-drift-spec.yaml
+++ b/v0/pipeline/steps/custom/sbom-drift-spec.yaml
@@ -1,0 +1,6 @@
+title: SbomDriftSpec
+type: object
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for SbomSourceriftSpec

--- a/v0/pipeline/steps/custom/sbom-drift.yaml
+++ b/v0/pipeline/steps/custom/sbom-drift.yaml
@@ -8,5 +8,15 @@ properties:
     enum:
       - baseline
       - last_generated_sbom
+      - repository
   description:
     desc: This is the description for SbomOrchestrationTool
+allOf:
+  - if:
+      properties:
+        base:
+          const: repository
+    then:
+      properties:
+        spec:
+          $ref: repository-sbom-drift.yaml

--- a/v0/pipeline/steps/custom/sbom-source.yaml
+++ b/v0/pipeline/steps/custom/sbom-source.yaml
@@ -7,6 +7,7 @@ properties:
     type: string
     enum:
     - image
+    - repository
   description:
     desc: This is the description for SbomSource
 $schema: http://json-schema.org/draft-07/schema#
@@ -19,3 +20,12 @@ allOf:
     properties:
       spec:
         $ref: image-sbom-source.yaml
+- if:
+    properties:
+      type:
+        const: repository
+  then:
+    properties:
+      spec:
+        $ref: repository-sbom-source.yaml
+

--- a/v0/template.json
+++ b/v0/template.json
@@ -29493,7 +29493,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "image" ]
+                "enum" : [ "image", "repository" ]
               },
               "description" : {
                 "desc" : "This is the description for SbomSource"
@@ -29512,6 +29512,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/ImageSbomSource"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "repository"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySbomSource"
                   }
                 }
               }
@@ -29547,6 +29562,39 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for SbomSourceSpec"
+              }
+            }
+          },
+          "RepositorySbomSource" : {
+            "title" : "RepositorySbomSource",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "url", "path", "variant_type", "variant" ],
+              "properties" : {
+                "url" : {
+                  "type" : "string"
+                },
+                "path" : {
+                  "type" : "string"
+                },
+                "variant_type" : {
+                  "type" : "string",
+                  "enum" : [ "branch", "git_tag", "commit" ]
+                },
+                "variant" : {
+                  "type" : "string"
+                },
+                "cloned_codebase" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for RepositorySbomSource"
               }
             }
           },
@@ -29742,10 +29790,60 @@
             "properties" : {
               "base" : {
                 "type" : "string",
-                "enum" : [ "baseline", "last_generated_sbom" ]
+                "enum" : [ "baseline", "last_generated_sbom", "repository" ]
               },
               "description" : {
                 "desc" : "This is the description for SbomOrchestrationTool"
+              }
+            },
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "base" : {
+                    "const" : "repository"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySbomDrift"
+                  }
+                }
+              }
+            } ]
+          },
+          "RepositorySbomDrift" : {
+            "title" : "RepositorySbomDrift",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomDriftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "variant_type", "variant" ],
+              "properties" : {
+                "variant_type" : {
+                  "type" : "string",
+                  "enum" : [ "branch", "git_tag", "commit" ]
+                },
+                "variant" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for RepositorySbomDrift"
+              }
+            }
+          },
+          "SbomDriftSpec" : {
+            "title" : "SbomDriftSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SbomSourceDriftSpec"
               }
             }
           },


### PR DESCRIPTION
New Orchestration Step Yaml

```
step:
  type: SscaOrchestration
  name: SscaOrchestration
  identifier: SscaOrchestration
  spec:
    mode: generation
    source:
      type: image | repository #This is repository case
      spec:
        url: https://github.com/harness/harness-core
        path: /ssca-manager
        variant_type: git-branch | git-tag | commit
        variant: develop
        cloned_codebase: default=/harness
      type: Syft
      spec:
        format: cyclonedx-json | spdx-json
    attestation: 
      type: cosign
      spec:
        privateKey: text_cosign_private_key
        password: text_cosign_password
    sbom_drift:
      base: baseline | last_generated_sbom | repository  #This is custom_tag case
      spec:
        variant: develop
        variant_type: branch
```

Changes Done:

- Adding new source type `repository` and corresponding spec.
- Adding new sbom_drift type `repository` and corresponding spec