### PR TITLE
[feat]: [CDS-89237]: updating k8s traffic routing schema

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -41665,9 +41665,6 @@
           "K8sTrafficRoutingProviderBaseSpec" : {
             "title" : "K8sTrafficRoutingProviderBaseSpec",
             "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
-            } ],
             "required" : [ "name" ],
             "properties" : {
               "name" : {
@@ -41684,6 +41681,73 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpec" : {
+            "title" : "RouteSpec",
+            "type" : "object",
+            "required" : [ "route" ],
+            "properties" : {
+              "route" : {
+                "type" : "object",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecBase"
+                } ],
+                "required" : [ "type" ],
+                "properties" : {
+                  "type" : {
+                    "type" : "string",
+                    "enum" : [ "http" ]
+                  },
+                  "rules" : {
+                    "oneOf" : [ {
+                      "type" : "array",
+                      "items" : {
+                        "oneOf" : [ {
+                          "type" : "object",
+                          "required" : [ "rule" ],
+                          "properties" : {
+                            "rule" : {
+                              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingRouteRule"
+                            }
+                          },
+                          "$schema" : "http://json-schema.org/draft-07/schema#"
+                        }, {
+                          "type" : "string",
+                          "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                          "minLength" : 1
+                        } ]
+                      }
+                    }, {
+                      "type" : "string",
+                      "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                      "minLength" : 1
+                    } ]
+                  }
+                },
+                "$schema" : "http://json-schema.org/draft-07/schema#"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpecBase" : {
+            "title" : "RouteSpecBase",
+            "type" : "object",
+            "properties" : {
+              "route" : {
+                "type" : "object",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
+                } ],
+                "required" : [ "name" ],
+                "properties" : {
+                  "name" : {
+                    "type" : "string"
+                  }
+                },
+                "$schema" : "http://json-schema.org/draft-07/schema#"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -41724,50 +41788,6 @@
                   "weight" : {
                     "oneOf" : [ {
                       "type" : "number"
-                    }, {
-                      "type" : "string",
-                      "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                      "minLength" : 1
-                    } ]
-                  }
-                },
-                "$schema" : "http://json-schema.org/draft-07/schema#"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "RouteSpec" : {
-            "title" : "RouteSpec",
-            "type" : "object",
-            "required" : [ "route" ],
-            "properties" : {
-              "route" : {
-                "type" : "object",
-                "required" : [ "type" ],
-                "properties" : {
-                  "type" : {
-                    "type" : "string",
-                    "enum" : [ "http" ]
-                  },
-                  "rules" : {
-                    "oneOf" : [ {
-                      "type" : "array",
-                      "items" : {
-                        "oneOf" : [ {
-                          "type" : "object",
-                          "required" : [ "rule" ],
-                          "properties" : {
-                            "rule" : {
-                              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingRouteRule"
-                            }
-                          },
-                          "$schema" : "http://json-schema.org/draft-07/schema#"
-                        }, {
-                          "type" : "string",
-                          "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                          "minLength" : 1
-                        } ]
-                      }
                     }, {
                       "type" : "string",
                       "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
@@ -56442,7 +56462,7 @@
                   "then" : {
                     "properties" : {
                       "trafficRouting" : {
-                        "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
+                        "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingInherit"
                       }
                     }
                   }
@@ -56467,6 +56487,34 @@
                 "desc" : "This is the description for K8sTrafficRoutingStepInfo"
               }
             }
+          },
+          "K8sTrafficRoutingInherit" : {
+            "title" : "K8sTrafficRoutingInherit",
+            "type" : "object",
+            "required" : [ "routes" ],
+            "properties" : {
+              "routes" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecInherit"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpecInherit" : {
+            "title" : "RouteSpecInherit",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecBase"
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "DownloadAwsS3StepNode" : {
             "title" : "DownloadAwsS3StepNode",

--- a/v0/pipeline/steps/cd/k8s-route-spec-base.yaml
+++ b/v0/pipeline/steps/cd/k8s-route-spec-base.yaml
@@ -1,0 +1,14 @@
+title: RouteSpecBase
+type: object
+properties:
+  route:
+    type: object
+    allOf:
+      - "$ref": "k8s-traffic-routing-destinations.yaml"
+    required:
+      - name
+    properties:
+      name:
+        type: string
+    $schema: http://json-schema.org/draft-07/schema#
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/steps/cd/k8s-route-spec-inherit.yaml
+++ b/v0/pipeline/steps/cd/k8s-route-spec-inherit.yaml
@@ -1,0 +1,5 @@
+title: RouteSpecInherit
+type: object
+allOf:
+  - "$ref": "k8s-route-spec-base.yaml"
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/steps/cd/k8s-route-spec.yaml
+++ b/v0/pipeline/steps/cd/k8s-route-spec.yaml
@@ -5,6 +5,8 @@ required:
 properties:
   route:
     type: object
+    allOf:
+      - "$ref": "k8s-route-spec-base.yaml"
     required:
       - type
     properties:

--- a/v0/pipeline/steps/cd/k8s-traffic-routing-spec-inherit.yaml
+++ b/v0/pipeline/steps/cd/k8s-traffic-routing-spec-inherit.yaml
@@ -1,15 +1,13 @@
-title: K8sTrafficRoutingProviderBaseSpec
+title: K8sTrafficRoutingInherit
 type: object
 required:
-  - name
+  - routes
 properties:
-  name:
-    type: string
   routes:
     oneOf:
       - type: array
         items:
-          "$ref": "k8s-route-spec.yaml"
+          "$ref": "k8s-route-spec-inherit.yaml"
       - type: string
         pattern: "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$"
         minLength: 1

--- a/v0/pipeline/steps/cd/k8s-traffic-routing-step-info.yaml
+++ b/v0/pipeline/steps/cd/k8s-traffic-routing-step-info.yaml
@@ -58,7 +58,7 @@ properties:
         then:
           properties:
             trafficRouting:
-              "$ref": "k8s-traffic-routing-destinations.yaml"
+              "$ref": "k8s-traffic-routing-spec-inherit.yaml"
       - if:
           properties:
             type:

--- a/v0/template.json
+++ b/v0/template.json
@@ -12690,9 +12690,6 @@
           "K8sTrafficRoutingProviderBaseSpec" : {
             "title" : "K8sTrafficRoutingProviderBaseSpec",
             "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
-            } ],
             "required" : [ "name" ],
             "properties" : {
               "name" : {
@@ -12709,6 +12706,73 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpec" : {
+            "title" : "RouteSpec",
+            "type" : "object",
+            "required" : [ "route" ],
+            "properties" : {
+              "route" : {
+                "type" : "object",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecBase"
+                } ],
+                "required" : [ "type" ],
+                "properties" : {
+                  "type" : {
+                    "type" : "string",
+                    "enum" : [ "http" ]
+                  },
+                  "rules" : {
+                    "oneOf" : [ {
+                      "type" : "array",
+                      "items" : {
+                        "oneOf" : [ {
+                          "type" : "object",
+                          "required" : [ "rule" ],
+                          "properties" : {
+                            "rule" : {
+                              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingRouteRule"
+                            }
+                          },
+                          "$schema" : "http://json-schema.org/draft-07/schema#"
+                        }, {
+                          "type" : "string",
+                          "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                          "minLength" : 1
+                        } ]
+                      }
+                    }, {
+                      "type" : "string",
+                      "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                      "minLength" : 1
+                    } ]
+                  }
+                },
+                "$schema" : "http://json-schema.org/draft-07/schema#"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpecBase" : {
+            "title" : "RouteSpecBase",
+            "type" : "object",
+            "properties" : {
+              "route" : {
+                "type" : "object",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
+                } ],
+                "required" : [ "name" ],
+                "properties" : {
+                  "name" : {
+                    "type" : "string"
+                  }
+                },
+                "$schema" : "http://json-schema.org/draft-07/schema#"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -12749,50 +12813,6 @@
                   "weight" : {
                     "oneOf" : [ {
                       "type" : "number"
-                    }, {
-                      "type" : "string",
-                      "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                      "minLength" : 1
-                    } ]
-                  }
-                },
-                "$schema" : "http://json-schema.org/draft-07/schema#"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "RouteSpec" : {
-            "title" : "RouteSpec",
-            "type" : "object",
-            "required" : [ "route" ],
-            "properties" : {
-              "route" : {
-                "type" : "object",
-                "required" : [ "type" ],
-                "properties" : {
-                  "type" : {
-                    "type" : "string",
-                    "enum" : [ "http" ]
-                  },
-                  "rules" : {
-                    "oneOf" : [ {
-                      "type" : "array",
-                      "items" : {
-                        "oneOf" : [ {
-                          "type" : "object",
-                          "required" : [ "rule" ],
-                          "properties" : {
-                            "rule" : {
-                              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingRouteRule"
-                            }
-                          },
-                          "$schema" : "http://json-schema.org/draft-07/schema#"
-                        }, {
-                          "type" : "string",
-                          "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                          "minLength" : 1
-                        } ]
-                      }
                     }, {
                       "type" : "string",
                       "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
@@ -21233,7 +21253,7 @@
                   "then" : {
                     "properties" : {
                       "trafficRouting" : {
-                        "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
+                        "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingInherit"
                       }
                     }
                   }
@@ -21258,6 +21278,34 @@
                 "desc" : "This is the description for K8sTrafficRoutingStepInfo"
               }
             }
+          },
+          "K8sTrafficRoutingInherit" : {
+            "title" : "K8sTrafficRoutingInherit",
+            "type" : "object",
+            "required" : [ "routes" ],
+            "properties" : {
+              "routes" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecInherit"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpecInherit" : {
+            "title" : "RouteSpecInherit",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecBase"
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "DownloadAwsS3StepNode_template" : {
             "title" : "DownloadAwsS3StepNode_template",

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -33664,9 +33664,6 @@
           "K8sTrafficRoutingProviderBaseSpec" : {
             "title" : "K8sTrafficRoutingProviderBaseSpec",
             "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
-            } ],
             "required" : [ "name" ],
             "properties" : {
               "name" : {
@@ -33683,6 +33680,73 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpec" : {
+            "title" : "RouteSpec",
+            "type" : "object",
+            "required" : [ "route" ],
+            "properties" : {
+              "route" : {
+                "type" : "object",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecBase"
+                } ],
+                "required" : [ "type" ],
+                "properties" : {
+                  "type" : {
+                    "type" : "string",
+                    "enum" : [ "http" ]
+                  },
+                  "rules" : {
+                    "oneOf" : [ {
+                      "type" : "array",
+                      "items" : {
+                        "oneOf" : [ {
+                          "type" : "object",
+                          "required" : [ "rule" ],
+                          "properties" : {
+                            "rule" : {
+                              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingRouteRule"
+                            }
+                          },
+                          "$schema" : "http://json-schema.org/draft-07/schema#"
+                        }, {
+                          "type" : "string",
+                          "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                          "minLength" : 1
+                        } ]
+                      }
+                    }, {
+                      "type" : "string",
+                      "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                      "minLength" : 1
+                    } ]
+                  }
+                },
+                "$schema" : "http://json-schema.org/draft-07/schema#"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpecBase" : {
+            "title" : "RouteSpecBase",
+            "type" : "object",
+            "properties" : {
+              "route" : {
+                "type" : "object",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
+                } ],
+                "required" : [ "name" ],
+                "properties" : {
+                  "name" : {
+                    "type" : "string"
+                  }
+                },
+                "$schema" : "http://json-schema.org/draft-07/schema#"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -33723,50 +33787,6 @@
                   "weight" : {
                     "oneOf" : [ {
                       "type" : "number"
-                    }, {
-                      "type" : "string",
-                      "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                      "minLength" : 1
-                    } ]
-                  }
-                },
-                "$schema" : "http://json-schema.org/draft-07/schema#"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "RouteSpec" : {
-            "title" : "RouteSpec",
-            "type" : "object",
-            "required" : [ "route" ],
-            "properties" : {
-              "route" : {
-                "type" : "object",
-                "required" : [ "type" ],
-                "properties" : {
-                  "type" : {
-                    "type" : "string",
-                    "enum" : [ "http" ]
-                  },
-                  "rules" : {
-                    "oneOf" : [ {
-                      "type" : "array",
-                      "items" : {
-                        "oneOf" : [ {
-                          "type" : "object",
-                          "required" : [ "rule" ],
-                          "properties" : {
-                            "rule" : {
-                              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingRouteRule"
-                            }
-                          },
-                          "$schema" : "http://json-schema.org/draft-07/schema#"
-                        }, {
-                          "type" : "string",
-                          "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                          "minLength" : 1
-                        } ]
-                      }
                     }, {
                       "type" : "string",
                       "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
@@ -48250,7 +48270,7 @@
                   "then" : {
                     "properties" : {
                       "trafficRouting" : {
-                        "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
+                        "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingInherit"
                       }
                     }
                   }
@@ -48325,6 +48345,34 @@
                 "desc" : "This is the description for K8sTrafficRoutingStepInfo"
               }
             }
+          },
+          "K8sTrafficRoutingInherit" : {
+            "title" : "K8sTrafficRoutingInherit",
+            "type" : "object",
+            "required" : [ "routes" ],
+            "properties" : {
+              "routes" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecInherit"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpecInherit" : {
+            "title" : "RouteSpecInherit",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecBase"
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "StepGroupNode" : {
             "title" : "StepGroupNode",

--- a/v1/pipeline/steps/cd/k8s-route-spec-base.yaml
+++ b/v1/pipeline/steps/cd/k8s-route-spec-base.yaml
@@ -1,0 +1,14 @@
+title: RouteSpecBase
+type: object
+properties:
+  route:
+    type: object
+    allOf:
+      - "$ref": "k8s-traffic-routing-destinations.yaml"
+    required:
+      - name
+    properties:
+      name:
+        type: string
+    $schema: http://json-schema.org/draft-07/schema#
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/steps/cd/k8s-route-spec-inherit.yaml
+++ b/v1/pipeline/steps/cd/k8s-route-spec-inherit.yaml
@@ -1,0 +1,5 @@
+title: RouteSpecInherit
+type: object
+allOf:
+  - "$ref": "k8s-route-spec-base.yaml"
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/steps/cd/k8s-route-spec.yaml
+++ b/v1/pipeline/steps/cd/k8s-route-spec.yaml
@@ -5,6 +5,8 @@ required:
 properties:
   route:
     type: object
+    allOf:
+      - "$ref": "k8s-route-spec-base.yaml"
     required:
       - type
     properties:

--- a/v1/pipeline/steps/cd/k8s-traffic-routing-provider-base-spec.yaml
+++ b/v1/pipeline/steps/cd/k8s-traffic-routing-provider-base-spec.yaml
@@ -1,7 +1,5 @@
 title: K8sTrafficRoutingProviderBaseSpec
 type: object
-allOf:
-  - "$ref": "k8s-traffic-routing-destinations.yaml"
 required:
   - name
 properties:

--- a/v1/pipeline/steps/cd/k8s-traffic-routing-spec-inherit.yaml
+++ b/v1/pipeline/steps/cd/k8s-traffic-routing-spec-inherit.yaml
@@ -1,15 +1,13 @@
-title: K8sTrafficRoutingProviderBaseSpec
+title: K8sTrafficRoutingInherit
 type: object
 required:
-  - name
+  - routes
 properties:
-  name:
-    type: string
   routes:
     oneOf:
       - type: array
         items:
-          "$ref": "k8s-route-spec.yaml"
+          "$ref": "k8s-route-spec-inherit.yaml"
       - type: string
         pattern: "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$"
         minLength: 1

--- a/v1/pipeline/steps/cd/k8s-traffic-routing-step-info.yaml
+++ b/v1/pipeline/steps/cd/k8s-traffic-routing-step-info.yaml
@@ -28,7 +28,7 @@ allOf:
         then:
           properties:
             trafficRouting:
-              "$ref": "k8s-traffic-routing-destinations.yaml"
+              "$ref": "k8s-traffic-routing-spec-inherit.yaml"
       - if:
           properties:
             type:

--- a/v1/template.json
+++ b/v1/template.json
@@ -14699,9 +14699,6 @@
           "K8sTrafficRoutingProviderBaseSpec" : {
             "title" : "K8sTrafficRoutingProviderBaseSpec",
             "type" : "object",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
-            } ],
             "required" : [ "name" ],
             "properties" : {
               "name" : {
@@ -14718,6 +14715,73 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpec" : {
+            "title" : "RouteSpec",
+            "type" : "object",
+            "required" : [ "route" ],
+            "properties" : {
+              "route" : {
+                "type" : "object",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecBase"
+                } ],
+                "required" : [ "type" ],
+                "properties" : {
+                  "type" : {
+                    "type" : "string",
+                    "enum" : [ "http" ]
+                  },
+                  "rules" : {
+                    "oneOf" : [ {
+                      "type" : "array",
+                      "items" : {
+                        "oneOf" : [ {
+                          "type" : "object",
+                          "required" : [ "rule" ],
+                          "properties" : {
+                            "rule" : {
+                              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingRouteRule"
+                            }
+                          },
+                          "$schema" : "http://json-schema.org/draft-07/schema#"
+                        }, {
+                          "type" : "string",
+                          "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                          "minLength" : 1
+                        } ]
+                      }
+                    }, {
+                      "type" : "string",
+                      "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                      "minLength" : 1
+                    } ]
+                  }
+                },
+                "$schema" : "http://json-schema.org/draft-07/schema#"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpecBase" : {
+            "title" : "RouteSpecBase",
+            "type" : "object",
+            "properties" : {
+              "route" : {
+                "type" : "object",
+                "allOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
+                } ],
+                "required" : [ "name" ],
+                "properties" : {
+                  "name" : {
+                    "type" : "string"
+                  }
+                },
+                "$schema" : "http://json-schema.org/draft-07/schema#"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
@@ -14758,50 +14822,6 @@
                   "weight" : {
                     "oneOf" : [ {
                       "type" : "number"
-                    }, {
-                      "type" : "string",
-                      "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                      "minLength" : 1
-                    } ]
-                  }
-                },
-                "$schema" : "http://json-schema.org/draft-07/schema#"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "RouteSpec" : {
-            "title" : "RouteSpec",
-            "type" : "object",
-            "required" : [ "route" ],
-            "properties" : {
-              "route" : {
-                "type" : "object",
-                "required" : [ "type" ],
-                "properties" : {
-                  "type" : {
-                    "type" : "string",
-                    "enum" : [ "http" ]
-                  },
-                  "rules" : {
-                    "oneOf" : [ {
-                      "type" : "array",
-                      "items" : {
-                        "oneOf" : [ {
-                          "type" : "object",
-                          "required" : [ "rule" ],
-                          "properties" : {
-                            "rule" : {
-                              "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingRouteRule"
-                            }
-                          },
-                          "$schema" : "http://json-schema.org/draft-07/schema#"
-                        }, {
-                          "type" : "string",
-                          "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
-                          "minLength" : 1
-                        } ]
-                      }
                     }, {
                       "type" : "string",
                       "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
@@ -23185,7 +23205,7 @@
                   "then" : {
                     "properties" : {
                       "trafficRouting" : {
-                        "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingDestinations"
+                        "$ref" : "#/definitions/pipeline/steps/cd/K8sTrafficRoutingInherit"
                       }
                     }
                   }
@@ -23260,6 +23280,34 @@
                 "desc" : "This is the description for K8sTrafficRoutingStepInfo"
               }
             }
+          },
+          "K8sTrafficRoutingInherit" : {
+            "title" : "K8sTrafficRoutingInherit",
+            "type" : "object",
+            "required" : [ "routes" ],
+            "properties" : {
+              "routes" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecInherit"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "RouteSpecInherit" : {
+            "title" : "RouteSpecInherit",
+            "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/RouteSpecBase"
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "DownloadAwsS3StepNode_template" : {
             "title" : "DownloadAwsS3StepNode_template",


### PR DESCRIPTION
Updating k8s traffic routing schema

1. Moving destinations from global to under each of the route instances
2. Adding name field for each of the routes