### PR TITLE
[feat]: [CDS-91902] : adding inputs in infra and service entity schema

### DIFF
--- a/v1/examples/cd_entities/infra-def-entity.yaml
+++ b/v1/examples/cd_entities/infra-def-entity.yaml
@@ -1,13 +1,23 @@
 version: 1
 kind: infra-def
-type: kubernetes-gcp
 spec:
-  connector: account.k8s_gcp
-  cluster: prod2
-  namespace: default
-  release: release-<+INFRA_KEY_SHORT_ID>
-parallel: true
-variables:
-  tag:
-    type: String
-    value: 1.9.0
+  type: kubernetes-gcp
+  spec:
+    connector: account.k8s_gcp
+    cluster: prod2
+    namespace: <+inputs.input_1>
+    release: release-<+INFRA_KEY_SHORT_ID>
+  parallel: true
+  variables:
+    tag:
+      type: String
+      value: 1.9.0
+  inputs:
+    input_1:
+      type: string
+      default: abc
+      validator:
+        allowed:
+          - a
+          - b
+          - abc

--- a/v1/examples/cd_entities/service-entity.yaml
+++ b/v1/examples/cd_entities/service-entity.yaml
@@ -29,7 +29,7 @@ spec:
         type: docker
         spec:
           connector: harness-docker
-          location: /library/mongo:<+inputs.mongo_tag>
+          location: /library/mongo:<+inputs.input_1>
       - id: prometheus
         sidecar: true                   # optional
         type: docker
@@ -46,3 +46,12 @@ spec:
     tag:
       type: String
       value: 1.9.0
+  inputs:
+    input_1:
+      type: string
+      default: abc
+      validator:
+        allowed:
+          - a
+          - b
+          - abc

--- a/v1/infra.json
+++ b/v1/infra.json
@@ -60,6 +60,28 @@
                 "$ref" : "#/definitions/pipeline/common/SecretVariable"
               } ]
             }
