### PR TITLE
feat: [SSCA-1861]: Changed connector variable to connectorRef

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -7744,6 +7744,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/SscaEnforcementStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SscaOrchestrationStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepNode"
                 } ]
               },
               "description" : {
@@ -8188,6 +8190,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -15364,6 +15368,62 @@
                 "desc" : "This is the description for ContainerStepInfo"
               }
             }
+          },
+          "SscaComplianceSource" : {
+            "title" : "SscaComplianceSource",
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "scm" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SscaComplianceSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "scm"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySscaComplianceSource"
+                  }
+                }
+              }
+            } ]
+          },
+          "RepositorySscaComplianceSource" : {
+            "title" : "RepositorySscaComplianceSource",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "repo", "scan_org" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string",
+                  "enum" : [ "github" ]
+                },
+                "repo" : {
+                  "type" : "string"
+                },
+                "scan_org" : {
+                  "type" : "boolean"
+                },
+                "description" : {
+                  "desc" : "This is the description for RepositorySbomSource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "FlagConfigurationStepNode" : {
             "title" : "FlagConfigurationStepNode",
@@ -32310,6 +32370,125 @@
                 }
               }
             } ]
+          },
+          "SscaComplianceStepNode" : {
+            "title" : "SscaComplianceStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SscaComplianceStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SscaCompliance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SscaCompliance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SscaComplianceStepInfo" : {
+            "title" : "SscaComplianceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "source" ],
+              "properties" : {
+                "description" : {
+                  "desc" : "This is the description for SscaComplianceStepInfo"
+                },
+                "mode" : {
+                  "type" : "string",
+                  "enum" : [ "compliance" ]
+                },
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "source" ],
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SscaComplianceStepInfo"
+              },
+              "mode" : {
+                "type" : "string",
+                "enum" : [ "compliance" ]
+              },
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              }
+            }
           }
         },
         "ci" : {

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -15406,12 +15406,12 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "repo", "scan_org" ],
+              "required" : [ "connector", "scan_org" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
                 },
