### PR TITLE
feat: [CDS-97667]: Add environment variables schema for native helm step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -38095,6 +38095,15 @@
                   "minLength" : 1
                 } ]
               },
+              "environmentVariables" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
               "description" : {
                 "desc" : "This is the description for HelmDeployStepInfo"
               }
@@ -48981,6 +48990,15 @@
                 }, {
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "environmentVariables" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
               },

--- a/v0/pipeline/steps/cd/helm-deploy-step-info.yaml
+++ b/v0/pipeline/steps/cd/helm-deploy-step-info.yaml
@@ -44,5 +44,11 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
+  environmentVariables:
+    oneOf:
+    - $ref: ../common/parameter-field-map-string-string.yaml
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for HelmDeployStepInfo

--- a/v0/pipeline/steps/cd/helm-rollback-step-info.yaml
+++ b/v0/pipeline/steps/cd/helm-rollback-step-info.yaml
@@ -36,5 +36,11 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
+  environmentVariables:
+    oneOf:
+    - $ref: ../common/parameter-field-map-string-string.yaml
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for HelmRollbackStepInfo

--- a/v0/template.json
+++ b/v0/template.json
@@ -10467,6 +10467,15 @@
                   "minLength" : 1
                 } ]
               },
+              "environmentVariables" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
               "description" : {
                 "desc" : "This is the description for HelmDeployStepInfo"
               }
@@ -10629,6 +10638,15 @@
                 }, {
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "environmentVariables" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
               },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -28953,7 +28953,7 @@
                   "minLength" : 1
                 } ]
               },
-              "environmentVariables" : {
+              "env_vars" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
                 }, {
@@ -39837,7 +39837,7 @@
                   "minLength" : 1
                 } ]
               },
-              "environmentVariables" : {
+              "env_vars" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
                 }, {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -26525,7 +26525,9 @@
                   },
                   "type" : "array"
                 }, {
-                  "type" : "string"
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
                 } ]
               },
               "type" : {
@@ -28948,6 +28950,15 @@
                 }, {
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "environmentVariables" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
               },
@@ -39823,6 +39834,15 @@
                 }, {
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "environmentVariables" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
               },

--- a/v1/pipeline/steps/cd/helm-deploy-step-info.yaml
+++ b/v1/pipeline/steps/cd/helm-deploy-step-info.yaml
@@ -44,7 +44,7 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
-  environmentVariables:
+  env_vars:
     oneOf:
     - $ref: ../common/parameter-field-map-string-string.yaml
     - type: string

--- a/v1/pipeline/steps/cd/helm-deploy-step-info.yaml
+++ b/v1/pipeline/steps/cd/helm-deploy-step-info.yaml
@@ -44,5 +44,11 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
+  environmentVariables:
+    oneOf:
+    - $ref: ../common/parameter-field-map-string-string.yaml
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for HelmDeployStepInfo

--- a/v1/pipeline/steps/cd/helm-rollback-step-info.yaml
+++ b/v1/pipeline/steps/cd/helm-rollback-step-info.yaml
@@ -36,7 +36,7 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
-  environmentVariables:
+  env_vars:
     oneOf:
     - $ref: ../common/parameter-field-map-string-string.yaml
     - type: string

--- a/v1/pipeline/steps/cd/helm-rollback-step-info.yaml
+++ b/v1/pipeline/steps/cd/helm-rollback-step-info.yaml
@@ -36,5 +36,11 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
+  environmentVariables:
+    oneOf:
+    - $ref: ../common/parameter-field-map-string-string.yaml
+    - type: string
+      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      minLength: 1
   description:
     desc: This is the description for HelmRollbackStepInfo

--- a/v1/template.json
+++ b/v1/template.json
@@ -12505,6 +12505,15 @@
                   "minLength" : 1
                 } ]
               },
+              "environmentVariables" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
               "description" : {
                 "desc" : "This is the description for HelmDeployStepInfo"
               }
@@ -12667,6 +12676,15 @@
                 }, {
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "environmentVariables" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
               },
@@ -57701,7 +57719,9 @@
                   },
                   "type" : "array"
                 }, {
-                  "type" : "string"
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
                 } ]
               },
               "type" : {

--- a/v1/template.json
+++ b/v1/template.json
@@ -12505,7 +12505,7 @@
                   "minLength" : 1
                 } ]
               },
-              "environmentVariables" : {
+              "env_vars" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
                 }, {
@@ -12679,7 +12679,7 @@
                   "minLength" : 1
                 } ]
               },
-              "environmentVariables" : {
+              "env_vars" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
                 }, {


### PR DESCRIPTION
Allow environment variables field for native helm steps. The values can be either runtime input or map of string key and values
| Test Case | Screenshot |
|--------|--------|
| Helm Deployment Step with environment variables and multiple value types (expression, fixed and runtime) | <img width="371" alt="Screenshot 2024-06-14 at 14 59 03" src="https://github.com/harness/harness-schema/assets/64782481/639ff5a2-3ef0-4ace-8c99-7a1e80fb548a"> |
| Helm Rollback step with environment variables as runtime input | <img width="321" alt="Screenshot 2024-06-14 at 14 59 14" src="https://github.com/harness/harness-schema/assets/64782481/91a64720-7a5b-4ffd-8078-1ccace04a7d0"> |
| Runtime input screen for case 1 and 2 | <img width="354" alt="Screenshot 2024-06-14 at 14 59 24" src="https://github.com/harness/harness-schema/assets/64782481/1e71b28d-f7d8-485c-bafb-aeab0e98ca12"> | 