+          },
+          "inputs" : {
+            "type" : "object",
+            "description" : "Inputs defines the infrastructure input parameters.",
+            "additionalProperties" : {
+              "oneOf" : [ {
+                "$ref" : "#/definitions/pipeline/common/StringInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/NumberInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/ArrayInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/BooleanInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/ObjectInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/SecretInput"
+              } ]
+            },
+            "propertyNames" : {
+              "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0,127}$"
+            }
           }
         },
         "allOf" : [ {
@@ -406,6 +428,285 @@
                     "dependsOn" : [ "type" ]
                   }
                 }
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "StringInput" : {
+          "title" : "StringInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "string"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "string" ]
+              },
+              "value" : {
+                "type" : "string"
+              },
+              "validator" : {
+                "type" : "object",
+                "oneOf" : [ {
+                  "allOf" : [ {
+                    "properties" : {
+                      "allowed" : {
+                        "description" : "defines allowed values for an input",
+                        "type" : "array",
+                        "items" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  } ],
+                  "required" : [ "allowed" ]
+                }, {
+                  "allOf" : [ {
+                    "properties" : {
+                      "regex" : {
+                        "description" : "defines regex pattern for an input value",
+                        "type" : "string"
+                      }
+                    }
+                  } ],
+                  "required" : [ "regex" ]
+                } ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "Input" : {
+          "title" : "Input",
+          "type" : "object",
+          "discriminator" : "type",
+          "description" : "Input defines an input parameter.",
+          "properties" : {
+            "type" : {
+              "description" : "Type defines the input type.",
+              "type" : "string",
+              "enum" : [ "string", "number", "boolean", "array", "object", "secret" ]
+            },
+            "desc" : {
+              "type" : "string",
+              "description" : "Desc defines the input description."
+            },
+            "required" : {
+              "type" : "boolean",
+              "description" : "Required indicates the input is required."
+            },
+            "execution_input" : {
+              "description" : "a boolean that defines whether the value is an execution input",
+              "type" : "boolean",
+              "default" : false
+            }
+          }
+        },
+        "NumberInput" : {
+          "title" : "NumberInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "number",
+                "format" : "double"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "number" ]
+              },
+              "value" : {
+                "oneOf" : [ {
+                  "type" : "number",
+                  "format" : "double"
+                }, {
+                  "type" : "string",
+                  "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+                } ]
+              },
+              "validator" : {
+                "type" : "object",
+                "oneOf" : [ {
+                  "allOf" : [ {
+                    "properties" : {
+                      "allowed" : {
+                        "description" : "defines allowed values for an input",
+                        "type" : "array",
+                        "items" : {
+                          "oneOf" : [ {
+                            "type" : "number",
+                            "format" : "double"
+                          }, {
+                            "type" : "string",
+                            "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+                          } ]
+                        }
+                      }
+                    }
+                  } ],
+                  "required" : [ "allowed" ]
+                }, {
+                  "allOf" : [ {
+                    "properties" : {
+                      "regex" : {
+                        "description" : "defines regex pattern for an input value",
+                        "type" : "string"
+                      }
+                    }
+                  } ],
+                  "required" : [ "regex" ]
+                } ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "ArrayInput" : {
+          "title" : "ArrayInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "array"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "array" ]
+              },
+              "value" : {
+                "type" : "array"
+              },
+              "validator" : {
+                "type" : "object",
+                "oneOf" : [ {
+                  "allOf" : [ {
+                    "properties" : {
+                      "allowed" : {
+                        "description" : "defines allowed values for an input",
+                        "type" : "array",
+                        "items" : {
+                          "type" : "array"
+                        }
+                      }
+                    }
+                  } ],
+                  "required" : [ "allowed" ]
+                }, {
+                  "allOf" : [ {
+                    "properties" : {
+                      "regex" : {
+                        "description" : "defines regex pattern for an input value",
+                        "type" : "string"
+                      }
+                    }
+                  } ],
+                  "required" : [ "regex" ]
+                } ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "BooleanInput" : {
+          "title" : "BooleanInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "boolean"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "boolean" ]
+              },
+              "value" : {
+                "type" : "boolean"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "ObjectInput" : {
+          "title" : "ObjectInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "object"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "object" ]
+              },
+              "value" : {
+                "type" : "object"
+              },
+              "validator" : {
+                "type" : "object",
+                "oneOf" : [ {
+                  "allOf" : [ {
+                    "properties" : {
+                      "allowed" : {
+                        "description" : "defines allowed values for an input",
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object"
+                        }
+                      }
+                    }
+                  } ],
+                  "required" : [ "allowed" ]
+                }, {
+                  "allOf" : [ {
+                    "properties" : {
+                      "regex" : {
+                        "description" : "defines regex pattern for an input value",
+                        "type" : "string"
+                      }
+                    }
+                  } ],
+                  "required" : [ "regex" ]
+                } ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "SecretInput" : {
+          "title" : "SecretInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "string"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "secret" ]
+              },
+              "value" : {
+                "type" : "string"
               }
             }
           } ],

--- a/v1/infraStructureEntity/infra-def-spec.yaml
+++ b/v1/infraStructureEntity/infra-def-spec.yaml
@@ -25,6 +25,19 @@ properties:
         - "$ref": ../pipeline/common/boolean-variable.yaml
         - "$ref": ../pipeline/common/object-variable.yaml
         - "$ref": ../pipeline/common/secret-variable.yaml
+  inputs:
+    type: object
+    description: Inputs defines the infrastructure input parameters.
+    additionalProperties:
+      oneOf:
+        - "$ref": ../pipeline/common/string-input.yaml
+        - "$ref": ../pipeline/common/number-input.yaml
+        - "$ref": ../pipeline/common/array-input.yaml
+        - "$ref": ../pipeline/common/boolean-input.yaml
+        - "$ref": ../pipeline/common/object-input.yaml
+        - "$ref": ../pipeline/common/secret-input.yaml
+    propertyNames:
+      pattern: "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0,127}$"
 allOf:
   - if:
       properties:

--- a/v1/service.json
+++ b/v1/service.json
@@ -33,6 +33,28 @@
           "type" : {
             "type" : "string",
             "enum" : [ "kubernetes" ]
+          },
+          "inputs" : {
+            "type" : "object",
+            "description" : "Inputs defines the service input parameters.",
+            "additionalProperties" : {
+              "oneOf" : [ {
+                "$ref" : "#/definitions/pipeline/common/StringInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/NumberInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/ArrayInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/BooleanInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/ObjectInput"
+              }, {
+                "$ref" : "#/definitions/pipeline/common/SecretInput"
+              } ]
+            },
+            "propertyNames" : {
+              "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0,127}$"
+            }
           }
         },
         "allOf" : [ {
@@ -430,6 +452,285 @@
     },
     "pipeline" : {
       "common" : {
+        "StringInput" : {
+          "title" : "StringInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "string"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "string" ]
+              },
+              "value" : {
+                "type" : "string"
+              },
+              "validator" : {
+                "type" : "object",
+                "oneOf" : [ {
+                  "allOf" : [ {
+                    "properties" : {
+                      "allowed" : {
+                        "description" : "defines allowed values for an input",
+                        "type" : "array",
+                        "items" : {
+                          "type" : "string"
+                        }
+                      }
+                    }
+                  } ],
+                  "required" : [ "allowed" ]
+                }, {
+                  "allOf" : [ {
+                    "properties" : {
+                      "regex" : {
+                        "description" : "defines regex pattern for an input value",
+                        "type" : "string"
+                      }
+                    }
+                  } ],
+                  "required" : [ "regex" ]
+                } ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "Input" : {
+          "title" : "Input",
+          "type" : "object",
+          "discriminator" : "type",
+          "description" : "Input defines an input parameter.",
+          "properties" : {
+            "type" : {
+              "description" : "Type defines the input type.",
+              "type" : "string",
+              "enum" : [ "string", "number", "boolean", "array", "object", "secret" ]
+            },
+            "desc" : {
+              "type" : "string",
+              "description" : "Desc defines the input description."
+            },
+            "required" : {
+              "type" : "boolean",
+              "description" : "Required indicates the input is required."
+            },
+            "execution_input" : {
+              "description" : "a boolean that defines whether the value is an execution input",
+              "type" : "boolean",
+              "default" : false
+            }
+          }
+        },
+        "NumberInput" : {
+          "title" : "NumberInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "number",
+                "format" : "double"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "number" ]
+              },
+              "value" : {
+                "oneOf" : [ {
+                  "type" : "number",
+                  "format" : "double"
+                }, {
+                  "type" : "string",
+                  "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+                } ]
+              },
+              "validator" : {
+                "type" : "object",
+                "oneOf" : [ {
+                  "allOf" : [ {
+                    "properties" : {
+                      "allowed" : {
+                        "description" : "defines allowed values for an input",
+                        "type" : "array",
+                        "items" : {
+                          "oneOf" : [ {
+                            "type" : "number",
+                            "format" : "double"
+                          }, {
+                            "type" : "string",
+                            "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+                          } ]
+                        }
+                      }
+                    }
+                  } ],
+                  "required" : [ "allowed" ]
+                }, {
+                  "allOf" : [ {
+                    "properties" : {
+                      "regex" : {
+                        "description" : "defines regex pattern for an input value",
+                        "type" : "string"
+                      }
+                    }
+                  } ],
+                  "required" : [ "regex" ]
+                } ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "ArrayInput" : {
+          "title" : "ArrayInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "array"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "array" ]
+              },
+              "value" : {
+                "type" : "array"
+              },
+              "validator" : {
+                "type" : "object",
+                "oneOf" : [ {
+                  "allOf" : [ {
+                    "properties" : {
+                      "allowed" : {
+                        "description" : "defines allowed values for an input",
+                        "type" : "array",
+                        "items" : {
+                          "type" : "array"
+                        }
+                      }
+                    }
+                  } ],
+                  "required" : [ "allowed" ]
+                }, {
+                  "allOf" : [ {
+                    "properties" : {
+                      "regex" : {
+                        "description" : "defines regex pattern for an input value",
+                        "type" : "string"
+                      }
+                    }
+                  } ],
+                  "required" : [ "regex" ]
+                } ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "BooleanInput" : {
+          "title" : "BooleanInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "boolean"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "boolean" ]
+              },
+              "value" : {
+                "type" : "boolean"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "ObjectInput" : {
+          "title" : "ObjectInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "object"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "object" ]
+              },
+              "value" : {
+                "type" : "object"
+              },
+              "validator" : {
+                "type" : "object",
+                "oneOf" : [ {
+                  "allOf" : [ {
+                    "properties" : {
+                      "allowed" : {
+                        "description" : "defines allowed values for an input",
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object"
+                        }
+                      }
+                    }
+                  } ],
+                  "required" : [ "allowed" ]
+                }, {
+                  "allOf" : [ {
+                    "properties" : {
+                      "regex" : {
+                        "description" : "defines regex pattern for an input value",
+                        "type" : "string"
+                      }
+                    }
+                  } ],
+                  "required" : [ "regex" ]
+                } ]
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "SecretInput" : {
+          "title" : "SecretInput",
+          "allOf" : [ {
+            "$ref" : "#/definitions/pipeline/common/Input"
+          }, {
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "default" : {
+                "type" : "string"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "secret" ]
+              },
+              "value" : {
+                "type" : "string"
+              }
+            }
+          } ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
         "StringVariable" : {
           "title" : "StringVariable",
           "allOf" : [ {

--- a/v1/serviceEntity/service-spec.yaml
+++ b/v1/serviceEntity/service-spec.yaml
@@ -8,6 +8,19 @@ properties:
     type: string
     enum:
     - kubernetes
+  inputs:
+    type: object
+    description: Inputs defines the service input parameters.
+    additionalProperties:
+      oneOf:
+        - "$ref": ../pipeline/common/string-input.yaml
+        - "$ref": ../pipeline/common/number-input.yaml
+        - "$ref": ../pipeline/common/array-input.yaml
+        - "$ref": ../pipeline/common/boolean-input.yaml
+        - "$ref": ../pipeline/common/object-input.yaml
+        - "$ref": ../pipeline/common/secret-input.yaml
+    propertyNames:
+      pattern: "^[a-zA-Z_][0-9a-zA-Z_\\.$-]{0,127}$"
 allOf:
 - if:
     properties:


### PR DESCRIPTION
infra
```
version: 1
kind: infra-def
spec:
  type: kubernetes-gcp
  spec:
    connector: account.k8s_gcp
    cluster: prod2
    namespace: <+inputs.input_1>
    release: release-<+INFRA_KEY_SHORT_ID>
  parallel: true
  variables:
    tag:
      type: String
      value: 1.9.0
  inputs:
    input_1:
      type: string
      default: abc
```

service 
```
version: 1
kind: service
type: native-helm
spec:
  variables:
    tag:
      type: String
      value: 1.9.0
  inputs:
    input_1:
      type: string
      default: abc
```