### PR TITLE
[feat]: [DBOPS-176]: onboard DBDevOps rollback schema step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -9161,6 +9161,8 @@
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkRollbackStepNode"
@@ -31999,6 +32001,232 @@
               },
               "description" : {
                 "desc" : "This is the description for DBApplySchemaStepInfo"
+              }
+            }
+          },
+          "DBRollbackSchemaStepNode" : {
+            "title" : "DBRollbackSchemaStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for DBRollbackSchemaStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "DBSchemaRollback" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "DBSchemaRollback"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "DBRollbackSchemaStepInfo" : {
+            "title" : "DBRollbackSchemaStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "connectorRef", "dbInstance", "tag" ],
+              "properties" : {
+                "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "tag" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "envVariables" : {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connectorRef", "dbInstance", "tag" ],
+            "properties" : {
+              "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "tag" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "envVariables" : {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "imagePullPolicy" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "Always", "Never", "IfNotPresent" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "privileged" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for DBRollbackSchemaStepInfo"
               }
             }
           }

--- a/v0/pipeline/stages/custom/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/custom/execution-wrapper-config.yaml
@@ -71,6 +71,7 @@ properties:
     - $ref: ../../steps/common/aws-cdk-diff-step-node.yaml
     - $ref: ../../steps/common/aws-cdk-deploy-step-node.yaml
     - $ref: ../../steps/common/dbops-apply-schema-step-node.yaml
+    - $ref: ../../steps/common/dbops-rollback-schema-step-node.yaml
     - $ref: ../../steps/common/aws-cdk-destroy-step-node.yaml
     - $ref: ../../steps/common/aws-cdk-rollback-step-node.yaml
     - $ref: ../../steps/cd/download-aws-s3-step-node.yaml

--- a/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
+++ b/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
@@ -1,0 +1,110 @@
+title: DBRollbackSchemaStepInfo
+allOf:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    required:
+      - connectorRef
+      - dbInstance
+      - tag
+    properties:
+      dbInstance:
+        type: string
+        minLength: 3
+      connectorRef:
+        type: string
+      tag:
+        type: string
+      delegateSelectors:
+        oneOf:
+          - type: array
+            items:
+              type: string
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+      envVariables:
+        oneOf:
+          - type: object
+            additionalProperties:
+              type: string
+          - type: string
+      image:
+        type: string
+      imagePullPolicy:
+        oneOf:
+          - type: string
+            enum:
+              - Always
+              - Never
+              - IfNotPresent
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+      privileged:
+        oneOf:
+          - type: boolean
+          - type: string
+            pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+            minLength: 1
+      resources:
+        $ref: ../../common/container-resource.yaml
+      runAsUser:
+        oneOf:
+          - type: integer
+            format: int32
+          - type: string
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+  - connectorRef
+  - dbInstance
+  - tag
+properties:
+  dbInstance:
+    type: string
+    minLength: 3
+  connectorRef:
+    type: string
+  tag:
+    type: string
+  delegateSelectors:
+    oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  envVariables:
+    oneOf:
+      - type: object
+        additionalProperties:
+          type: string
+      - type: string
+  image:
+    type: string
+  imagePullPolicy:
+    oneOf:
+      - type: string
+        enum:
+          - Always
+          - Never
+          - IfNotPresent
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  privileged:
+    oneOf:
+      - type: boolean
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
+  resources:
+    $ref: ../../common/container-resource.yaml
+  runAsUser:
+    oneOf:
+      - type: integer
+        format: int32
+      - type: string
+  description:
+    desc: This is the description for DBRollbackSchemaStepInfo

--- a/v0/pipeline/steps/common/dbops-rollback-schema-step-node.yaml
+++ b/v0/pipeline/steps/common/dbops-rollback-schema-step-node.yaml
@@ -1,0 +1,55 @@
+title: DBRollbackSchemaStepNode
+type: object
+required:
+  - identifier
+  - name
+  - type
+properties:
+  description:
+    type: string
+    desc: This is the description for DBRollbackSchemaStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+      - $ref: ../../common/strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+      - DBSchemaRollback
+  when:
+    oneOf:
+      - $ref: ../../common/step-when-condition.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: DBSchemaRollback
+    then:
+      properties:
+        spec:
+          $ref: dbops-rollback-schema-step-info.yaml

--- a/v0/template.json
+++ b/v0/template.json
@@ -450,6 +450,8 @@
               }, {
                 "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode_template"
               }, {
+                "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode_template"
+              }, {
                 "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode_template"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/common/AwsCdkRollbackStepNode_template"
@@ -50728,6 +50730,220 @@
               }
             }
           },
