### PR TITLE
fix: [CDS-83957]: Fix unable to set stackName and samVersion as runti…

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -47931,22 +47931,11 @@
                   } ]
                 },
                 "samVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 },
                 "stackName" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string",
+                  "minLength" : 1
                 }
               }
             } ],
@@ -48015,22 +48004,11 @@
                 } ]
               },
               "samVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "stackName" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string",
+                "minLength" : 1
               },
               "description" : {
                 "desc" : "This is the description for AwsSamDeployStepInfo"
@@ -55063,13 +55041,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -55137,13 +55109,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaDeployV2StepInfo"
@@ -55295,13 +55261,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -55369,13 +55329,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaPackageV2StepInfo"
@@ -55515,13 +55469,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -55577,13 +55525,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaPrepareRollbackV2StepInfo"
@@ -55723,13 +55665,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -55785,13 +55721,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaRollbackV2StepInfo"

--- a/v0/pipeline/steps/cd/aws-sam-deploy-step-info.yaml
+++ b/v0/pipeline/steps/cd/aws-sam-deploy-step-info.yaml
@@ -49,17 +49,10 @@ allOf:
         format: int32
       - type: string
     samVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
     stackName:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
+      minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -109,16 +102,9 @@ properties:
       format: int32
     - type: string
   samVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   stackName:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
+    minLength: 1
   description:
     desc: This is the description for AwsSamDeployStepInfo

--- a/v0/pipeline/steps/cd/serverless-aws-lambda-deploy-v2-step-info.yaml
+++ b/v0/pipeline/steps/cd/serverless-aws-lambda-deploy-v2-step-info.yaml
@@ -47,11 +47,7 @@ allOf:
         format: int32
       - type: string
     serverlessVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -99,10 +95,6 @@ properties:
       format: int32
     - type: string
   serverlessVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for ServerlessAwsLambdaDeployV2StepInfo

--- a/v0/pipeline/steps/cd/serverless-aws-lambda-package-v2-step-info.yaml
+++ b/v0/pipeline/steps/cd/serverless-aws-lambda-package-v2-step-info.yaml
@@ -47,11 +47,7 @@ allOf:
         format: int32
       - type: string
     serverlessVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -99,10 +95,6 @@ properties:
       format: int32
     - type: string
   serverlessVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for ServerlessAwsLambdaPackageV2StepInfo

--- a/v0/pipeline/steps/cd/serverless-aws-lambda-prepare-rollback-v2-step-info.yaml
+++ b/v0/pipeline/steps/cd/serverless-aws-lambda-prepare-rollback-v2-step-info.yaml
@@ -39,11 +39,7 @@ allOf:
         format: int32
       - type: string
     serverlessVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -83,10 +79,6 @@ properties:
       format: int32
     - type: string
   serverlessVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for ServerlessAwsLambdaPrepareRollbackV2StepInfo

--- a/v0/pipeline/steps/cd/serverless-aws-lambda-rollback-v2-step-info.yaml
+++ b/v0/pipeline/steps/cd/serverless-aws-lambda-rollback-v2-step-info.yaml
@@ -39,11 +39,7 @@ allOf:
         format: int32
       - type: string
     serverlessVersion:
-      oneOf:
-      - type: string
-      - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-        minLength: 1
+      type: string
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -83,10 +79,6 @@ properties:
       format: int32
     - type: string
   serverlessVersion:
-    oneOf:
-    - type: string
-    - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
-      minLength: 1
+    type: string
   description:
     desc: This is the description for ServerlessAwsLambdaRollbackV2StepInfo

--- a/v0/template.json
+++ b/v0/template.json
@@ -2921,22 +2921,11 @@
                   } ]
                 },
                 "samVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 },
                 "stackName" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string",
+                  "minLength" : 1
                 }
               }
             } ],
@@ -3005,22 +2994,11 @@
                 } ]
               },
               "samVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "stackName" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string",
+                "minLength" : 1
               },
               "description" : {
                 "desc" : "This is the description for AwsSamDeployStepInfo"
@@ -14701,13 +14679,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -14775,13 +14747,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaDeployV2StepInfo"
@@ -14921,13 +14887,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -14995,13 +14955,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaPackageV2StepInfo"
@@ -15129,13 +15083,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -15191,13 +15139,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaPrepareRollbackV2StepInfo"
@@ -15431,13 +15373,7 @@
                   } ]
                 },
                 "serverlessVersion" : {
-                  "oneOf" : [ {
-                    "type" : "string"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
+                  "type" : "string"
                 }
               }
             } ],
@@ -15493,13 +15429,7 @@
                 } ]
               },
               "serverlessVersion" : {
-                "oneOf" : [ {
-                  "type" : "string"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                  "minLength" : 1
-                } ]
+                "type" : "string"
               },
               "description" : {
                 "desc" : "This is the description for ServerlessAwsLambdaRollbackV2StepInfo"


### PR DESCRIPTION
…me input for AWS SAM deployment

Issue - Unable to set "stackName","samVersion" as runtime input value for AWS SAM deployment type.
Saving pipeline fails with the following error.
`stackName: should be valid to one and only one of the schemas but more than one schemas {{"type":"string"},{"type":"string","pattern":"^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$","minLength":1}} are valid`
This happens because for "<+input>", both the types are valid. It is also a string, and also a string following the pattern with length > minLength.

Fix - Setting the stackName, samVersion to be of type string only.
Since stackName is required, kept the minLength for it. samVersion is an optional field. 

Also made the change for serverlessVersion, which has the same issue. 

Testing notes - Tested the change locally by running a sam deployment with stackName as runtime input. 

