### PR TITLE
feat: [SSCA-1861]:Changed variable connector to connectorRef, to make…

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -15406,9 +15406,9 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "scan_org" ],
+              "required" : [ "connectorRef", "scan_org" ],
               "properties" : {
-                "connector" : {
+                "connectorRef" : {
                   "type" : "string"
                 },
                 "repoName" : {

--- a/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -3,10 +3,10 @@ allOf:
 - $ref: ssca-compliance-source-spec.yaml
 - type: object
   required:
-  - connector
+  - connectorRef
   - scan_org
   properties:
-    connector:
+    connectorRef:
       type: string
     repoName:
       type: string

--- a/v0/template.json
+++ b/v0/template.json
@@ -36676,9 +36676,9 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "scan_org" ],
+              "required" : [ "connectorRef", "scan_org" ],
               "properties" : {
-                "connector" : {
+                "connectorRef" : {
                   "type" : "string"
                 },
                 "repoName" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -10459,9 +10459,9 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "scan_org" ],
+              "required" : [ "connectorRef", "scan_org" ],
               "properties" : {
-                "connector" : {
+                "connectorRef" : {
                   "type" : "string"
                 },
                 "repoName" : {

--- a/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -3,10 +3,10 @@ allOf:
 - $ref: ssca-compliance-source-spec.yaml
 - type: object
   required:
-  - connector
+  - connectorRef
   - scan_org
   properties:
-    connector:
+    connectorRef:
       type: string
     repoName:
       type: string

--- a/v1/template.json
+++ b/v1/template.json
@@ -37653,9 +37653,9 @@
               "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "scan_org" ],
+              "required" : [ "connectorRef", "scan_org" ],
               "properties" : {
-                "connector" : {
+                "connectorRef" : {
                   "type" : "string"
                 },
                 "repoName" : {


### PR DESCRIPTION
In CI, Git Clone Step uses connectorRef as variable name for fetching the connector string.
Previously SSCA Compliance step had used the same as connector variable, renaming it to connectorRef to make it uniform.

Note: This will not break anything as SSCA Compliance Step is still a new step and is not publicly accessible.