### PR TITLE
feat: [CDS-87603]: added targetedHosts to ssh infra AWS and Azure

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -3513,7 +3513,12 @@
                 },
                 "asgName" : {
                   "type" : "string"
-                }
+                },
+                "targetedHosts" : [ {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -3596,7 +3601,12 @@
                   }, {
                     "type" : "string"
                   } ]
-                }
+                },
+                "targetedHosts" : [ {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",

--- a/v0/pipeline/stages/cd/ssh-win-rm-aws-infrastructure.yaml
+++ b/v0/pipeline/stages/cd/ssh-win-rm-aws-infrastructure.yaml
@@ -29,6 +29,10 @@ allOf:
       minLength: 1
     asgName:
       type: string
+    targetedHosts:
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/stages/cd/ssh-win-rm-azure-infrastructure.yaml
+++ b/v0/pipeline/stages/cd/ssh-win-rm-azure-infrastructure.yaml
@@ -36,6 +36,10 @@ allOf:
         additionalProperties:
           type: string
       - type: string
+    targetedHosts:
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/template.json
+++ b/v0/template.json
@@ -65289,7 +65289,12 @@
                 },
                 "asgName" : {
                   "type" : "string"
-                }
+                },
+                "targetedHosts" : [ {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -65372,7 +65377,12 @@
                   }, {
                     "type" : "string"
                   } ]
-                }
+                },
+                "targetedHosts" : [ {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",

--- a/v1/pipeline/stages/cd/ssh-win-rm-aws-infrastructure.yaml
+++ b/v1/pipeline/stages/cd/ssh-win-rm-aws-infrastructure.yaml
@@ -29,6 +29,10 @@ allOf:
       minLength: 1
     asgName:
       type: string
+    targetedHosts:
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v1/pipeline/stages/cd/ssh-win-rm-azure-infrastructure.yaml
+++ b/v1/pipeline/stages/cd/ssh-win-rm-azure-infrastructure.yaml
@@ -36,6 +36,10 @@ allOf:
         additionalProperties:
           type: string
       - type: string
+    targetedHosts:
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:


### PR DESCRIPTION
added targetedHosts to ssh infra AWS and Azure

```
infrastructureDefinition:
  name: aws-infra
  identifier: awsinfra
  orgIdentifier: default
  projectIdentifier: alexc
  environmentRef: prod
  deploymentType: Ssh
  type: SshWinRmAws
  spec:
    credentialsRef: <+input>
    connectorRef: <+input>
    region: <+input>
    awsInstanceFilter:
      tags: <+input>
      vpcs: []
    hostConnectionType: PublicIP
    targetedHosts: <+input>
  allowSimultaneousDeployments: false
```

```
infrastructureDefinition:
  name: azure-infra
  identifier: azureinfra
  orgIdentifier: default
  projectIdentifier: alexc
  environmentRef: prod
  deploymentType: Ssh
  type: SshWinRmAzure
  spec:
    credentialsRef: <+input>
    connectorRef: <+input>
    subscriptionId: <+input>
    resourceGroup: <+input>
    tags: <+input>
    hostConnectionType: Hostname
    targetedHosts: <+input>
  allowSimultaneousDeployments: false
```