+          "DBRollbackSchemaStepNode_template" : {
+            "title" : "DBRollbackSchemaStepNode_template",
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "DBSchemaRollback" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "DBSchemaRollback"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "DBRollbackSchemaStepInfo" : {
+            "title" : "DBRollbackSchemaStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "connectorRef", "dbInstance", "tag" ],
+              "properties" : {
+                "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "tag" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "envVariables" : {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connectorRef", "dbInstance", "tag" ],
+            "properties" : {
+              "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "tag" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "envVariables" : {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "imagePullPolicy" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "Always", "Never", "IfNotPresent" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "privileged" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for DBRollbackSchemaStepInfo"
+              }
+            }
+          },
           "AwsCdkDestroyStepNode_template" : {
             "title" : "AwsCdkDestroyStepNode_template",
             "type" : "object",
@@ -52170,6 +52386,83 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "DBRollbackSchemaStepNode" : {
+            "title" : "DBRollbackSchemaStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for DBRollbackSchemaStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "DBSchemaRollback" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "DBSchemaRollback"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepInfo"
                   }
                 }
               }
@@ -73345,6 +73638,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                 }, {

--- a/v0/template/template_config.yaml
+++ b/v0/template/template_config.yaml
@@ -204,6 +204,7 @@ step_template_types:
   - ../pipeline/stages/cd/custom-deployment-config.yaml
   - ../pipeline/steps/common/aws-cdk-deploy-step-node.yaml
   - ../pipeline/steps/common/dbops-apply-schema-step-node.yaml
+  - ../pipeline/steps/common/dbops-rollback-schema-step-node.yaml
   - ../pipeline/steps/common/aws-cdk-destroy-step-node.yaml
   - ../pipeline/steps/common/aws-cdk-rollback-step-node.yaml
   - ../pipeline/steps/cd/update-git-ops-app-step-node.yaml

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -780,6 +780,8 @@
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                   }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                  }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/cd/UpdateGitOpsAppStepNode"
@@ -1061,6 +1063,8 @@
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
@@ -1912,6 +1916,8 @@
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/UpdateGitOpsAppStepNode"
@@ -2198,6 +2204,8 @@
                 "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
               }, {
@@ -2538,6 +2546,8 @@
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
@@ -3730,6 +3740,8 @@
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                   }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                  }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/custom/StepGroupNode"
@@ -3877,6 +3889,8 @@
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
@@ -4174,6 +4188,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                 }, {
@@ -10688,6 +10704,8 @@
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                           }, {
+                            "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                          }, {
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/custom/StepGroupNode"
@@ -10880,6 +10898,8 @@
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                          }, {
+                            "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                           }, {
@@ -13795,6 +13815,232 @@
               },
               "description" : {
                 "desc" : "This is the description for DBApplySchemaStepInfo"
+              }
+            }
+          },
+          "DBRollbackSchemaStepNode" : {
+            "title" : "DBRollbackSchemaStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for DBRollbackSchemaStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "DBSchemaRollback" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "DBSchemaRollback"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "DBRollbackSchemaStepInfo" : {
+            "title" : "DBRollbackSchemaStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "connectorRef", "image", "dbInstance", "tag" ],
+              "properties" : {
+                "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "tag" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "envVariables" : {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connectorRef", "dbInstance", "tag" ],
+            "properties" : {
+              "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "tag" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "envVariables" : {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "imagePullPolicy" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "Always", "Never", "IfNotPresent" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "privileged" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for DBRollbackSchemaStepInfo"
               }
             }
           },
