### PR TITLE
feat: [CDS-98844]: Allow support for applicationRegex in Gitops Sync Step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -44326,10 +44326,16 @@
                 "desc" : "This is the description for SyncStepInfo"
               }
             },
-            "oneOf" : [ {
-              "required" : [ "applicationsList" ]
+            "anyOf" : [ {
+              "oneOf" : [ {
+                "required" : [ "applicationRegex" ]
+              }, {
+                "required" : [ "applicationsList" ]
+              } ]
             }, {
-              "required" : [ "applicationRegex" ]
+              "not" : {
+                "required" : [ "applicationRegex", "applicationsList" ]
+              }
             } ]
           },
           "AgentApplicationTargets" : {

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -44187,6 +44187,9 @@
                     "minLength" : 1
                   } ]
                 },
+                "applicationRegex" : {
+                  "type" : "string"
+                },
                 "applyOnly" : {
                   "oneOf" : [ {
                     "type" : "boolean"
@@ -44240,7 +44243,12 @@
                     "type" : "string"
                   } ]
                 }
-              }
+              },
+              "oneOf" : [ {
+                "required" : [ "applicationsList" ]
+              }, {
+                "required" : [ "applicationRegex" ]
+              } ]
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
@@ -44257,6 +44265,9 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              },
+              "applicationRegex" : {
+                "type" : "string"
               },
               "applyOnly" : {
                 "oneOf" : [ {
@@ -44314,7 +44325,12 @@
               "description" : {
                 "desc" : "This is the description for SyncStepInfo"
               }
-            }
+            },
+            "oneOf" : [ {
+              "required" : [ "applicationsList" ]
+            }, {
+              "required" : [ "applicationRegex" ]
+            } ]
           },
           "AgentApplicationTargets" : {
             "title" : "AgentApplicationTargets",

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -44244,10 +44244,16 @@
                   } ]
                 }
               },
-              "oneOf" : [ {
-                "required" : [ "applicationsList" ]
+              "anyOf" : [ {
+                "oneOf" : [ {
+                  "required" : [ "applicationRegex" ]
+                }, {
+                  "required" : [ "applicationsList" ]
+                } ]
               }, {
-                "required" : [ "applicationRegex" ]
+                "not" : {
+                  "required" : [ "applicationRegex", "applicationsList" ]
+                }
               } ]
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",

--- a/v0/pipeline/steps/cd/sync-step-info.yaml
+++ b/v0/pipeline/steps/cd/sync-step-info.yaml
@@ -109,8 +109,13 @@ properties:
     - type: string
   description:
     desc: This is the description for SyncStepInfo
-oneOf: 
-  - required: 
-    - applicationsList
+anyOf:
+- oneOf:
   - required:
     - applicationRegex
+  - required:
+    - applicationsList
+- not:
+    required:
+    - applicationRegex
+    - applicationsList

--- a/v0/pipeline/steps/cd/sync-step-info.yaml
+++ b/v0/pipeline/steps/cd/sync-step-info.yaml
@@ -51,11 +51,16 @@ allOf:
       oneOf:
         - type: boolean
         - type: string
-  oneOf: 
-  - required: 
-    - applicationsList
-  - required:
-    - applicationRegex
+  anyOf:
+  - oneOf:
+    - required:
+      - applicationRegex
+    - required:
+      - applicationsList
+  - not:
+      required:
+      - applicationRegex
+      - applicationsList
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:

--- a/v0/pipeline/steps/cd/sync-step-info.yaml
+++ b/v0/pipeline/steps/cd/sync-step-info.yaml
@@ -73,6 +73,8 @@ properties:
     - type: string
       pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
       minLength: 1
+  applicationRegex:
+      type: string
   applyOnly:
     oneOf:
     - type: boolean
@@ -107,3 +109,8 @@ properties:
     - type: string
   description:
     desc: This is the description for SyncStepInfo
+oneOf: 
+  - required: 
+    - applicationsList
+  - required:
+    - applicationRegex

--- a/v0/pipeline/steps/cd/sync-step-info.yaml
+++ b/v0/pipeline/steps/cd/sync-step-info.yaml
@@ -17,6 +17,8 @@ allOf:
       - type: string
         pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
         minLength: 1
+    applicationRegex:
+      type: string
     applyOnly:
       oneOf:
       - type: boolean
@@ -49,6 +51,11 @@ allOf:
       oneOf:
         - type: boolean
         - type: string
+  oneOf: 
+  - required: 
+    - applicationsList
+  - required:
+    - applicationRegex
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:

--- a/v0/template.json
+++ b/v0/template.json
@@ -16396,10 +16396,16 @@
                   } ]
                 }
               },
