### PR TITLE
feat: [CDS-89581]: Incorrect yaml generated for failure strategy

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -10010,6 +10010,68 @@
               "desc" : "This is the description for FailureStrategyActionConfig"
             }
           },
+          "$schema" : "http://json-schema.org/draft-07/schema#",
+          "allOf" : [ {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "Retry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/Retry"
+                }
+              }
+            }
+          } ]
+        },
+        "Retry" : {
+          "title" : "Retry",
+          "type" : "object",
+          "required" : [ "retryCount", "retryIntervals", "onRetryFailure" ],
+          "properties" : {
+            "retryCount" : {
+              "type" : "number",
+              "example" : 3
+            },
+            "retryIntervals" : {
+              "type" : "array",
+              "minItems" : 1,
+              "items" : {
+                "type" : "string",
+                "minLength" : 1,
+                "format" : "duration"
+              },
+              "example" : [ "5s", "10s", "20s" ]
+            },
+            "onRetryFailure" : {
+              "properties" : {
+                "action" : {
+                  "$ref" : "#/definitions/pipeline/common/OnRetryFailure"
+                }
+              }
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "OnRetryFailure" : {
+          "title" : "OnRetryFailure",
+          "type" : "object",
+          "description" : "Failure action post all retries",
+          "required" : [ "type" ],
+          "properties" : {
+            "type" : {
+              "description" : "Type defines failure strategy actions",
+              "type" : "string",
+              "enum" : [ "Ignore", "MarkAsSuccess", "Abort", "MarkAsFailure" ]
+            },
+            "description" : {
+              "desc" : "This is the description for onRetryFailure"
+            }
+          },
           "$schema" : "http://json-schema.org/draft-07/schema#"
         },
         "StrategyConfig" : {

--- a/v0/pipeline/common/failure-strategy-action-config.yaml
+++ b/v0/pipeline/common/failure-strategy-action-config.yaml
@@ -21,3 +21,14 @@ properties:
   description:
     desc: This is the description for FailureStrategyActionConfig
 $schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: Retry
+  then:
+    properties:
+      spec:
+        $ref: ./retry.yaml
+
+

--- a/v0/pipeline/common/on-retry-failure.yaml
+++ b/v0/pipeline/common/on-retry-failure.yaml
@@ -1,0 +1,17 @@
+title: OnRetryFailure
+type: object
+description: Failure action post all retries
+required:
+- type
+properties:
+  type:
+    description: Type defines failure strategy actions
+    type: string
+    enum:
+    - Ignore
+    - MarkAsSuccess
+    - Abort
+    - MarkAsFailure
+  description:
+    desc: This is the description for onRetryFailure
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/common/retry.yaml
+++ b/v0/pipeline/common/retry.yaml
@@ -1,0 +1,24 @@
+title: Retry
+type: object
+required:
+  - retryCount
+  - retryIntervals
+  - onRetryFailure
+properties:
+  retryCount:
+    type: number
+    example: 3
+  retryIntervals:
+    type: array
+    minItems: 1
+    items:
+      type: string
+      minLength: 1
+      format: duration
+    example: [5s, 10s, 20s]
+  onRetryFailure:
+    properties:
+      action:
+        $ref: ./on-retry-failure.yaml
+  
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/template.json
+++ b/v0/template.json
@@ -63771,6 +63771,68 @@
               "desc" : "This is the description for FailureStrategyActionConfig"
             }
           },
+          "$schema" : "http://json-schema.org/draft-07/schema#",
+          "allOf" : [ {
+            "if" : {
+              "properties" : {
+                "type" : {
+                  "const" : "Retry"
+                }
+              }
+            },
+            "then" : {
+              "properties" : {
+                "spec" : {
+                  "$ref" : "#/definitions/pipeline/common/Retry"
+                }
+              }
+            }
+          } ]
+        },
+        "Retry" : {
+          "title" : "Retry",
+          "type" : "object",
+          "required" : [ "retryCount", "retryIntervals", "onRetryFailure" ],
+          "properties" : {
+            "retryCount" : {
+              "type" : "number",
+              "example" : 3
+            },
+            "retryIntervals" : {
+              "type" : "array",
+              "minItems" : 1,
+              "items" : {
+                "type" : "string",
+                "minLength" : 1,
+                "format" : "duration"
+              },
+              "example" : [ "5s", "10s", "20s" ]
+            },
+            "onRetryFailure" : {
+              "properties" : {
+                "action" : {
+                  "$ref" : "#/definitions/pipeline/common/OnRetryFailure"
+                }
+              }
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "OnRetryFailure" : {
+          "title" : "OnRetryFailure",
+          "type" : "object",
+          "description" : "Failure action post all retries",
+          "required" : [ "type" ],
+          "properties" : {
+            "type" : {
+              "description" : "Type defines failure strategy actions",
+              "type" : "string",
+              "enum" : [ "Ignore", "MarkAsSuccess", "Abort", "MarkAsFailure" ]
+            },
+            "description" : {
+              "desc" : "This is the description for onRetryFailure"
+            }
+          },
           "$schema" : "http://json-schema.org/draft-07/schema#"
         },
         "StrategyConfig" : {


### PR DESCRIPTION
**Issue:** RetryInterval is not marked as a mandatory field which throws up an error later during plan creation.

**fix:** Added a schema validation to mark retryCount, retryIntervals and Post retry strategies as mandatory fields

**Testing:** 

1. Passed an empty array in retryIntervals

<img width="1358" alt="image" src="https://github.com/harness/harness-schema/assets/142220748/77fbf5dd-3577-475b-8119-40ecb21d291a">

2. Passed an empty string in an array of retryIntervals 

<img width="1087" alt="image" src="https://github.com/harness/harness-schema/assets/142220748/36074672-d0c9-4221-8ae2-8e62f4945b95">
3. Passed empty string as an array
<img width="1080" alt="image" src="https://github.com/harness/harness-schema/assets/142220748/c67b9f6c-667f-4e86-8079-bae5c1eb2e33">
4. Passed an empty array all together
<img width="1246" alt="image" src="https://github.com/harness/harness-schema/assets/142220748/f39de5ad-9cf6-425b-af36-c0b821426305">

<img width="1444" alt="image" src="https://github.com/harness/harness-schema/assets/142220748/1dd0ef6c-d814-4295-b142-1f5a4e6754f0">
5. removed post retry failure strategies
<img width="1397" alt="image" src="https://github.com/harness/harness-schema/assets/142220748/89e702b8-78a0-48cd-acb6-78a19005662e">
6. Didn't provide retryIntervals
<img width="1374" alt="image" src="https://github.com/harness/harness-schema/assets/142220748/2d8b5362-08ce-41f3-a395-865d439e9579">
7. Didn't provide retryCounts
<img width="1436" alt="image" src="https://github.com/harness/harness-schema/assets/142220748/16d6b1db-0c4a-4fb2-bb5b-1f557771243b">

<img width="1391" alt="image" src="https://github.com/harness/harness-schema/assets/142220748/16bf742c-a8ef-4f89-8f41-76d3d089704c">