-                "repo" : {
+                "repoName" : {
                   "type" : "string"
                 },
                 "scan_org" : {
@@ -32458,10 +32458,6 @@
                 "description" : {
                   "desc" : "This is the description for SscaComplianceStepInfo"
                 },
-                "mode" : {
-                  "type" : "string",
-                  "enum" : [ "compliance" ]
-                },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
                 },
@@ -32476,10 +32472,6 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for SscaComplianceStepInfo"
-              },
-              "mode" : {
-                "type" : "string",
-                "enum" : [ "compliance" ]
               },
               "source" : {
                 "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -15409,8 +15409,7 @@
               "required" : [ "connector", "repo", "scan_org" ],
               "properties" : {
                 "connector" : {
-                  "type" : "string",
-                  "enum" : [ "github" ]
+                  "type" : "string"
                 },
                 "repo" : {
                   "type" : "string"
@@ -15419,7 +15418,7 @@
                   "type" : "boolean"
                 },
                 "description" : {
-                  "desc" : "This is the description for RepositorySbomSource"
+                  "desc" : "This is the description for RepositorySscaComplianceSource"
                 }
               }
             } ],

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -15406,9 +15406,9 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "scan_org" ],
+              "required" : [ "connectorRef", "scan_org" ],
               "properties" : {
-                "connector" : {
+                "connectorRef" : {
                   "type" : "string"
                 },
                 "repoName" : {

--- a/v0/pipeline/stages/ci/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/ci/execution-wrapper-config.yaml
@@ -77,6 +77,7 @@ properties:
       - $ref: ../../steps/custom/wait-step-node.yaml
       - $ref: ../../steps/common/slsa-verification-step-node.yaml
       - $ref: ../../steps/common/wiz-scan-node.yaml
+      - $ref: ../../steps/common/ssca-compliance-step-node.yaml
   stepGroup:
     $ref: step-group-element-config.yaml
   description:

--- a/v0/pipeline/stages/security/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/security/execution-wrapper-config.yaml
@@ -59,6 +59,7 @@ properties:
     - $ref: ../../steps/common/wiz-scan-node.yaml
     - $ref: ../../steps/common/ssca-enforcement-step-node.yaml
     - $ref: ../../steps/common/ssca-orchestration-step-node.yaml
+    - $ref: ../../steps/common/ssca-compliance-step-node.yaml
   description:
     desc: This is the description for ExecutionWrapperConfig
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/steps/common/ssca-compliance-step-info.yaml
+++ b/v0/pipeline/steps/common/ssca-compliance-step-info.yaml
@@ -1,0 +1,33 @@
+title: SscaComplianceStepInfo
+allOf:
+- $ref: ../../common/step-spec-type.yaml
+- type: object
+  required:
+  - source
+  properties:
+    description:
+      desc: This is the description for SscaComplianceStepInfo
+    mode:
+      type: string
+      enum:
+      - compliance
+    source:
+      $ref: ../custom/ssca-compliance-source.yaml
+    resources:
+      $ref: ../../common/container-resource.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+- source
+properties:
+  description:
+    desc: This is the description for SscaComplianceStepInfo
+  mode:
+    type: string
+    enum:
+    - compliance
+  source:
+    $ref: ../custom/ssca-compliance-source.yaml
+  resources:
+    $ref: ../../common/container-resource.yaml
+

--- a/v0/pipeline/steps/common/ssca-compliance-step-info.yaml
+++ b/v0/pipeline/steps/common/ssca-compliance-step-info.yaml
@@ -7,10 +7,6 @@ allOf:
   properties:
     description:
       desc: This is the description for SscaComplianceStepInfo
-    mode:
-      type: string
-      enum:
-      - compliance
     source:
       $ref: ../custom/ssca-compliance-source.yaml
     resources:
@@ -22,10 +18,6 @@ required:
 properties:
   description:
     desc: This is the description for SscaComplianceStepInfo
-  mode:
-    type: string
-    enum:
-    - compliance
   source:
     $ref: ../custom/ssca-compliance-source.yaml
   resources:

--- a/v0/pipeline/steps/common/ssca-compliance-step-node.yaml
+++ b/v0/pipeline/steps/common/ssca-compliance-step-node.yaml
@@ -1,0 +1,55 @@
+title: SscaComplianceStepNode
+type: object
+required:
+- identifier
+- name
+- spec
+properties:
+  description:
+    type: string
+    desc: This is the description for SscaComplianceStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+    - type: array
+      items:
+        $ref: ../../common/failure-strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+    - $ref: ../../common/strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+    - SscaCompliance
+  when:
+    oneOf:
+    - $ref: ../../common/step-when-condition.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: SscaCompliance
+  then:
+    properties:
+      spec:
+        $ref: ssca-compliance-step-info.yaml

--- a/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -3,10 +3,10 @@ allOf:
 - $ref: ssca-compliance-source-spec.yaml
 - type: object
   required:
-  - connector
+  - connectorRef
   - scan_org
   properties:
-    connector:
+    connectorRef:
       type: string
     repoName:
       type: string

--- a/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -1,15 +1,14 @@
 title: RepositorySscaComplianceSource
 allOf:
-- $ref: sbom-source-spec.yaml
+- $ref: ssca-compliance-source-spec.yaml
 - type: object
   required:
   - connector
-  - repo
   - scan_org
   properties:
     connector:
       type: string
-    repo:
+    repoName:
       type: string
     scan_org:
       type: boolean

--- a/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -1,0 +1,20 @@
+title: RepositorySscaComplianceSource
+allOf:
+- $ref: sbom-source-spec.yaml
+- type: object
+  required:
+  - connector
+  - repo
+  - scan_org
+  properties:
+    connector:
+      type: string
+      enum:
+        - github
+    repo:
+      type: string
+    scan_org:
+      type: boolean
+    description:
+      desc: This is the description for RepositorySbomSource
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -9,12 +9,10 @@ allOf:
   properties:
     connector:
       type: string
-      enum:
-        - github
     repo:
       type: string
     scan_org:
       type: boolean
     description:
-      desc: This is the description for RepositorySbomSource
+      desc: This is the description for RepositorySscaComplianceSource
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/steps/custom/ssca-compliance-source-spec.yaml
+++ b/v0/pipeline/steps/custom/ssca-compliance-source-spec.yaml
@@ -1,0 +1,6 @@
+title: SbomSourceSpec
+type: object
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for SscaComplianceSourceSpec

--- a/v0/pipeline/steps/custom/ssca-compliance-source.yaml
+++ b/v0/pipeline/steps/custom/ssca-compliance-source.yaml
@@ -1,0 +1,22 @@
+title: SscaComplianceSource
+type: object
+required:
+- type
+properties:
+  type:
+    type: string
+    enum:
+    - scm
+  description:
+    desc: This is the description for SscaComplianceSource
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: scm
+  then:
+    properties:
+      spec:
+        $ref: repository-ssca-compliance-source.yaml
+

--- a/v0/template.json
+++ b/v0/template.json
@@ -36676,9 +36676,9 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "scan_org" ],
+              "required" : [ "connectorRef", "scan_org" ],
               "properties" : {
-                "connector" : {
+                "connectorRef" : {
                   "type" : "string"
                 },
                 "repoName" : {

--- a/v0/template.json
+++ b/v0/template.json
@@ -36679,8 +36679,7 @@
               "required" : [ "connector", "repo", "scan_org" ],
               "properties" : {
                 "connector" : {
-                  "type" : "string",
-                  "enum" : [ "github" ]
+                  "type" : "string"
                 },
                 "repo" : {
                   "type" : "string"
@@ -36689,7 +36688,7 @@
                   "type" : "boolean"
                 },
                 "description" : {
-                  "desc" : "This is the description for RepositorySbomSource"
+                  "desc" : "This is the description for RepositorySscaComplianceSource"
                 }
               }
             } ],

--- a/v0/template.json
+++ b/v0/template.json
@@ -36676,12 +36676,12 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "repo", "scan_org" ],
+              "required" : [ "connector", "scan_org" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
                 },
-                "repo" : {
+                "repoName" : {
                   "type" : "string"
                 },
                 "scan_org" : {
@@ -57560,10 +57560,6 @@
                 "description" : {
                   "desc" : "This is the description for SscaComplianceStepInfo"
                 },
-                "mode" : {
-                  "type" : "string",
-                  "enum" : [ "compliance" ]
-                },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
                 },
@@ -57578,10 +57574,6 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for SscaComplianceStepInfo"
-              },
-              "mode" : {
-                "type" : "string",
-                "enum" : [ "compliance" ]
               },
               "source" : {
                 "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"

--- a/v0/template.json
+++ b/v0/template.json
@@ -36638,6 +36638,62 @@
                 "desc" : "This is the description for CdSscaOrchestrationStepInfo"
               }
             }
+          },
+          "SscaComplianceSource" : {
+            "title" : "SscaComplianceSource",
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "scm" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SscaComplianceSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "scm"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySscaComplianceSource"
+                  }
+                }
+              }
+            } ]
+          },
+          "RepositorySscaComplianceSource" : {
+            "title" : "RepositorySscaComplianceSource",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "repo", "scan_org" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string",
+                  "enum" : [ "github" ]
+                },
+                "repo" : {
+                  "type" : "string"
+                },
+                "scan_org" : {
+                  "type" : "boolean"
+                },
+                "description" : {
+                  "desc" : "This is the description for RepositorySbomSource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           }
         },
         "common" : {
@@ -57417,6 +57473,125 @@
               }
             } ]
           },
