### PR TITLE
fix: [CDS-95409]: allow expressions in Update Gitops App step's valueFiles

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -58402,7 +58402,7 @@
                   }
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v0/pipeline/steps/cd/helm-values.yaml
+++ b/v0/pipeline/steps/cd/helm-values.yaml
@@ -23,7 +23,7 @@ properties:
       items:
         type: string
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\\+.+>.*)
       minLength: 1
   description:
     desc: This is the description for HelmValues

--- a/v0/template.json
+++ b/v0/template.json
@@ -21529,7 +21529,7 @@
                   }
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -49286,7 +49286,7 @@
                   }
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v1/pipeline/steps/cd/helm-values.yaml
+++ b/v1/pipeline/steps/cd/helm-values.yaml
@@ -23,7 +23,7 @@ properties:
       items:
         type: string
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\\+.+>.*)
       minLength: 1
   description:
     desc: This is the description for HelmValues

--- a/v1/template.json
+++ b/v1/template.json
@@ -23487,7 +23487,7 @@
                   }
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },


### PR DESCRIPTION
Currently the `valueFiles` attribute in UpdateGitopsApp step only supports fixed values and runtime expression. This change allows the usage of expressions in this field.