### PR TITLE
feat: [SSCA-2017]: allow scan org expression via harness schema

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -15425,7 +15425,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "^<\\+.*>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                     "minLength" : 1
                   } ]
                 },

--- a/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
+++ b/v0/pipeline/steps/custom/repository-ssca-compliance-source.yaml
@@ -14,7 +14,7 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: ^<\+.*>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
         minLength: 1
     description:
       desc: This is the description for RepositorySscaComplianceSource

--- a/v0/template.json
+++ b/v0/template.json
@@ -36689,7 +36689,7 @@
                     "type" : "boolean"
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "^<\\+.*>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                     "minLength" : 1
                   } ]
                 },


### PR DESCRIPTION
We want to have this field as both expression and runtime input.
