### PR TITLE
fix: [CI-12730]: added pattern for report path in steps

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -15885,7 +15885,9 @@
                       "type" : "string"
                     }
                   }, {
-                    "type" : "string"
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
                   } ]
                 }
               }

--- a/v0/pipeline/steps/common/junit-test-report.yaml
+++ b/v0/pipeline/steps/common/junit-test-report.yaml
@@ -9,6 +9,8 @@ allOf:
         items:
           type: string
       - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/template.json
+++ b/v0/template.json
@@ -36789,7 +36789,9 @@
                       "type" : "string"
                     }
                   }, {
-                    "type" : "string"
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
                   } ]
                 }
               }

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -11298,7 +11298,9 @@
                       "type" : "string"
                     }
                   }, {
-                    "type" : "string"
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
                   } ]
                 }
               }
@@ -26525,7 +26527,9 @@
                   },
                   "type" : "array"
                 }, {
-                  "type" : "string"
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
                 } ]
               },
               "type" : {

--- a/v1/pipeline/steps/common/junit-test-report.yaml
+++ b/v1/pipeline/steps/common/junit-test-report.yaml
@@ -9,6 +9,8 @@ allOf:
         items:
           type: string
       - type: string
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v1/pipeline/steps/common/report.yaml
+++ b/v1/pipeline/steps/common/report.yaml
@@ -9,7 +9,7 @@ properties:
           type: string
         type: array
       - type: string
-        pattern: "^<\\+input>$"
+        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
         minLength: 1
   type:
     type: string

--- a/v1/pipeline/steps/common/report.yaml
+++ b/v1/pipeline/steps/common/report.yaml
@@ -9,6 +9,8 @@ properties:
           type: string
         type: array
       - type: string
+        pattern: "^<\\+input>$"
+        minLength: 1
   type:
     type: string
     description: Type provides the report type.

--- a/v1/template.json
+++ b/v1/template.json
@@ -39600,7 +39600,9 @@
                       "type" : "string"
                     }
                   }, {
-                    "type" : "string"
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
                   } ]
                 }
               }
@@ -57701,7 +57703,9 @@
                   },
                   "type" : "array"
                 }, {
-                  "type" : "string"
+                  "type" : "string",
+                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
                 } ]
               },
               "type" : {


### PR DESCRIPTION
Added a strict string validation for report path to contain either an array or runtime-input with execution-input allowed values and regex