### PR TITLE
fix: [CI-12730]: added pattern for report path in steps

### DIFF
--- a/v1/pipeline/steps/common/report.yaml
+++ b/v1/pipeline/steps/common/report.yaml
@@ -9,6 +9,8 @@ properties:
           type: string
         type: array
       - type: string
+        pattern: "^<\\+input>$"
+        minLength: 1
   type:
     type: string
     description: Type provides the report type.


### PR DESCRIPTION
Added a strict string validation for report path to contain either an array or runtime-input