+          "SscaComplianceStepNode" : {
+            "title" : "SscaComplianceStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SscaComplianceStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SscaCompliance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SscaCompliance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SscaComplianceStepInfo" : {
+            "title" : "SscaComplianceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "source" ],
+              "properties" : {
+                "description" : {
+                  "desc" : "This is the description for SscaComplianceStepInfo"
+                },
+                "mode" : {
+                  "type" : "string",
+                  "enum" : [ "compliance" ]
+                },
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "source" ],
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SscaComplianceStepInfo"
+              },
+              "mode" : {
+                "type" : "string",
+                "enum" : [ "compliance" ]
+              },
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              }
+            }
+          },
           "DockerInfraYaml" : {
             "title" : "DockerInfraYaml",
             "allOf" : [ {
@@ -75389,6 +75564,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -76533,6 +76710,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/SscaEnforcementStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SscaOrchestrationStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepNode"
                 } ]
               },
               "description" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -10459,12 +10459,12 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "repo", "scan_org" ],
+              "required" : [ "connector", "scan_org" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
                 },
-                "repo" : {
+                "repoName" : {
                   "type" : "string"
                 },
                 "scan_org" : {
@@ -26462,10 +26462,6 @@
                 "description" : {
                   "desc" : "This is the description for SscaComplianceStepInfo"
                 },
-                "mode" : {
-                  "type" : "string",
-                  "enum" : [ "compliance" ]
-                },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
                 },
@@ -26480,10 +26476,6 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for SscaComplianceStepInfo"
-              },
-              "mode" : {
-                "type" : "string",
-                "enum" : [ "compliance" ]
               },
               "source" : {
                 "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -10459,9 +10459,9 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "scan_org" ],
+              "required" : [ "connectorRef", "scan_org" ],
               "properties" : {
-                "connector" : {
+                "connectorRef" : {
                   "type" : "string"
                 },
                 "repoName" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -10462,8 +10462,7 @@
               "required" : [ "connector", "repo", "scan_org" ],
               "properties" : {
                 "connector" : {
-                  "type" : "string",
-                  "enum" : [ "github" ]
+                  "type" : "string"
                 },
                 "repo" : {
                   "type" : "string"
@@ -10472,7 +10471,7 @@
                   "type" : "boolean"
                 },
                 "description" : {
-                  "desc" : "This is the description for RepositorySbomSource"
+                  "desc" : "This is the description for RepositorySscaComplianceSource"
                 }
               }
             } ],

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -3119,6 +3119,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/TemplateStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepNode"
                 } ]
               },
               "description" : {
@@ -10418,6 +10420,62 @@
                 "type" : "string"
               }
             },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "SscaComplianceSource" : {
+            "title" : "SscaComplianceSource",
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "scm" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SscaComplianceSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "scm"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySscaComplianceSource"
+                  }
+                }
+              }
+            } ]
+          },
+          "RepositorySscaComplianceSource" : {
+            "title" : "RepositorySscaComplianceSource",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "repo", "scan_org" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string",
+                  "enum" : [ "github" ]
+                },
+                "repo" : {
+                  "type" : "string"
+                },
+                "scan_org" : {
+                  "type" : "boolean"
+                },
+                "description" : {
+                  "desc" : "This is the description for RepositorySbomSource"
+                }
+              }
+            } ],
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "FlagConfigurationStepNode" : {
@@ -26316,6 +26374,125 @@
                 }
               }
             } ]