@@ -49878,6 +50124,8 @@
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                           }, {
+                            "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                          }, {
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/cd/UpdateGitOpsAppStepNode"
@@ -50202,6 +50450,8 @@
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                          }, {
+                            "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                           }, {

--- a/v1/pipeline/stages/cd/deployment-stage-spec-element-wrapper-config.yaml
+++ b/v1/pipeline/stages/cd/deployment-stage-spec-element-wrapper-config.yaml
@@ -129,6 +129,7 @@ steps:
     - ../../steps/common/aws-cdk-diff-step-node.yaml
     - ../../steps/common/aws-cdk-deploy-step-node.yaml
     - ../../steps/common/dbops-apply-schema-step-node.yaml
+    - ../../steps/common/dbops-rollback-schema-step-node.yaml
     - ../../steps/common/aws-cdk-destroy-step-node.yaml
     - ../../steps/cd/update-git-ops-app-step-node.yaml
     - ../../steps/cd/k8s-traffic-routing-step-node.yaml

--- a/v1/pipeline/stages/cd/execution-wrapper-config.yaml
+++ b/v1/pipeline/stages/cd/execution-wrapper-config.yaml
@@ -139,6 +139,7 @@ properties:
     - $ref: ../../steps/common/aws-cdk-diff-step-node.yaml
     - $ref: ../../steps/common/aws-cdk-deploy-step-node.yaml
     - $ref: ../../steps/common/dbops-apply-schema-step-node.yaml
+    - $ref: ../../steps/common/dbops-rollback-schema-step-node.yaml
     - $ref: ../../steps/common/aws-cdk-destroy-step-node.yaml
     - $ref: ../../steps/cd/update-git-ops-app-step-node.yaml
     - $ref: ../../steps/cd/k8s-traffic-routing-step-node.yaml

--- a/v1/pipeline/stages/cf/execution-wrapper-config.yaml
+++ b/v1/pipeline/stages/cf/execution-wrapper-config.yaml
@@ -72,6 +72,7 @@ properties:
     - $ref: ../../steps/common/aws-cdk-diff-step-node.yaml
     - $ref: ../../steps/common/aws-cdk-deploy-step-node.yaml
     - $ref: ../../steps/common/dbops-apply-schema-step-node.yaml
+    - $ref: ../../steps/common/dbops-rollback-schema-step-node.yaml
     - $ref: ../../steps/common/aws-cdk-destroy-step-node.yaml
     - $ref: ../../steps/cd/download-aws-s3-step-node.yaml
     - $ref: ../../steps/cd/download-harness-store-step-node.yaml

--- a/v1/pipeline/stages/custom/custom-stage-spec-element-wrapper-config.yaml
+++ b/v1/pipeline/stages/custom/custom-stage-spec-element-wrapper-config.yaml
@@ -65,6 +65,7 @@ steps:
   - ../../steps/common/aws-cdk-diff-step-node.yaml
   - ../../steps/common/aws-cdk-deploy-step-node.yaml
   - ../../steps/common/dbops-apply-schema-step-node.yaml
+  - ../../steps/common/dbops-rollback-schema-step-node.yaml
   - ../../steps/common/aws-cdk-destroy-step-node.yaml
   - ../../steps/custom/step-group-node.yaml
   - ../../steps/custom/parallel-node.yaml

--- a/v1/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
+++ b/v1/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
@@ -1,0 +1,111 @@
+title: DBRollbackSchemaStepInfo
+allOf:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    required:
+      - connectorRef
+      - image
+      - dbInstance
+      - tag
+    properties:
+      dbInstance:
+        type: string
+        minLength: 3
+      connectorRef:
+        type: string
+      tag:
+        type: string
+      delegateSelectors:
+        oneOf:
+          - type: array
+            items:
+              type: string
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+      envVariables:
+        oneOf:
+          - type: object
+            additionalProperties:
+              type: string
+          - type: string
+      image:
+        type: string
+      imagePullPolicy:
+        oneOf:
+          - type: string
+            enum:
+              - Always
+              - Never
+              - IfNotPresent
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+      privileged:
+        oneOf:
+          - type: boolean
+          - type: string
+            pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+            minLength: 1
+      resources:
+        $ref: ../../common/container-resource.yaml
+      runAsUser:
+        oneOf:
+          - type: integer
+            format: int32
+          - type: string
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+  - connectorRef
+  - dbInstance
+  - tag
+properties:
+  dbInstance:
+    type: string
+    minLength: 3
+  connectorRef:
+    type: string
+  tag:
+    type: string
+  delegateSelectors:
+    oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  envVariables:
+    oneOf:
+      - type: object
+        additionalProperties:
+          type: string
+      - type: string
+  image:
+    type: string
+  imagePullPolicy:
+    oneOf:
+      - type: string
+        enum:
+          - Always
+          - Never
+          - IfNotPresent
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  privileged:
+    oneOf:
+      - type: boolean
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
+  resources:
+    $ref: ../../common/container-resource.yaml
+  runAsUser:
+    oneOf:
+      - type: integer
+        format: int32
+      - type: string
+  description:
+    desc: This is the description for DBRollbackSchemaStepInfo

--- a/v1/pipeline/steps/common/dbops-rollback-schema-step-node.yaml
+++ b/v1/pipeline/steps/common/dbops-rollback-schema-step-node.yaml
@@ -1,0 +1,56 @@
+title: DBRollbackSchemaStepNode
+type: object
+required:
+  - identifier
+  - name
+  - spec
+  - type
+properties:
+  description:
+    type: string
+    desc: This is the description for DBRollbackSchemaStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+      - $ref: ../../common/strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+      - DBSchemaRollback
+  when:
+    oneOf:
+      - $ref: ../../common/step-when-condition.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: DBSchemaRollback
+    then:
+      properties:
+        spec:
+          $ref: dbops-rollback-schema-step-info.yaml

--- a/v1/template.json
+++ b/v1/template.json
@@ -450,7 +450,7 @@
                     "$ref" : "#/definitions/pipeline/stages/cd/CustomDeploymentConfig_template"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode_template"
-                  }, { }, {
+                  }, { }, { }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode_template"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/cd/UpdateGitOpsAppStepNode_template"
@@ -945,6 +945,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                 }, {
@@ -31987,6 +31989,8 @@
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                           }, {
+                            "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                          }, {
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/cd/UpdateGitOpsAppStepNode"
@@ -32311,6 +32315,8 @@
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                          }, {
+                            "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                           }, {
@@ -37559,6 +37565,8 @@
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                           }, {
+                            "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                          }, {
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/custom/StepGroupNode"
@@ -37751,6 +37759,8 @@
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                          }, {
+                            "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                           }, {
                             "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                           }, {
@@ -52961,6 +52971,232 @@
               }
             }
           },