-              "oneOf" : [ {
-                "required" : [ "applicationsList" ]
+              "anyOf" : [ {
+                "oneOf" : [ {
+                  "required" : [ "applicationRegex" ]
+                }, {
+                  "required" : [ "applicationsList" ]
+                } ]
               }, {
-                "required" : [ "applicationRegex" ]
+                "not" : {
+                  "required" : [ "applicationRegex", "applicationsList" ]
+                }
               } ]
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",

--- a/v0/template.json
+++ b/v0/template.json
@@ -16339,6 +16339,9 @@
                     "minLength" : 1
                   } ]
                 },
+                "applicationRegex" : {
+                  "type" : "string"
+                },
                 "applyOnly" : {
                   "oneOf" : [ {
                     "type" : "boolean"
@@ -16392,7 +16395,12 @@
                     "type" : "string"
                   } ]
                 }
-              }
+              },
+              "oneOf" : [ {
+                "required" : [ "applicationsList" ]
+              }, {
+                "required" : [ "applicationRegex" ]
+              } ]
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
@@ -16409,6 +16417,9 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              },
+              "applicationRegex" : {
+                "type" : "string"
               },
               "applyOnly" : {
                 "oneOf" : [ {
@@ -16466,7 +16477,12 @@
               "description" : {
                 "desc" : "This is the description for SyncStepInfo"
               }
-            }
+            },
+            "oneOf" : [ {
+              "required" : [ "applicationsList" ]
+            }, {
+              "required" : [ "applicationRegex" ]
+            } ]
           },
           "AgentApplicationTargets" : {
             "title" : "AgentApplicationTargets",

--- a/v0/template.json
+++ b/v0/template.json
@@ -16478,10 +16478,16 @@
                 "desc" : "This is the description for SyncStepInfo"
               }
             },
-            "oneOf" : [ {
-              "required" : [ "applicationsList" ]
+            "anyOf" : [ {
+              "oneOf" : [ {
+                "required" : [ "applicationRegex" ]
+              }, {
+                "required" : [ "applicationsList" ]
+              } ]
             }, {
-              "required" : [ "applicationRegex" ]
+              "not" : {
+                "required" : [ "applicationRegex", "applicationsList" ]
+              }
             } ]
           },
           "AgentApplicationTargets" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -35071,10 +35071,16 @@
                   } ]
                 }
               },
-              "oneOf" : [ {
-                "required" : [ "applicationsList" ]
+              "anyOf" : [ {
+                "oneOf" : [ {
+                  "required" : [ "applicationRegex" ]
+                }, {
+                  "required" : [ "applicationsList" ]
+                } ]
               }, {
-                "required" : [ "applicationRegex" ]
+                "not" : {
+                  "required" : [ "applicationRegex", "applicationsList" ]
+                }
               } ]
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -35014,6 +35014,9 @@
                     "minLength" : 1
                   } ]
                 },
+                "applicationRegex" : {
+                  "type" : "string"
+                },
                 "applyOnly" : {
                   "oneOf" : [ {
                     "type" : "boolean"
@@ -35067,7 +35070,12 @@
                     "type" : "string"
                   } ]
                 }
-              }
+              },
+              "oneOf" : [ {
+                "required" : [ "applicationsList" ]
+              }, {
+                "required" : [ "applicationRegex" ]
+              } ]
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
@@ -35084,6 +35092,9 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              },
+              "applicationRegex" : {
+                "type" : "string"
               },
               "applyOnly" : {
                 "oneOf" : [ {
@@ -35141,7 +35152,12 @@
               "description" : {
                 "desc" : "This is the description for SyncStepInfo"
               }
-            }
+            },
+            "oneOf" : [ {
+              "required" : [ "applicationsList" ]
+            }, {
+              "required" : [ "applicationRegex" ]
+            } ]
           },
           "AgentApplicationTargets" : {
             "title" : "AgentApplicationTargets",

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -35153,10 +35153,16 @@
                 "desc" : "This is the description for SyncStepInfo"
               }
             },