+          },
+          "SscaComplianceStepNode" : {
+            "title" : "SscaComplianceStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SscaComplianceStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SscaCompliance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SscaCompliance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SscaComplianceStepInfo" : {
+            "title" : "SscaComplianceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "source" ],
+              "properties" : {
+                "description" : {
+                  "desc" : "This is the description for SscaComplianceStepInfo"
+                },
+                "mode" : {
+                  "type" : "string",
+                  "enum" : [ "compliance" ]
+                },
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "source" ],
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SscaComplianceStepInfo"
+              },
+              "mode" : {
+                "type" : "string",
+                "enum" : [ "compliance" ]
+              },
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              }
+            }
           },
           "Mount" : {
             "title" : "Mount",

--- a/v1/pipeline/stages/security/execution-wrapper-config.yaml
+++ b/v1/pipeline/stages/security/execution-wrapper-config.yaml
@@ -54,6 +54,7 @@ properties:
     - $ref: ../../steps/custom/policy-step-node.yaml
     - $ref: ../../steps/common/template-step-node.yaml
     - $ref: ../../steps/common/wiz-scan-node.yaml
+    - $ref: ../../steps/common/ssca-compliance-step-node.yaml
   description:
     desc: This is the description for ExecutionWrapperConfig
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/steps/common/ssca-compliance-step-info.yaml
+++ b/v1/pipeline/steps/common/ssca-compliance-step-info.yaml
@@ -1,0 +1,33 @@
+title: SscaComplianceStepInfo
+allOf:
+- $ref: ../../common/step-spec-type.yaml
+- type: object
+  required:
+  - source
+  properties:
+    description:
+      desc: This is the description for SscaComplianceStepInfo
+    mode:
+      type: string
+      enum:
+      - compliance
+    source:
+      $ref: ../custom/ssca-compliance-source.yaml
+    resources:
+      $ref: ../../common/container-resource.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+- source
+properties:
+  description:
+    desc: This is the description for SscaComplianceStepInfo
+  mode:
+    type: string
+    enum:
+    - compliance
+  source:
+    $ref: ../custom/ssca-compliance-source.yaml
+  resources:
+    $ref: ../../common/container-resource.yaml
+

--- a/v1/pipeline/steps/common/ssca-compliance-step-info.yaml
+++ b/v1/pipeline/steps/common/ssca-compliance-step-info.yaml
@@ -7,10 +7,6 @@ allOf:
   properties:
     description:
       desc: This is the description for SscaComplianceStepInfo
-    mode:
-      type: string
-      enum:
-      - compliance
     source:
       $ref: ../custom/ssca-compliance-source.yaml
     resources:
@@ -22,10 +18,6 @@ required:
 properties:
   description:
     desc: This is the description for SscaComplianceStepInfo
-  mode:
-    type: string
-    enum:
-    - compliance
   source:
     $ref: ../custom/ssca-compliance-source.yaml
   resources:

--- a/v1/pipeline/steps/common/ssca-compliance-step-node.yaml
+++ b/v1/pipeline/steps/common/ssca-compliance-step-node.yaml
@@ -1,0 +1,55 @@
+title: SscaComplianceStepNode
+type: object
+required:
+- identifier
+- name
+- spec
+properties:
+  description:
+    type: string
+    desc: This is the description for SscaComplianceStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+    - type: array
+      items:
+        $ref: ../../common/failure-strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+    - $ref: ../../common/strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+    - SscaCompliance
+  when:
+    oneOf:
+    - $ref: ../../common/step-when-condition.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: SscaCompliance
+  then:
+    properties:
+      spec:
+        $ref: ssca-compliance-step-info.yaml

--- a/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -3,10 +3,10 @@ allOf:
 - $ref: ssca-compliance-source-spec.yaml
 - type: object
   required:
-  - connector
+  - connectorRef
   - scan_org
   properties:
-    connector:
+    connectorRef:
       type: string
     repoName:
       type: string

--- a/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -1,15 +1,14 @@
 title: RepositorySscaComplianceSource
 allOf:
-- $ref: sbom-source-spec.yaml
+- $ref: ssca-compliance-source-spec.yaml
 - type: object
   required:
   - connector
-  - repo
   - scan_org
   properties:
     connector:
       type: string
-    repo:
+    repoName:
       type: string
     scan_org:
       type: boolean

--- a/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -1,0 +1,20 @@
+title: RepositorySscaComplianceSource
+allOf:
+- $ref: sbom-source-spec.yaml
+- type: object
+  required:
+  - connector
+  - repo
+  - scan_org
+  properties:
+    connector:
+      type: string
+      enum:
+        - github
+    repo:
+      type: string
+    scan_org:
+      type: boolean
+    description:
+      desc: This is the description for RepositorySbomSource
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -9,12 +9,10 @@ allOf:
   properties:
     connector:
       type: string
-      enum:
-        - github
     repo:
       type: string
     scan_org:
       type: boolean
     description:
-      desc: This is the description for RepositorySbomSource
+      desc: This is the description for RepositorySscaComplianceSource
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/steps/custom/ssca-compliance-source-spec.yaml
+++ b/v1/pipeline/steps/custom/ssca-compliance-source-spec.yaml
@@ -1,0 +1,6 @@
+title: SbomSourceSpec
+type: object
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for SscaComplianceSourceSpec

--- a/v1/pipeline/steps/custom/ssca-compliance-source.yaml
+++ b/v1/pipeline/steps/custom/ssca-compliance-source.yaml
@@ -1,0 +1,22 @@
+title: SscaComplianceSource
+type: object
+required:
+- type
+properties:
+  type:
+    type: string
+    enum:
+    - scm
+  description:
+    desc: This is the description for SscaComplianceSource
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: scm
+  then:
+    properties:
+      spec:
+        $ref: repository-ssca-compliance-source.yaml
+

--- a/v1/template.json
+++ b/v1/template.json
@@ -37656,8 +37656,7 @@
               "required" : [ "connector", "repo", "scan_org" ],
               "properties" : {
                 "connector" : {
-                  "type" : "string",
-                  "enum" : [ "github" ]
+                  "type" : "string"
                 },
                 "repo" : {
                   "type" : "string"
@@ -37666,7 +37665,7 @@
                   "type" : "boolean"
                 },
                 "description" : {
-                  "desc" : "This is the description for RepositorySbomSource"
+                  "desc" : "This is the description for RepositorySscaComplianceSource"
                 }
               }
             } ],

