### PR TITLE
feat: [STO-7524]: Add Wiz Scan Configurations in enum

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -30827,7 +30827,7 @@
                 },
                 "config" : {
                   "type" : "string",
-                  "enum" : [ "default" ]
+                  "enum" : [ "default", "wiz-container-images", "wiz-directory" ]
                 },
                 "image" : {
                   "$ref" : "#/definitions/pipeline/steps/common/STOYamlImage"
@@ -30914,7 +30914,7 @@
               },
               "config" : {
                 "type" : "string",
-                "enum" : [ "default" ]
+                "enum" : [ "default", "wiz-container-images", "wiz-directory" ]
               },
               "image" : {
                 "$ref" : "#/definitions/pipeline/steps/common/STOYamlImage"

--- a/v0/pipeline/steps/common/wiz-step-info.yaml
+++ b/v0/pipeline/steps/common/wiz-step-info.yaml
@@ -17,6 +17,8 @@ allOf:
         type: string
         enum:
           - default
+          - wiz-container-images
+          - wiz-directory
       image:
         $ref: stoyaml-image.yaml
       imagePullPolicy:
@@ -85,6 +87,8 @@ properties:
     type: string
     enum:
       - default
+      - wiz-container-images
+      - wiz-directory
   image:
     $ref: stoyaml-image.yaml
   imagePullPolicy:

--- a/v0/template.json
+++ b/v0/template.json
@@ -48734,7 +48734,7 @@
                 },
                 "config" : {
                   "type" : "string",
-                  "enum" : [ "default" ]
+                  "enum" : [ "default", "wiz-container-images", "wiz-directory" ]
                 },
                 "image" : {
                   "$ref" : "#/definitions/pipeline/steps/common/STOYamlImage"
@@ -48821,7 +48821,7 @@
               },
               "config" : {
                 "type" : "string",
-                "enum" : [ "default" ]
+                "enum" : [ "default", "wiz-container-images", "wiz-directory" ]
               },
               "image" : {
                 "$ref" : "#/definitions/pipeline/steps/common/STOYamlImage"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -25110,7 +25110,7 @@
                 },
                 "config" : {
                   "type" : "string",
-                  "enum" : [ "default" ]
+                  "enum" : [ "default", "wiz-container-images", "wiz-directory" ]
                 },
                 "image" : {
                   "$ref" : "#/definitions/pipeline/steps/common/STOYamlImage"
@@ -25197,7 +25197,7 @@
               },
               "config" : {
                 "type" : "string",
-                "enum" : [ "default" ]
+                "enum" : [ "default", "wiz-container-images", "wiz-directory" ]
               },
               "image" : {
                 "$ref" : "#/definitions/pipeline/steps/common/STOYamlImage"

--- a/v1/pipeline/steps/common/wiz-step-info.yaml
+++ b/v1/pipeline/steps/common/wiz-step-info.yaml
@@ -17,6 +17,8 @@ allOf:
         type: string
         enum:
           - default
+          - wiz-container-images
+          - wiz-directory
       image:
         $ref: stoyaml-image.yaml
       imagePullPolicy:
@@ -85,6 +87,8 @@ properties:
     type: string
     enum:
       - default
+      - wiz-container-images
+      - wiz-directory
   image:
     $ref: stoyaml-image.yaml
   imagePullPolicy:

--- a/v1/template.json
+++ b/v1/template.json
@@ -49367,7 +49367,7 @@
                 },
                 "config" : {
                   "type" : "string",
-                  "enum" : [ "default" ]
+                  "enum" : [ "default", "wiz-container-images", "wiz-directory" ]
                 },
                 "image" : {
                   "$ref" : "#/definitions/pipeline/steps/common/STOYamlImage"
@@ -49454,7 +49454,7 @@
               },
               "config" : {
                 "type" : "string",
-                "enum" : [ "default" ]
+                "enum" : [ "default", "wiz-container-images", "wiz-directory" ]
               },
               "image" : {
                 "$ref" : "#/definitions/pipeline/steps/common/STOYamlImage"


### PR DESCRIPTION
Wiz Scan Configuration Enum currently supports "Default". This PR is created to add directory and container images to the scan configuration in STO.