### PR TITLE
[feat]: [CDS-88257]: adding k8s traffic resource name field

### DIFF
--- a/v0/pipeline/steps/cd/k8s-traffic-routing-provider-base-spec.yaml
+++ b/v0/pipeline/steps/cd/k8s-traffic-routing-provider-base-spec.yaml
@@ -3,6 +3,8 @@ type: object
 allOf:
   - "$ref": "k8s-traffic-routing-destinations.yaml"
 properties:
+  name:
+    type: string
   routes:
     type: array
     items:

--- a/v1/pipeline/steps/cd/k8s-traffic-routing-provider-base-spec.yaml
+++ b/v1/pipeline/steps/cd/k8s-traffic-routing-provider-base-spec.yaml
@@ -3,6 +3,8 @@ type: object
 allOf:
   - "$ref": "k8s-traffic-routing-destinations.yaml"
 properties:
+  name:
+    type: string
   routes:
     type: array
     items:


### PR DESCRIPTION
Added a new field for k8s traffic routing which will be used to name the traffic routing resources during creation.