--- a/v1/template.json
+++ b/v1/template.json
@@ -37616,6 +37616,62 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
+          "SscaComplianceSource" : {
+            "title" : "SscaComplianceSource",
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "scm" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SscaComplianceSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "scm"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySscaComplianceSource"
+                  }
+                }
+              }
+            } ]
+          },
+          "RepositorySscaComplianceSource" : {
+            "title" : "RepositorySscaComplianceSource",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "repo", "scan_org" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string",
+                  "enum" : [ "github" ]
+                },
+                "repo" : {
+                  "type" : "string"
+                },
+                "scan_org" : {
+                  "type" : "boolean"
+                },
+                "description" : {
+                  "desc" : "This is the description for RepositorySbomSource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
           "FlagConfigurationStepNode" : {
             "title" : "FlagConfigurationStepNode",
             "type" : "object",
@@ -57501,6 +57557,125 @@
               }
             } ]
           },
+          "SscaComplianceStepNode" : {
+            "title" : "SscaComplianceStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for SscaComplianceStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SscaCompliance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SscaCompliance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SscaComplianceStepInfo" : {
+            "title" : "SscaComplianceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "source" ],
+              "properties" : {
+                "description" : {
+                  "desc" : "This is the description for SscaComplianceStepInfo"
+                },
+                "mode" : {
+                  "type" : "string",
+                  "enum" : [ "compliance" ]
+                },
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "source" ],
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SscaComplianceStepInfo"
+              },
+              "mode" : {
+                "type" : "string",
+                "enum" : [ "compliance" ]
+              },
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              }
+            }
+          },
           "Mount" : {
             "title" : "Mount",
             "type" : "object",
@@ -66614,6 +66789,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/TemplateStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepNode"
                 } ]
               },
               "description" : {

--- a/v1/template.json
+++ b/v1/template.json
@@ -37653,9 +37653,9 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "scan_org" ],
+              "required" : [ "connectorRef", "scan_org" ],
               "properties" : {
-                "connector" : {
+                "connectorRef" : {
                   "type" : "string"
                 },
                 "repoName" : {

--- a/v1/template.json
+++ b/v1/template.json
@@ -37653,12 +37653,12 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "repo", "scan_org" ],
+              "required" : [ "connector", "scan_org" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
                 },
-                "repo" : {
+                "repoName" : {
                   "type" : "string"
                 },
                 "scan_org" : {
@@ -57644,10 +57644,6 @@
                 "description" : {
                   "desc" : "This is the description for SscaComplianceStepInfo"
                 },
-                "mode" : {
-                  "type" : "string",
-                  "enum" : [ "compliance" ]
-                },
                 "source" : {
                   "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
                 },
@@ -57662,10 +57658,6 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for SscaComplianceStepInfo"
-              },
-              "mode" : {
-                "type" : "string",
-                "enum" : [ "compliance" ]
               },
               "source" : {
                 "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"


### PR DESCRIPTION
In CI, Git Clone Step uses connectorRef as variable name for fetching the connector string.
Previously SSCA Compliance step had used the same as connector variable, renaming it to connectorRef to make it uniform.

Note: This will not break anything as SSCA Compliance Step is still a new step and is not publicly accessible.