### PR TITLE
feat: [SSCA-1954]: Allowed expressions in Ssca Compliance scan_org field

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -15415,7 +15415,13 @@
                   "type" : "string"
                 },
                 "scan_org" : {
-                  "type" : "boolean"
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "description" : {
                   "desc" : "This is the description for RepositorySscaComplianceSource"

--- a/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -11,7 +11,11 @@ allOf:
     repoName:
       type: string
     scan_org:
-      type: boolean
+      oneOf:
+      - type: boolean
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
     description:
       desc: This is the description for RepositorySscaComplianceSource
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/template.json
+++ b/v0/template.json
@@ -36685,7 +36685,13 @@
                   "type" : "string"
                 },
                 "scan_org" : {
-                  "type" : "boolean"
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "description" : {
                   "desc" : "This is the description for RepositorySscaComplianceSource"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -10468,7 +10468,13 @@
                   "type" : "string"
                 },
                 "scan_org" : {
-                  "type" : "boolean"
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "description" : {
                   "desc" : "This is the description for RepositorySscaComplianceSource"

--- a/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v1/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -11,7 +11,11 @@ allOf:
     repoName:
       type: string
     scan_org:
-      type: boolean
+      oneOf:
+      - type: boolean
+      - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
     description:
       desc: This is the description for RepositorySscaComplianceSource
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/template.json
+++ b/v1/template.json
@@ -37662,7 +37662,13 @@
                   "type" : "string"
                 },
                 "scan_org" : {
-                  "type" : "boolean"
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "description" : {
                   "desc" : "This is the description for RepositorySscaComplianceSource"


### PR DESCRIPTION
SSCA Compliance step does not accept expression in scan_org field. To fix this added OneOf boolean or string with pattern.
The same is done for the privilege variable in pipeline.