-            "oneOf" : [ {
-              "required" : [ "applicationsList" ]
+            "anyOf" : [ {
+              "oneOf" : [ {
+                "required" : [ "applicationRegex" ]
+              }, {
+                "required" : [ "applicationsList" ]
+              } ]
             }, {
-              "required" : [ "applicationRegex" ]
+              "not" : {
+                "required" : [ "applicationRegex", "applicationsList" ]
+              }
             } ]
           },
           "AgentApplicationTargets" : {

--- a/v1/pipeline/steps/cd/sync-step-info.yaml
+++ b/v1/pipeline/steps/cd/sync-step-info.yaml
@@ -17,6 +17,8 @@ allOf:
       - type: string
         pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
         minLength: 1
+    applicationRegex:
+      type: string
     applyOnly:
       oneOf:
       - type: boolean
@@ -49,6 +51,11 @@ allOf:
       oneOf:
         - type: boolean
         - type: string
+  oneOf: 
+  - required: 
+    - applicationsList
+  - required:
+    - applicationRegex
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -66,6 +73,8 @@ properties:
     - type: string
       pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
       minLength: 1
+  applicationRegex:
+      type: string
   applyOnly:
     oneOf:
     - type: boolean
@@ -100,3 +109,8 @@ properties:
     - type: string
   description:
     desc: This is the description for SyncStepInfo
+oneOf: 
+  - required: 
+    - applicationsList
+  - required:
+    - applicationRegex

--- a/v1/pipeline/steps/cd/sync-step-info.yaml
+++ b/v1/pipeline/steps/cd/sync-step-info.yaml
@@ -109,8 +109,13 @@ properties:
     - type: string
   description:
     desc: This is the description for SyncStepInfo
-oneOf: 
-  - required: 
-    - applicationsList
+anyOf:
+- oneOf:
   - required:
     - applicationRegex
+  - required:
+    - applicationsList
+- not:
+    required:
+    - applicationRegex
+    - applicationsList

--- a/v1/pipeline/steps/cd/sync-step-info.yaml
+++ b/v1/pipeline/steps/cd/sync-step-info.yaml
@@ -51,11 +51,16 @@ allOf:
       oneOf:
         - type: boolean
         - type: string
-  oneOf: 
-  - required: 
-    - applicationsList
-  - required:
-    - applicationRegex
+  anyOf:
+  - oneOf:
+    - required:
+      - applicationRegex
+    - required:
+      - applicationsList
+  - not:
+      required:
+      - applicationRegex
+      - applicationsList
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:

--- a/v1/template.json
+++ b/v1/template.json
@@ -18443,10 +18443,16 @@
                 "desc" : "This is the description for SyncStepInfo"
               }
             },
-            "oneOf" : [ {
-              "required" : [ "applicationsList" ]
+            "anyOf" : [ {
+              "oneOf" : [ {
+                "required" : [ "applicationRegex" ]
+              }, {
+                "required" : [ "applicationsList" ]
+              } ]
             }, {
-              "required" : [ "applicationRegex" ]
+              "not" : {
+                "required" : [ "applicationRegex", "applicationsList" ]
+              }
             } ]
           },
           "AgentApplicationTargets" : {

--- a/v1/template.json
+++ b/v1/template.json
@@ -18304,6 +18304,9 @@
                     "minLength" : 1
                   } ]
                 },
+                "applicationRegex" : {
+                  "type" : "string"
+                },
                 "applyOnly" : {
                   "oneOf" : [ {
                     "type" : "boolean"
@@ -18357,7 +18360,12 @@
                     "type" : "string"
                   } ]
                 }
-              }
+              },
+              "oneOf" : [ {
+                "required" : [ "applicationsList" ]
+              }, {
+                "required" : [ "applicationRegex" ]
+              } ]
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
@@ -18374,6 +18382,9 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              },
+              "applicationRegex" : {
+                "type" : "string"
               },
               "applyOnly" : {
                 "oneOf" : [ {
@@ -18431,7 +18442,12 @@
               "description" : {
                 "desc" : "This is the description for SyncStepInfo"
               }
-            }
+            },
+            "oneOf" : [ {
+              "required" : [ "applicationsList" ]
+            }, {
+              "required" : [ "applicationRegex" ]
+            } ]
           },
           "AgentApplicationTargets" : {
             "title" : "AgentApplicationTargets",

--- a/v1/template.json
+++ b/v1/template.json
@@ -18361,10 +18361,16 @@
                   } ]
                 }
               },
-              "oneOf" : [ {
-                "required" : [ "applicationsList" ]
+              "anyOf" : [ {
+                "oneOf" : [ {
+                  "required" : [ "applicationRegex" ]
+                }, {
+                  "required" : [ "applicationsList" ]
+                } ]
               }, {
-                "required" : [ "applicationRegex" ]
+                "not" : {
+                  "required" : [ "applicationRegex", "applicationsList" ]
+                }
               } ]
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
This will add a new property to gitops sync step. **applicationRegex**
This should be a regex string(validated in code with pattern.compile())

And with this change, only one of either applicationList(existing field) or applicationRegex will be allowed as a property not both. So this will allow either **none of these fields** OR **one of these fields** not both.

1. If neither are there, then the not subschema will pass, and the anyOf passes. (no applicationRegex, no applicationList is valid)
2. If one is there, then the oneOf subschema will pass, and the anyOf passes. (one of them is also valid)
3. If both are there, then
both of the oneOf subschemas will pass, so the oneOf fails
the not subschema will fail
so the anyOf fails (both of them is not valid)