### PR TITLE
fix: [CDS-92236]: Improve yaml schema to prevent creation of invalid pipelines

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -556,6 +556,7 @@
         "stages" : {
           "type" : "object",
           "title" : "stages",
+          "propertyNames": {"enum": ["parallel", "stage"]},
           "properties" : {
             "parallel" : {
               "$ref" : "#/definitions/pipeline/stages/ParallelStageElementConfig"


### PR DESCRIPTION
Previously, a user would be able to create a pipeline with this yaml (yaml-schema validation would not throw an error):

```
pipeline:
  name: BrokenPipeline
  identifier: BrokenPipeline
  projectIdentifier: viniciusProject
  orgIdentifier: viniciusOrg
  tags: {}
  stages:
    - noMatterWhich:
        - keysYouUse:
            - stage1:
                name: stage1
                identifier: stage1
                description: ""
                type: Custom
                spec: {}
            - stage2:
                name: stage2
                identifier: stage2
                description: ""
                type: Custom
                spec: {}
            - stage3:
                name: stage3
                identifier: stage3
                description: ""
                type: Custom
                spec: {}
```

This yaml is not supported by us.

In this PR, we make a simple change to pipeline's yaml schema that prevents this kind of invalid pipeline from being created.

Testing:
Tested in local. Schema validation will now catch an error in the above pipeline yaml:
![image](https://github.com/harness/harness-schema/assets/109106581/5122a616-034e-40a1-b803-72165b7332a4)


ReleaseNotes summary needed? No

Is it new task type? No
Did you make changes to the code in a backward-compatible manner? Yes
Did you add a new class which is added in kryo serialization? - No
If the older version of pipeline-service creates the step parameter/outcomes/outputs/delegate task params and calls newer respective service, will it be okay? Yes
if the newer version of pipeline-service creates the step parameter/outcomes/outputs/delegate task params and calls older respective service, will it be okay? Yes
Did you set/unset thread context in existing codebase for Principal ? No
Did you add an enum(That too at end of list) → No
FeatureFlag Added/Removed -> No
Is the change impacting multiple service and breaking change/dependent? No
Verify Changes with affects any https://docs.google.com/spreadsheets/d/1m9pdEMoqvl-sa6JQDdvgzzOcDSfXgitrhCsUSNQNWgU/edit#gid=0: No
Will the new version of the delegate receive old version task and process? Yes
If new version of the pipeline-service receives response for the old task will it be able to handle it successfully? Yes
Did you make a change in delegate task which will be created in pipeline-services via grpc call to manager? No