### PR TITLE
fix: [CDS-98140]: k8s - allow expression usage in paths parameter for apply/rollout/delete/patch steps

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -49518,7 +49518,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -61022,7 +61022,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -51865,7 +51865,7 @@
                     "minItems" : 1
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -51935,7 +51935,7 @@
                   "minItems" : 1
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v0/pipeline/steps/cd/delete-manifest-path-spec.yaml
+++ b/v0/pipeline/steps/cd/delete-manifest-path-spec.yaml
@@ -11,7 +11,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v0/pipeline/steps/cd/k8s-apply-step-info.yaml
+++ b/v0/pipeline/steps/cd/k8s-apply-step-info.yaml
@@ -32,7 +32,7 @@ allOf:
         maxItems: 2147483647
         minItems: 1
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
     overrides:
       type: array
@@ -77,7 +77,7 @@ properties:
       maxItems: 2147483647
       minItems: 1
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   manifestSource:
     $ref: manifest-source-wrapper.yaml

--- a/v0/pipeline/steps/cd/rollout-manifest-path-spec.yaml
+++ b/v0/pipeline/steps/cd/rollout-manifest-path-spec.yaml
@@ -11,7 +11,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v0/template.json
+++ b/v0/template.json
@@ -11053,7 +11053,7 @@
                     "minItems" : 1
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -11123,7 +11123,7 @@
                   "minItems" : 1
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v0/template.json
+++ b/v0/template.json
@@ -14205,7 +14205,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -30859,7 +30859,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -40346,7 +40346,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -52428,7 +52428,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -42679,7 +42679,7 @@
                     "minItems" : 1
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -42749,7 +42749,7 @@
                   "minItems" : 1
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v1/pipeline/steps/cd/delete-manifest-path-spec.yaml
+++ b/v1/pipeline/steps/cd/delete-manifest-path-spec.yaml
@@ -11,7 +11,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v1/pipeline/steps/cd/k8s-apply-step-info.yaml
+++ b/v1/pipeline/steps/cd/k8s-apply-step-info.yaml
@@ -32,7 +32,7 @@ allOf:
         maxItems: 256
         minItems: 1
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
     overrides:
       type: array
@@ -77,7 +77,7 @@ properties:
       maxItems: 256
       minItems: 1
     - type: string
-      pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+      pattern: (<\+.+>.*)
       minLength: 1
   manifestSource:
     $ref: manifest-source-wrapper.yaml

--- a/v1/pipeline/steps/cd/rollout-manifest-path-spec.yaml
+++ b/v1/pipeline/steps/cd/rollout-manifest-path-spec.yaml
@@ -11,7 +11,7 @@ allOf:
         items:
           type: string
       - type: string
-        pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+        pattern: (<\+.+>.*)
         minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:

--- a/v1/template.json
+++ b/v1/template.json
@@ -13083,7 +13083,7 @@
                     "minItems" : 1
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 },
@@ -13153,7 +13153,7 @@
                   "minItems" : 1
                 }, {
                   "type" : "string",
-                  "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                  "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
               },

--- a/v1/template.json
+++ b/v1/template.json
@@ -16236,7 +16236,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }
@@ -33463,7 +33463,7 @@
                     }
                   }, {
                     "type" : "string",
-                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
                 }


### PR DESCRIPTION
allow K8s Apply, Delete, Rollout & Patch steps to provide manifest paths as an expression