+          "DBRollbackSchemaStepNode" : {
+            "title" : "DBRollbackSchemaStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for DBRollbackSchemaStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "DBSchemaRollback" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "DBSchemaRollback"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "DBRollbackSchemaStepInfo" : {
+            "title" : "DBRollbackSchemaStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "connectorRef", "image", "dbInstance", "tag" ],
+              "properties" : {
+                "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "tag" : {
+                  "type" : "string"
+                },
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "envVariables" : {
+                  "oneOf" : [ {
+                    "type" : "object",
+                    "additionalProperties" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string"
+                  } ]
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "imagePullPolicy" : {
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "enum" : [ "Always", "Never", "IfNotPresent" ]
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "privileged" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "runAsUser" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32"
+                  }, {
+                    "type" : "string"
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connectorRef", "dbInstance", "tag" ],
+            "properties" : {
+              "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "connectorRef" : {
+                "type" : "string"
+              },
+              "tag" : {
+                "type" : "string"
+              },
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "envVariables" : {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "imagePullPolicy" : {
+                "oneOf" : [ {
+                  "type" : "string",
+                  "enum" : [ "Always", "Never", "IfNotPresent" ]
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "privileged" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "runAsUser" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32"
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for DBRollbackSchemaStepInfo"
+              }
+            }
+          },
           "AwsCdkDestroyStepNode" : {
             "title" : "AwsCdkDestroyStepNode",
             "type" : "object",
@@ -62092,6 +62328,8 @@
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                   }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                  }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/cd/UpdateGitOpsAppStepNode"
@@ -62373,6 +62611,8 @@
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
@@ -62990,6 +63230,8 @@
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/UpdateGitOpsAppStepNode"
@@ -63276,6 +63518,8 @@
                 "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
               }, {
@@ -63616,6 +63860,8 @@
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
@@ -66577,6 +66823,8 @@
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
                   }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
+                  }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/custom/StepGroupNode"
@@ -66724,6 +66972,8 @@
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                  }, {
+                    "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                   }, {
                     "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                   }, {
@@ -67021,6 +67271,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDeployStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/DBApplySchemaStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/DBRollbackSchemaStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/AwsCdkDestroyStepNode"
                 }, {

--- a/v1/template/template_config.yaml
+++ b/v1/template/template_config.yaml
@@ -185,6 +185,7 @@ step_template_types:
   - ../pipeline/stages/cd/custom-deployment-config.yaml
   - ../pipeline/steps/common/aws-cdk-deploy-step-node.yaml
   - ../pipeline/steps/common/dbops-apply-schema-step-nodeyaml
+  - ../pipeline/steps/common/dbops-rollback-schema-step-nodeyaml
   - ../pipeline/steps/common/aws-cdk-destroy-step-node.yaml
   - ../pipeline/steps/cd/update-git-ops-app-step-node.yaml
   - ../pipeline/steps/cd/k8s-traffic-routing-step-node.yaml


### PR DESCRIPTION
Add Rollback Schema step for DB Devops Module
This is a containerised step

Example step configuration in step template:
```
template:
  name: schema_rollback
  identifier: schema_rollback_1
  versionLabel: "1"
  type: Step
  projectIdentifier: NG_Trial
  orgIdentifier: default
  tags: {}
  spec:
    type: DBSchemaRollback
    spec:
      connectorRef: <+input>
      dbInstance: ab/bc
      image: drone-liquibase:latest
      build: <+input>
      tag: abcd
    description: <+input>
```