### PR TITLE
feat:[CDS-88674]: make non empty approval fields mandatory in V1

### DIFF
--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -9072,10 +9072,11 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "approvers" ],
+              "required" : [ "approvers", "message" ],
               "properties" : {
                 "callback_id" : {
-                  "type" : "string"
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z0-9_-]*(<\\+[^ ]+>)?[a-zA-Z0-9_.()-]*$"
                 },
                 "message" : {
                   "type" : "string",
@@ -9111,6 +9112,7 @@
           "ApproverInputInfo" : {
             "title" : "ApproverInputInfo",
             "type" : "object",
+            "required" : [ "name" ],
             "properties" : {
               "default" : {
                 "type" : "string"

--- a/v1/pipeline/steps/custom/approver-input-info.yaml
+++ b/v1/pipeline/steps/custom/approver-input-info.yaml
@@ -1,5 +1,7 @@
 title: ApproverInputInfo
 type: object
+required:
+  - name
 properties:
   default:
     type: string

--- a/v1/pipeline/steps/custom/harness-approval-step-info.yaml
+++ b/v1/pipeline/steps/custom/harness-approval-step-info.yaml
@@ -4,9 +4,11 @@ allOf:
 - type: object
   required:
   - approvers
+  - message
   properties:
     callback_id:
       type: string
+      pattern: "^[a-zA-Z0-9_-]*(<\\+[^ ]+>)?[a-zA-Z0-9_.()-]*$"
     message:
       type: string
       minLength: 1

--- a/v1/template.json
+++ b/v1/template.json
@@ -33068,10 +33068,11 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "approvers" ],
+              "required" : [ "approvers", "message" ],
               "properties" : {
                 "callback_id" : {
-                  "type" : "string"
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z0-9_-]*(<\\+[^ ]+>)?[a-zA-Z0-9_.()-]*$"
                 },
                 "message" : {
                   "type" : "string",
@@ -33107,6 +33108,7 @@
           "ApproverInputInfo" : {
             "title" : "ApproverInputInfo",
             "type" : "object",
+            "required" : [ "name" ],
             "properties" : {
               "default" : {
                 "type" : "string"


### PR DESCRIPTION
- approval message is not empty but not mandatory in V0 schema. We can't make it mandatory in V0, hence making it mandatory in V1. FE also mandates this field.
- similar case is with `approver input's name` field. [`FE ticket`](https://harness.atlassian.net/browse/CDS-88673) to make this field mandatory
- Additional a regex check which was missed in V1.
- Tested the changes locally