### PR TITLE
fix: [PIPE-16799]: Able to save Pipeline without any stage and step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -12,6 +12,7 @@
       "pipeline" : {
         "type" : "object",
         "title" : "pipeline",
+        "required" : [ "stages" ],
         "properties" : {
           "allowStageExecutions" : {
             "type" : "boolean"

--- a/v0/pipeline/pipeline.yaml
+++ b/v0/pipeline/pipeline.yaml
@@ -1,5 +1,7 @@
 type: object
 title: pipeline
+required:
+  - stages
 properties:
   allowStageExecutions:
     type: boolean


### PR DESCRIPTION
Ticket Link: https://harness.atlassian.net/browse/PIPE-16799
Issue: Customer could save pipeline without any stages and step
Changes: Making "stages" in the yaml as required field.
Testing: Done in local

- Tested changes after updating pipeline.json 
- To ensure requirement of stages for a pipeline, checked template flow as well.
- Ensured we get proper error message when we try to create a stage or pipeline template without any stage.

Screenshots:

![Screenshot 2024-05-24 at 7 42 20 PM](https://github.com/harness/harness-schema/assets/155067394/2ed93e80-8ee9-4489-a943-a7bffb8943fa)
<img width="1792" alt="Screenshot 2024-05-27 at 12 15 16 PM" src="https://github.com/harness/harness-schema/assets/155067394/c54a5c8c-ea1b-4962-98c8-a41ace67d774">
<img width="1792" alt="Screenshot 2024-05-27 at 12 18 05 PM" src="https://github.com/harness/harness-schema/assets/155067394/81c042b3-e8d4-4427-9c04-8117e4c69b7d">

