### PR TITLE
[feat]: [DBOPS-176]: Update static schema for DBSchemaApply and DBSchemaRollback step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -31927,12 +31927,10 @@
               "required" : [ "connectorRef", "dbSchema", "dbInstance" ],
               "properties" : {
                 "dbInstance" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "dbSchema" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -32002,12 +32000,10 @@
             "required" : [ "connectorRef", "dbSchema", "dbInstance" ],
             "properties" : {
               "dbInstance" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "dbSchema" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "connectorRef" : {
                 "type" : "string"
@@ -32161,12 +32157,10 @@
               "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
               "properties" : {
                 "dbInstance" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "dbSchema" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -32236,12 +32230,10 @@
             "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
             "properties" : {
               "dbInstance" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "dbSchema" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "connectorRef" : {
                 "type" : "string"

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -31924,9 +31924,13 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef" ],
+              "required" : [ "connectorRef", "dbSchema", "dbInstance" ],
               "properties" : {
                 "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "dbSchema" : {
                   "type" : "string",
                   "minLength" : 3
                 },
@@ -31995,9 +31999,13 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef" ],
+            "required" : [ "connectorRef", "dbSchema", "dbInstance" ],
             "properties" : {
               "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "dbSchema" : {
                 "type" : "string",
                 "minLength" : 3
               },
@@ -32150,9 +32158,13 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef", "dbInstance", "tag" ],
+              "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
               "properties" : {
                 "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "dbSchema" : {
                   "type" : "string",
                   "minLength" : 3
                 },
@@ -32221,9 +32233,13 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef", "dbInstance", "tag" ],
+            "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
             "properties" : {
               "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "dbSchema" : {
                 "type" : "string",
                 "minLength" : 3
               },

--- a/v0/pipeline/steps/common/dbops-apply-schema-step-info.yaml
+++ b/v0/pipeline/steps/common/dbops-apply-schema-step-info.yaml
@@ -9,10 +9,8 @@ allOf:
   properties:
     dbInstance:
       type: string
-      minLength: 3
     dbSchema:
       type: string
-      minLength: 3
     connectorRef:
       type: string
     tag:
@@ -65,10 +63,8 @@ required:
 properties:
   dbInstance:
       type: string
-      minLength: 3
   dbSchema:
     type: string
-    minLength: 3
   connectorRef:
     type: string
   tag:

--- a/v0/pipeline/steps/common/dbops-apply-schema-step-info.yaml
+++ b/v0/pipeline/steps/common/dbops-apply-schema-step-info.yaml
@@ -4,8 +4,13 @@ allOf:
 - type: object
   required:
   - connectorRef
+  - dbSchema
+  - dbInstance
   properties:
     dbInstance:
+      type: string
+      minLength: 3
+    dbSchema:
       type: string
       minLength: 3
     connectorRef:
@@ -55,10 +60,15 @@ $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
 - connectorRef
+- dbSchema
+- dbInstance
 properties:
   dbInstance:
       type: string
       minLength: 3
+  dbSchema:
+    type: string
+    minLength: 3
   connectorRef:
     type: string
   tag:

--- a/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
+++ b/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
@@ -10,10 +10,8 @@ allOf:
     properties:
       dbInstance:
         type: string
-        minLength: 3
       dbSchema:
         type: string
-        minLength: 3
       connectorRef:
         type: string
       tag:
@@ -67,10 +65,8 @@ required:
 properties:
   dbInstance:
     type: string
-    minLength: 3
   dbSchema:
     type: string
-    minLength: 3
   connectorRef:
     type: string
   tag:

--- a/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
+++ b/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
@@ -5,9 +5,13 @@ allOf:
     required:
       - connectorRef
       - dbInstance
+      - dbSchema
       - tag
     properties:
       dbInstance:
+        type: string
+        minLength: 3
+      dbSchema:
         type: string
         minLength: 3
       connectorRef:
@@ -58,9 +62,13 @@ type: object
 required:
   - connectorRef
   - dbInstance
+  - dbSchema
   - tag
 properties:
   dbInstance:
+    type: string
+    minLength: 3
+  dbSchema:
     type: string
     minLength: 3
   connectorRef:

--- a/v0/template.json
+++ b/v0/template.json
@@ -50912,12 +50912,10 @@
               "required" : [ "connectorRef", "dbSchema", "dbInstance" ],
               "properties" : {
                 "dbInstance" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "dbSchema" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -50987,12 +50985,10 @@
             "required" : [ "connectorRef", "dbSchema", "dbInstance" ],
             "properties" : {
               "dbInstance" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "dbSchema" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "connectorRef" : {
                 "type" : "string"
@@ -51134,12 +51130,10 @@
               "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
               "properties" : {
                 "dbInstance" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "dbSchema" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -51209,12 +51203,10 @@
             "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
             "properties" : {
               "dbInstance" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "dbSchema" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "connectorRef" : {
                 "type" : "string"

--- a/v0/template.json
+++ b/v0/template.json
@@ -50909,9 +50909,13 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef" ],
+              "required" : [ "connectorRef", "dbSchema", "dbInstance" ],
               "properties" : {
                 "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "dbSchema" : {
                   "type" : "string",
                   "minLength" : 3
                 },
@@ -50980,9 +50984,13 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef" ],
+            "required" : [ "connectorRef", "dbSchema", "dbInstance" ],
             "properties" : {
               "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "dbSchema" : {
                 "type" : "string",
                 "minLength" : 3
               },
@@ -51123,9 +51131,13 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef", "dbInstance", "tag" ],
+              "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
               "properties" : {
                 "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "dbSchema" : {
                   "type" : "string",
                   "minLength" : 3
                 },
@@ -51194,9 +51206,13 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef", "dbInstance", "tag" ],
+            "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
             "properties" : {
               "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "dbSchema" : {
                 "type" : "string",
                 "minLength" : 3
               },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -13677,9 +13677,13 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef", "image" ],
+              "required" : [ "connectorRef", "image", "dbInstance", "dbSchema" ],
               "properties" : {
                 "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "dbSchema" : {
                   "type" : "string",
                   "minLength" : 3
                 },
@@ -13748,9 +13752,13 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef" ],
+            "required" : [ "connectorRef", "dbInstance", "dbSchema" ],
             "properties" : {
               "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "dbSchema" : {
                 "type" : "string",
                 "minLength" : 3
               },
@@ -13903,9 +13911,13 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef", "image", "dbInstance", "tag" ],
+              "required" : [ "connectorRef", "image", "dbInstance", "dbSchema", "tag" ],
               "properties" : {
                 "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "dbSchema" : {
                   "type" : "string",
                   "minLength" : 3
                 },
@@ -13974,9 +13986,13 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef", "dbInstance", "tag" ],
+            "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
             "properties" : {
               "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "dbSchema" : {
                 "type" : "string",
                 "minLength" : 3
               },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -13680,12 +13680,10 @@
               "required" : [ "connectorRef", "image", "dbInstance", "dbSchema" ],
               "properties" : {
                 "dbInstance" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "dbSchema" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -13755,12 +13753,10 @@
             "required" : [ "connectorRef", "dbInstance", "dbSchema" ],
             "properties" : {
               "dbInstance" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "dbSchema" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "connectorRef" : {
                 "type" : "string"
@@ -13914,12 +13910,10 @@
               "required" : [ "connectorRef", "image", "dbInstance", "dbSchema", "tag" ],
               "properties" : {
                 "dbInstance" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "dbSchema" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -13989,12 +13983,10 @@
             "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
             "properties" : {
               "dbInstance" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "dbSchema" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "connectorRef" : {
                 "type" : "string"

--- a/v1/pipeline/steps/common/dbops-apply-schema-step-info.yaml
+++ b/v1/pipeline/steps/common/dbops-apply-schema-step-info.yaml
@@ -10,10 +10,8 @@ allOf:
   properties:
     dbInstance:
       type: string
-      minLength: 3
     dbSchema:
       type: string
-      minLength: 3
     connectorRef:
       type: string
     tag:
@@ -66,10 +64,8 @@ required:
 properties:
   dbInstance:
       type: string
-      minLength: 3
   dbSchema:
     type: string
-    minLength: 3
   connectorRef:
     type: string
   tag:

--- a/v1/pipeline/steps/common/dbops-apply-schema-step-info.yaml
+++ b/v1/pipeline/steps/common/dbops-apply-schema-step-info.yaml
@@ -5,8 +5,13 @@ allOf:
   required:
   - connectorRef
   - image
+  - dbInstance
+  - dbSchema
   properties:
     dbInstance:
+      type: string
+      minLength: 3
+    dbSchema:
       type: string
       minLength: 3
     connectorRef:
@@ -56,10 +61,15 @@ $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
 - connectorRef
+- dbInstance
+- dbSchema
 properties:
   dbInstance:
       type: string
       minLength: 3
+  dbSchema:
+    type: string
+    minLength: 3
   connectorRef:
     type: string
   tag:

--- a/v1/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
+++ b/v1/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
@@ -11,10 +11,8 @@ allOf:
     properties:
       dbInstance:
         type: string
-        minLength: 3
       dbSchema:
         type: string
-        minLength: 3
       connectorRef:
         type: string
       tag:
@@ -68,10 +66,8 @@ required:
 properties:
   dbInstance:
     type: string
-    minLength: 3
   dbSchema:
     type: string
-    minLength: 3
   connectorRef:
     type: string
   tag:

--- a/v1/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
+++ b/v1/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
@@ -6,9 +6,13 @@ allOf:
       - connectorRef
       - image
       - dbInstance
+      - dbSchema
       - tag
     properties:
       dbInstance:
+        type: string
+        minLength: 3
+      dbSchema:
         type: string
         minLength: 3
       connectorRef:
@@ -59,9 +63,13 @@ type: object
 required:
   - connectorRef
   - dbInstance
+  - dbSchema
   - tag
 properties:
   dbInstance:
+    type: string
+    minLength: 3
+  dbSchema:
     type: string
     minLength: 3
   connectorRef:

--- a/v1/template.json
+++ b/v1/template.json
@@ -53124,12 +53124,10 @@
               "required" : [ "connectorRef", "image", "dbInstance", "dbSchema" ],
               "properties" : {
                 "dbInstance" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "dbSchema" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -53199,12 +53197,10 @@
             "required" : [ "connectorRef", "dbInstance", "dbSchema" ],
             "properties" : {
               "dbInstance" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "dbSchema" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "connectorRef" : {
                 "type" : "string"
@@ -53358,12 +53354,10 @@
               "required" : [ "connectorRef", "image", "dbInstance", "dbSchema", "tag" ],
               "properties" : {
                 "dbInstance" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "dbSchema" : {
-                  "type" : "string",
-                  "minLength" : 3
+                  "type" : "string"
                 },
                 "connectorRef" : {
                   "type" : "string"
@@ -53433,12 +53427,10 @@
             "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
             "properties" : {
               "dbInstance" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "dbSchema" : {
-                "type" : "string",
-                "minLength" : 3
+                "type" : "string"
               },
               "connectorRef" : {
                 "type" : "string"

--- a/v1/template.json
+++ b/v1/template.json
@@ -53121,9 +53121,13 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef", "image" ],
+              "required" : [ "connectorRef", "image", "dbInstance", "dbSchema" ],
               "properties" : {
                 "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "dbSchema" : {
                   "type" : "string",
                   "minLength" : 3
                 },
@@ -53192,9 +53196,13 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef" ],
+            "required" : [ "connectorRef", "dbInstance", "dbSchema" ],
             "properties" : {
               "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "dbSchema" : {
                 "type" : "string",
                 "minLength" : 3
               },
@@ -53347,9 +53355,13 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef", "image", "dbInstance", "tag" ],
+              "required" : [ "connectorRef", "image", "dbInstance", "dbSchema", "tag" ],
               "properties" : {
                 "dbInstance" : {
+                  "type" : "string",
+                  "minLength" : 3
+                },
+                "dbSchema" : {
                   "type" : "string",
                   "minLength" : 3
                 },
@@ -53418,9 +53430,13 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef", "dbInstance", "tag" ],
+            "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
             "properties" : {
               "dbInstance" : {
+                "type" : "string",
+                "minLength" : 3
+              },
+              "dbSchema" : {
                 "type" : "string",
                 "minLength" : 3
               },


### PR DESCRIPTION
Update static schema for DBSchemaApply and DBSchemaRollback step to include dbSchema field.
Also: 
- Adding required check for dbSchema and dbInstance field.
- Removing minimum length for fields (May be it was introduced as we were concatening both fields in dbInstance earlier)

Example step yaml:
```
  type: DBSchemaRollback
  name: DBSchemaRollback
  identifier: DBSchemaRollback
  spec:
    connectorRef: harness
    dbInstance: instance
    dbSchema: account.schema
    image: drone-liquibase:latest
    tag: abcded
  timeout: 10m

```