### PR TITLE
feat:[SSCA-2392] : Modify schema for SSCA steps to add vault attestation and verify attestation

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -8477,26 +8477,23 @@
           },
           "CosignAttestationV1" : {
             "title" : "CosignAttestationV1",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
-            }, {
-              "type" : "object",
-              "required" : [ "private_key", "password" ],
-              "properties" : {
-                "password" : {
-                  "type" : "string"
-                },
-                "private_key" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "private_key", "password" ],
             "properties" : {
+              "password" : {
+                "type" : "string"
+              },
+              "private_key" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignAttestationV1"
+                "type" : "string",
+                "description" : "This is the description for CosignAttestationV1"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
           },
           "AttestationSpecV1" : {
             "title" : "AttestationSpecV1",
@@ -8510,26 +8507,23 @@
           },
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Attestation with Secret Manager V1"
+                "type" : "string",
+                "description" : "This is the description for Cosign Attestation with Secret Manager V1"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
           }
         },
         "approval" : {
@@ -11312,26 +11306,23 @@
           },
           "CosignAttestation" : {
             "title" : "CosignAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "privateKey", "password" ],
-              "properties" : {
-                "privateKey" : {
-                  "type" : "string"
-                },
-                "password" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "privateKey", "password" ],
             "properties" : {
+              "privateKey" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignAttestation"
+                "type" : "string",
+                "description" : "This is the description for CosignAttestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
           },
           "AttestationSpec" : {
             "title" : "AttestationSpec",
@@ -11345,26 +11336,23 @@
           },
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
           },
           "ContainerK8sInfra" : {
             "title" : "ContainerK8sInfra",
@@ -12165,23 +12153,20 @@
           },
           "CosignVerifyAttestation" : {
             "title" : "CosignVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "publicKey" ],
-              "properties" : {
-                "publicKey" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "publicKey" ],
             "properties" : {
+              "publicKey" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignVerifyAttestation"
+                "type" : "string",
+                "description" : "This is the description for CosignVerifyAttestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
           },
           "VerifyAttestationSpec" : {
             "title" : "VerifyAttestationSpec",
@@ -12195,26 +12180,23 @@
           },
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
           },
           "SbomDrift" : {
             "title" : "SbomDrift",
@@ -29601,23 +29583,20 @@
           },
           "CosignSlsaVerifyAttestation" : {
             "title" : "CosignSlsaVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "public_key" ],
-              "properties" : {
-                "public_key" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "public_key" ],
             "properties" : {
+              "public_key" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignSlsaVerifyAttestation"
+                "type" : "string",
+                "description" : "This is the description for Cosign SLSA Verify Attestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
           },
           "SlsaVerifyAttestationSpec" : {
             "title" : "SlsaVerifyAttestationSpec",
@@ -29631,26 +29610,23 @@
           },
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
           },
           "DBApplySchemaStepNode" : {
             "title" : "DBApplySchemaStepNode",

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11218,10 +11218,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignAttestation" : {
@@ -12061,10 +12076,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignVerifyAttestation" : {
@@ -29487,10 +29517,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignSlsaVerifyAttestation" : {

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -12107,7 +12107,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
-              "required" : [ "publicKey", "cosignVariables" ],
+              "required" : [ "publicKey" ],
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
@@ -29595,6 +29595,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -8429,6 +8429,9 @@
               },
               "description" : {
                 "desc" : "This is the description for AttestationV1"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -8443,11 +8446,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
-                    "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
+                    "oneOf" : [ {
+                      "allOf" : [ {
+                        "required" : [ "privateKey", "password" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
+                      } ]
+                    }, {
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
+                      } ]
+                    } ]
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignAttestationV1" : {
             "title" : "CosignAttestationV1",
@@ -8455,12 +8471,27 @@
               "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
             }, {
               "type" : "object",
+              "required" : [ "private_key", "password" ],
               "properties" : {
                 "password" : {
                   "type" : "string"
                 },
                 "private_key" : {
                   "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -8478,6 +8509,43 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for AttestationSpecV1"
+              }
+            }
+          },
+          "CosignSecretManagerAttestation" : {
+            "title" : "CosignSecretManagerAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "keyName" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Attestation with Secret Manager V1"
               }
             }
           }
@@ -11215,6 +11283,9 @@
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -11230,9 +11301,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                      "allOf" : [ {
+                        "required" : [ "privateKey", "password" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                      } ]
                     } ]
                   }
                 }
@@ -12076,6 +12155,9 @@
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -12091,9 +12173,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "publicKey" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                      } ]
                     } ]
                   }
                 }
@@ -29520,6 +29610,9 @@
               },
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -29535,9 +29628,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "public_key" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                      } ]
                     } ]
                   }
                 }

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -8447,18 +8447,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "privateKey", "password" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -8478,20 +8484,6 @@
                 },
                 "private_key" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -8525,20 +8517,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -11301,18 +11279,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "privateKey", "password" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -11332,20 +11316,6 @@
                 },
                 "password" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -11379,20 +11349,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -12173,18 +12129,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "publicKey" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -12201,20 +12163,6 @@
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -12248,20 +12196,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -29628,18 +29562,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "public_key" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -29656,20 +29596,6 @@
               "properties" : {
                 "public_key" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -29703,20 +29629,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11237,7 +11237,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignAttestation" : {
             "title" : "CosignAttestation",
@@ -11245,6 +11246,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "privateKey", "password" ],
               "properties" : {
                 "privateKey" : {
                   "type" : "string"
@@ -11291,6 +11293,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -12095,7 +12098,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignVerifyAttestation" : {
             "title" : "CosignVerifyAttestation",
@@ -12103,6 +12107,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "publicKey", "cosignVariables" ],
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
@@ -12146,6 +12151,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -29536,7 +29542,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignSlsaVerifyAttestation" : {
             "title" : "CosignSlsaVerifyAttestation",
@@ -29544,6 +29551,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "public_key" ],
               "properties" : {
                 "public_key" : {
                   "type" : "string"

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -8508,12 +8508,12 @@
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {
@@ -11337,12 +11337,12 @@
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {
@@ -12181,12 +12181,12 @@
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {
@@ -29611,12 +29611,12 @@
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -8428,7 +8428,8 @@
                 "enum" : [ "cosign" ]
               },
               "description" : {
-                "desc" : "This is the description for AttestationV1"
+                "type" : "string",
+                "description" : "This is the description for AttestationV1"
               },
               "spec" : {
                 "type" : "object"
@@ -8446,21 +8447,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
                     }, {
                       "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }
@@ -11278,21 +11282,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }
@@ -12128,21 +12135,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }
@@ -29561,21 +29571,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11209,12 +11209,9 @@
             "title" : "Attestation",
             "type" : "object",
             "properties" : {
-              "privateKey" : {
-                "type" : "string"
-              },
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
@@ -11224,7 +11221,7 @@
             "allOf" : [ {
               "if" : {
                 "properties" : {
-                  "type" : {
+                  "attestWith" : {
                     "const" : "cosign"
                   }
                 }
@@ -11233,6 +11230,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
                   }
                 }
               }
@@ -11245,11 +11257,25 @@
             }, {
               "type" : "object",
               "properties" : {
-                "password" : {
-                  "type" : "string"
-                },
                 "privateKey" : {
                   "type" : "string"
+                },
+                "privateKeyPassword" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -11267,6 +11293,42 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for AttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerAttestation" : {
+            "title" : "CosignSecretManagerAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Attestation with Secret Manager"
               }
             }
           },
@@ -12016,9 +12078,9 @@
             "title" : "VerifyAttestation",
             "type" : "object",
             "properties" : {
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
@@ -12028,7 +12090,7 @@
             "allOf" : [ {
               "if" : {
                 "properties" : {
-                  "type" : {
+                  "attestWith" : {
                     "const" : "cosign"
                   }
                 }
@@ -12037,6 +12099,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                   }
                 }
               }
@@ -12051,6 +12128,20 @@
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -12068,6 +12159,42 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for VerifyAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerVerifyAttestation" : {
+            "title" : "CosignSecretManagerVerifyAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
             }
           },
@@ -29403,9 +29530,9 @@
             "title" : "SlsaVerifyAttestation",
             "type" : "object",
             "properties" : {
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestation"
@@ -29427,6 +29554,21 @@
                   }
                 }
               }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                  }
+                }
+              }
             } ]
           },
           "CosignSlsaVerifyAttestation" : {
@@ -29438,6 +29580,20 @@
               "properties" : {
                 "public_key" : {
                   "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -29455,6 +29611,42 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerVerifyAttestation" : {
+            "title" : "CosignSecretManagerVerifyAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
             }
           },

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11209,45 +11209,19 @@
             "title" : "Attestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
             } ]
           },
           "CosignAttestation" : {
@@ -11260,7 +11234,7 @@
                 "privateKey" : {
                   "type" : "string"
                 },
-                "privateKeyPassword" : {
+                "password" : {
                   "type" : "string"
                 },
                 "cosignVariables" : {
@@ -12078,45 +12052,19 @@
             "title" : "VerifyAttestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
             } ]
           },
           "CosignVerifyAttestation" : {
@@ -29530,45 +29478,19 @@
             "title" : "SlsaVerifyAttestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
             } ]
           },
           "CosignSlsaVerifyAttestation" : {

--- a/v0/pipeline/stages/ci/attestation-v1.yaml
+++ b/v0/pipeline/stages/ci/attestation-v1.yaml
@@ -19,10 +19,15 @@ allOf:
       properties:
         spec:
           oneOf:
-            - allOf:
-                - required: [privateKey, password]
-                - $ref: cosign-attestation-v1.yaml
-            - allOf:
-                - required: [connector, keyName]
-                - $ref: cosign-secret-manager-attestation-v1.yaml
+            - $ref: cosign-attestation-v1.yaml
+            - $ref: cosign-secret-manager-attestation-v1.yaml
+          cosignVariables:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
 additionalProperties: false

--- a/v0/pipeline/stages/ci/attestation-v1.yaml
+++ b/v0/pipeline/stages/ci/attestation-v1.yaml
@@ -4,9 +4,10 @@ properties:
   type:
     type: string
     enum:
-    - cosign
+      - cosign
   description:
-    desc: This is the description for AttestationV1
+    type: string  # Correcting 'desc' to 'type' for valid schema
+    description: This is the description for AttestationV1
   spec:
     type: object
 $schema: http://json-schema.org/draft-07/schema#
@@ -18,16 +19,18 @@ allOf:
     then:
       properties:
         spec:
+          type: object
           oneOf:
             - $ref: cosign-attestation-v1.yaml
             - $ref: cosign-secret-manager-attestation-v1.yaml
-          cosignVariables:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
+          properties:
+            cosignVariables:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
 additionalProperties: false

--- a/v0/pipeline/stages/ci/attestation-v1.yaml
+++ b/v0/pipeline/stages/ci/attestation-v1.yaml
@@ -7,13 +7,22 @@ properties:
     - cosign
   description:
     desc: This is the description for AttestationV1
+  spec:
+    type: object
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
-- if:
-    properties:
-      type:
-        const: cosign
-  then:
-    properties:
-      spec:
-        $ref: cosign-attestation-v1.yaml
+  - if:
+      properties:
+        type:
+          const: cosign
+    then:
+      properties:
+        spec:
+          oneOf:
+            - allOf:
+                - required: [privateKey, password]
+                - $ref: cosign-attestation-v1.yaml
+            - allOf:
+                - required: [connector, keyName]
+                - $ref: cosign-secret-manager-attestation-v1.yaml
+additionalProperties: false

--- a/v0/pipeline/stages/ci/cosign-attestation-v1.yaml
+++ b/v0/pipeline/stages/ci/cosign-attestation-v1.yaml
@@ -1,16 +1,16 @@
 title: CosignAttestationV1
-allOf:
-- $ref: attestation-spec-v1.yaml
-- type: object
-  required:
-    - private_key
-    - password
-  properties:
-    password:
-      type: string
-    private_key:
-      type: string
-$schema: http://json-schema.org/draft-07/schema#
+type: object
+$ref: attestation-spec-v1.yaml
+required:
+  - private_key
+  - password
 properties:
+  password:
+    type: string
+  private_key:
+    type: string
   description:
-    desc: This is the description for CosignAttestationV1
+    type: string
+    description: This is the description for CosignAttestationV1
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/stages/ci/cosign-attestation-v1.yaml
+++ b/v0/pipeline/stages/ci/cosign-attestation-v1.yaml
@@ -10,15 +10,6 @@ allOf:
       type: string
     private_key:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/stages/ci/cosign-secret-manager-attestation-v1.yaml
+++ b/v0/pipeline/stages/ci/cosign-secret-manager-attestation-v1.yaml
@@ -3,11 +3,11 @@ type: object
 $ref: attestation-spec-v1.yaml
 required:
   - connector
-  - keyName
+  - key
 properties:
   connector:
     type: string
-  keyName:
+  key:
     type: string
   description:
     type: string

--- a/v0/pipeline/stages/ci/cosign-secret-manager-attestation-v1.yaml
+++ b/v0/pipeline/stages/ci/cosign-secret-manager-attestation-v1.yaml
@@ -1,16 +1,17 @@
 title: CosignSecretManagerAttestation
-allOf:
-- $ref: attestation-spec-v1.yaml
-- type: object
-  required:
-    - connector
-    - keyName
-  properties:
-    connector:
-      type: string
-    keyName:
-      type: string
-$schema: http://json-schema.org/draft-07/schema#
+type: object
+$ref: attestation-spec-v1.yaml
+required:
+  - connector
+  - keyName
 properties:
+  connector:
+    type: string
+  keyName:
+    type: string
   description:
-    desc: This is the description for Cosign Attestation with Secret Manager V1
+    type: string
+    description: This is the description for Cosign Attestation with Secret Manager V1
+
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/stages/ci/cosign-secret-manager-attestation-v1.yaml
+++ b/v0/pipeline/stages/ci/cosign-secret-manager-attestation-v1.yaml
@@ -10,15 +10,6 @@ allOf:
       type: string
     keyName:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/stages/ci/cosign-secret-manager-attestation-v1.yaml
+++ b/v0/pipeline/stages/ci/cosign-secret-manager-attestation-v1.yaml
@@ -1,14 +1,14 @@
-title: CosignAttestationV1
+title: CosignSecretManagerAttestation
 allOf:
 - $ref: attestation-spec-v1.yaml
 - type: object
   required:
-    - private_key
-    - password
+    - connector
+    - keyName
   properties:
-    password:
+    connector:
       type: string
-    private_key:
+    keyName:
       type: string
     cosignVariables:
       type: array
@@ -22,4 +22,4 @@ allOf:
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:
-    desc: This is the description for CosignAttestationV1
+    desc: This is the description for Cosign Attestation with Secret Manager V1

--- a/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
@@ -2,6 +2,9 @@ title: CosignSecretManagerVerifyAttestation
 allOf:
 - $ref: slsa-verify-attestation-spec.yaml
 - type: object
+  required:
+  - connector
+  - keyName
   properties:
     connector:
       type: string

--- a/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
@@ -1,9 +1,11 @@
-title: CosignVerifyAttestation
+title: CosignSecretManagerVerifyAttestation
 allOf:
-- $ref: verify-attestation-spec.yaml
+- $ref: slsa-verify-attestation-spec.yaml
 - type: object
   properties:
-    publicKey:
+    connector:
+      type: string
+    keyName:
       type: string
     cosignVariables:
       type: array
@@ -17,4 +19,4 @@ allOf:
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:
-    desc: This is the description for CosignVerifyAttestation
+    desc: This is the description for Cosign Verify Attestation with Secret Manager

--- a/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
@@ -10,15 +10,6 @@ allOf:
       type: string
     keyName:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
@@ -1,16 +1,16 @@
 title: CosignSecretManagerVerifyAttestation
-allOf:
-- $ref: slsa-verify-attestation-spec.yaml
-- type: object
-  required:
+type: object
+$ref: slsa-verify-attestation-spec.yaml
+required:
   - connector
   - keyName
-  properties:
-    connector:
-      type: string
-    keyName:
-      type: string
-$schema: http://json-schema.org/draft-07/schema#
 properties:
+  connector:
+    type: string
+  keyName:
+    type: string
   description:
-    desc: This is the description for Cosign Verify Attestation with Secret Manager
+    type: string
+    description: This is the description for Cosign Verify Attestation with Secret Manager
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-secret-manager-verify-attestation.yaml
@@ -3,11 +3,11 @@ type: object
 $ref: slsa-verify-attestation-spec.yaml
 required:
   - connector
-  - keyName
+  - key
 properties:
   connector:
     type: string
-  keyName:
+  key:
     type: string
   description:
     type: string

--- a/v0/pipeline/steps/common/cosign-slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-slsa-verify-attestation.yaml
@@ -1,13 +1,13 @@
 title: CosignSlsaVerifyAttestation
-allOf:
-- $ref: slsa-verify-attestation-spec.yaml
-- type: object
-  required:
-  - public_key
-  properties:
-    public_key:
-      type: string
-$schema: http://json-schema.org/draft-07/schema#
+type: object
+$ref: slsa-verify-attestation-spec.yaml
+required:
+- public_key
 properties:
+  public_key:
+    type: string
   description:
-    desc: This is the description for CosignSlsaVerifyAttestation
+    type: string
+    description: This is the description for Cosign SLSA Verify Attestation
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/common/cosign-slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-slsa-verify-attestation.yaml
@@ -7,15 +7,6 @@ allOf:
   properties:
     public_key:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/common/cosign-slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-slsa-verify-attestation.yaml
@@ -5,6 +5,15 @@ allOf:
   properties:
     public_key:
       type: string
+    cosignVariables:
+      type: array
+      items:
+        type: object
+        properties:
+          key:
+            type: string
+          value:
+            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/common/cosign-slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-slsa-verify-attestation.yaml
@@ -2,6 +2,8 @@ title: CosignSlsaVerifyAttestation
 allOf:
 - $ref: slsa-verify-attestation-spec.yaml
 - type: object
+  required:
+  - public_key
   properties:
     public_key:
       type: string

--- a/v0/pipeline/steps/common/slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/slsa-verify-attestation.yaml
@@ -7,6 +7,8 @@ properties:
       - cosign
   description:
     desc: This is the description for SlsaVerifyAttestation
+  spec:
+    type: object
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
   - if:
@@ -17,6 +19,10 @@ allOf:
       properties:
         spec:
           oneOf:
-            - $ref: cosign-slsa-verify-attestation.yaml
-            - $ref: cosign-secret-manager-verify-attestation.yaml
+            - allOf:
+                - required: [public_key]
+                - $ref: cosign-slsa-verify-attestation.yaml
+            - allOf:
+                - required: [connector, keyName]
+                - $ref: cosign-secret-manager-verify-attestation.yaml
 additionalProperties: false

--- a/v0/pipeline/steps/common/slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/slsa-verify-attestation.yaml
@@ -1,19 +1,28 @@
 title: SlsaVerifyAttestation
 type: object
 properties:
-  type:
+  attestWith:
     type: string
     enum:
-    - cosign
+      - cosign
+      - cosignWithSecretManager
   description:
     desc: This is the description for SlsaVerifyAttestation
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
-- if:
-    properties:
-      type:
-        const: cosign
-  then:
-    properties:
-      spec:
-        $ref: cosign-slsa-verify-attestation.yaml
+  - if:
+      properties:
+        type:
+          const: cosign
+    then:
+      properties:
+        spec:
+          $ref: cosign-slsa-verify-attestation.yaml
+  - if:
+      properties:
+        attestWith:
+          const: cosignWithSecretManager
+    then:
+      properties:
+        spec:
+          $ref: cosign-secret-manager-verify-attestation.yaml

--- a/v0/pipeline/steps/common/slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/slsa-verify-attestation.yaml
@@ -19,3 +19,4 @@ allOf:
           oneOf:
             - $ref: cosign-slsa-verify-attestation.yaml
             - $ref: cosign-secret-manager-verify-attestation.yaml
+additionalProperties: false

--- a/v0/pipeline/steps/common/slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/slsa-verify-attestation.yaml
@@ -18,16 +18,18 @@ allOf:
     then:
       properties:
         spec:
+          type: object
           oneOf:
             - $ref: cosign-slsa-verify-attestation.yaml
             - $ref: cosign-secret-manager-verify-attestation.yaml
-          cosignVariables:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
+          properties:
+            cosignVariables:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
 additionalProperties: false

--- a/v0/pipeline/steps/common/slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/slsa-verify-attestation.yaml
@@ -8,6 +8,14 @@ properties:
   description:
     desc: This is the description for SlsaVerifyAttestation
 $schema: http://json-schema.org/draft-07/schema#
-oneOf:
-  - $ref: cosign-slsa-verify-attestation.yaml
-  - $ref: cosign-secret-manager-verify-attestation.yaml
+allOf:
+  - if:
+      properties:
+        type:
+          const: cosign
+    then:
+      properties:
+        spec:
+          oneOf:
+            - $ref: cosign-slsa-verify-attestation.yaml
+            - $ref: cosign-secret-manager-verify-attestation.yaml

--- a/v0/pipeline/steps/common/slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/slsa-verify-attestation.yaml
@@ -1,28 +1,13 @@
 title: SlsaVerifyAttestation
 type: object
 properties:
-  attestWith:
+  type:
     type: string
     enum:
       - cosign
-      - cosignWithSecretManager
   description:
     desc: This is the description for SlsaVerifyAttestation
 $schema: http://json-schema.org/draft-07/schema#
-allOf:
-  - if:
-      properties:
-        type:
-          const: cosign
-    then:
-      properties:
-        spec:
-          $ref: cosign-slsa-verify-attestation.yaml
-  - if:
-      properties:
-        attestWith:
-          const: cosignWithSecretManager
-    then:
-      properties:
-        spec:
-          $ref: cosign-secret-manager-verify-attestation.yaml
+oneOf:
+  - $ref: cosign-slsa-verify-attestation.yaml
+  - $ref: cosign-secret-manager-verify-attestation.yaml

--- a/v0/pipeline/steps/common/slsa-verify-attestation.yaml
+++ b/v0/pipeline/steps/common/slsa-verify-attestation.yaml
@@ -19,10 +19,15 @@ allOf:
       properties:
         spec:
           oneOf:
-            - allOf:
-                - required: [public_key]
-                - $ref: cosign-slsa-verify-attestation.yaml
-            - allOf:
-                - required: [connector, keyName]
-                - $ref: cosign-secret-manager-verify-attestation.yaml
+            - $ref: cosign-slsa-verify-attestation.yaml
+            - $ref: cosign-secret-manager-verify-attestation.yaml
+          cosignVariables:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
 additionalProperties: false

--- a/v0/pipeline/steps/custom/attestation.yaml
+++ b/v0/pipeline/steps/custom/attestation.yaml
@@ -8,6 +8,14 @@ properties:
   description:
     desc: This is the description for Attestation
 $schema: http://json-schema.org/draft-07/schema#
-oneOf:
-  - $ref: cosign-attestation.yaml
-  - $ref: cosign-secret-manager-attestation.yaml
+allOf:
+  - if:
+      properties:
+        type:
+          const: cosign
+    then:
+      properties:
+        spec:
+          oneOf:
+            - $ref: cosign-attestation.yaml
+            - $ref: cosign-secret-manager-attestation.yaml

--- a/v0/pipeline/steps/custom/attestation.yaml
+++ b/v0/pipeline/steps/custom/attestation.yaml
@@ -18,16 +18,18 @@ allOf:
     then:
       properties:
         spec:
+          type: object
           oneOf:
             - $ref: cosign-attestation.yaml
             - $ref: cosign-secret-manager-attestation.yaml
-          cosignVariables:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
+          properties:
+            cosignVariables:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
 additionalProperties: false

--- a/v0/pipeline/steps/custom/attestation.yaml
+++ b/v0/pipeline/steps/custom/attestation.yaml
@@ -19,10 +19,15 @@ allOf:
       properties:
         spec:
           oneOf:
-            - allOf:
-                - required: [privateKey, password]
-                - $ref: cosign-attestation.yaml
-            - allOf:
-                - required: [connector, keyName]
-                - $ref: cosign-secret-manager-attestation.yaml
+            - $ref: cosign-attestation.yaml
+            - $ref: cosign-secret-manager-attestation.yaml
+          cosignVariables:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
 additionalProperties: false

--- a/v0/pipeline/steps/custom/attestation.yaml
+++ b/v0/pipeline/steps/custom/attestation.yaml
@@ -1,21 +1,28 @@
 title: Attestation
 type: object
 properties:
-  privateKey:
-    type: string
-  type:
+  attestWith:
     type: string
     enum:
-    - cosign
+      - cosign
+      - cosignWithSecretManager
   description:
     desc: This is the description for Attestation
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
-- if:
-    properties:
-      type:
-        const: cosign
-  then:
-    properties:
-      spec:
-        $ref: cosign-attestation.yaml
+  - if:
+      properties:
+        attestWith:
+          const: cosign
+    then:
+      properties:
+        spec:
+          $ref: cosign-attestation.yaml
+  - if:
+      properties:
+        attestWith:
+          const: cosignWithSecretManager
+    then:
+      properties:
+        spec:
+          $ref: cosign-secret-manager-attestation.yaml

--- a/v0/pipeline/steps/custom/attestation.yaml
+++ b/v0/pipeline/steps/custom/attestation.yaml
@@ -1,28 +1,13 @@
 title: Attestation
 type: object
 properties:
-  attestWith:
+  type:
     type: string
     enum:
       - cosign
-      - cosignWithSecretManager
   description:
     desc: This is the description for Attestation
 $schema: http://json-schema.org/draft-07/schema#
-allOf:
-  - if:
-      properties:
-        attestWith:
-          const: cosign
-    then:
-      properties:
-        spec:
-          $ref: cosign-attestation.yaml
-  - if:
-      properties:
-        attestWith:
-          const: cosignWithSecretManager
-    then:
-      properties:
-        spec:
-          $ref: cosign-secret-manager-attestation.yaml
+oneOf:
+  - $ref: cosign-attestation.yaml
+  - $ref: cosign-secret-manager-attestation.yaml

--- a/v0/pipeline/steps/custom/attestation.yaml
+++ b/v0/pipeline/steps/custom/attestation.yaml
@@ -7,6 +7,8 @@ properties:
       - cosign
   description:
     desc: This is the description for Attestation
+  spec:
+    type: object
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
   - if:
@@ -17,6 +19,10 @@ allOf:
       properties:
         spec:
           oneOf:
-            - $ref: cosign-attestation.yaml
-            - $ref: cosign-secret-manager-attestation.yaml
+            - allOf:
+                - required: [privateKey, password]
+                - $ref: cosign-attestation.yaml
+            - allOf:
+                - required: [connector, keyName]
+                - $ref: cosign-secret-manager-attestation.yaml
 additionalProperties: false

--- a/v0/pipeline/steps/custom/attestation.yaml
+++ b/v0/pipeline/steps/custom/attestation.yaml
@@ -19,3 +19,4 @@ allOf:
           oneOf:
             - $ref: cosign-attestation.yaml
             - $ref: cosign-secret-manager-attestation.yaml
+additionalProperties: false

--- a/v0/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-attestation.yaml
@@ -5,7 +5,7 @@ allOf:
   properties:
     privateKey:
       type: string
-    privateKeyPassword:
+    password:
       type: string
     cosignVariables:
       type: array

--- a/v0/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-attestation.yaml
@@ -3,10 +3,19 @@ allOf:
 - $ref: attestation-spec.yaml
 - type: object
   properties:
-    password:
-      type: string
     privateKey:
       type: string
+    privateKeyPassword:
+      type: string
+    cosignVariables:
+      type: array
+      items:
+        type: object
+        properties:
+          key:
+            type: string
+          value:
+            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-attestation.yaml
@@ -2,6 +2,9 @@ title: CosignAttestation
 allOf:
 - $ref: attestation-spec.yaml
 - type: object
+  required:
+    - privateKey
+    - password
   properties:
     privateKey:
       type: string

--- a/v0/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-attestation.yaml
@@ -1,16 +1,16 @@
 title: CosignAttestation
-allOf:
-- $ref: attestation-spec.yaml
-- type: object
-  required:
-    - privateKey
-    - password
-  properties:
-    privateKey:
-      type: string
-    password:
-      type: string
-$schema: http://json-schema.org/draft-07/schema#
+type: object
+$ref: attestation-spec.yaml
+required:
+  - privateKey
+  - password
 properties:
+  privateKey:
+    type: string
+  password:
+    type: string
   description:
-    desc: This is the description for CosignAttestation
+    type: string
+    description: This is the description for CosignAttestation
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-attestation.yaml
@@ -10,15 +10,6 @@ allOf:
       type: string
     password:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -1,16 +1,17 @@
 title: CosignSecretManagerAttestation
-allOf:
-- $ref: attestation-spec.yaml
-- type: object
-  required:
-    - connector
-    - keyName
-  properties:
-    connector:
-      type: string
-    keyName:
-      type: string
-$schema: http://json-schema.org/draft-07/schema#
+type: object
+$ref: attestation-spec.yaml
+required:
+  - connector
+  - keyName
 properties:
+  connector:
+    type: string
+  keyName:
+    type: string
   description:
-    desc: This is the description for Cosign Attestation with Secret Manager
+    type: string
+    description: This is the description for Cosign Attestation with Secret Manager
+
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -3,11 +3,11 @@ type: object
 $ref: attestation-spec.yaml
 required:
   - connector
-  - keyName
+  - key
 properties:
   connector:
     type: string
-  keyName:
+  key:
     type: string
   description:
     type: string

--- a/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -2,6 +2,9 @@ title: CosignSecretManagerAttestation
 allOf:
 - $ref: attestation-spec.yaml
 - type: object
+  required:
+    - connector
+    - keyName
   properties:
     connector:
       type: string

--- a/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -10,15 +10,6 @@ allOf:
       type: string
     keyName:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -1,9 +1,11 @@
-title: CosignVerifyAttestation
+title: CosignSecretManagerAttestation
 allOf:
-- $ref: verify-attestation-spec.yaml
+- $ref: attestation-spec.yaml
 - type: object
   properties:
-    publicKey:
+    connector:
+      type: string
+    keyName:
       type: string
     cosignVariables:
       type: array
@@ -17,4 +19,4 @@ allOf:
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:
-    desc: This is the description for CosignVerifyAttestation
+    desc: This is the description for Cosign Attestation with Secret Manager

--- a/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -2,6 +2,9 @@ title: CosignSecretManagerVerifyAttestation
 allOf:
 - $ref: verify-attestation-spec.yaml
 - type: object
+  required:
+    - connector
+    - keyName
   properties:
     connector:
       type: string

--- a/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -10,15 +10,6 @@ allOf:
       type: string
     keyName:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -1,16 +1,16 @@
 title: CosignSecretManagerVerifyAttestation
-allOf:
-- $ref: verify-attestation-spec.yaml
-- type: object
-  required:
-    - connector
-    - keyName
-  properties:
-    connector:
-      type: string
-    keyName:
-      type: string
-$schema: http://json-schema.org/draft-07/schema#
+type: object
+$ref: verify-attestation-spec.yaml
+required:
+  - connector
+  - keyName
 properties:
+  connector:
+    type: string
+  keyName:
+    type: string
   description:
-    desc: This is the description for Cosign Verify Attestation with Secret Manager
+    type: string
+    description: This is the description for Cosign Verify Attestation with Secret Manager
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -3,11 +3,11 @@ type: object
 $ref: verify-attestation-spec.yaml
 required:
   - connector
-  - keyName
+  - key
 properties:
   connector:
     type: string
-  keyName:
+  key:
     type: string
   description:
     type: string

--- a/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -1,9 +1,11 @@
-title: CosignVerifyAttestation
+title: CosignSecretManagerVerifyAttestation
 allOf:
 - $ref: verify-attestation-spec.yaml
 - type: object
   properties:
-    publicKey:
+    connector:
+      type: string
+    keyName:
       type: string
     cosignVariables:
       type: array
@@ -17,4 +19,4 @@ allOf:
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:
-    desc: This is the description for CosignVerifyAttestation
+    desc: This is the description for Cosign Verify Attestation with Secret Manager

--- a/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
@@ -6,16 +6,7 @@ allOf:
     - publicKey
   properties:
     publicKey:
-      type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string   
+      type: string   
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
@@ -5,6 +5,15 @@ allOf:
   properties:
     publicKey:
       type: string
+    cosignVariables:
+      type: array
+      items:
+        type: object
+        properties:
+          key:
+            type: string
+          value:
+            type: string   
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
@@ -4,7 +4,6 @@ allOf:
 - type: object
   required:
     - publicKey
-    - cosignVariables
   properties:
     publicKey:
       type: string

--- a/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
@@ -2,6 +2,9 @@ title: CosignVerifyAttestation
 allOf:
 - $ref: verify-attestation-spec.yaml
 - type: object
+  required:
+    - publicKey
+    - cosignVariables
   properties:
     publicKey:
       type: string

--- a/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/cosign-verify-attestation.yaml
@@ -1,13 +1,13 @@
 title: CosignVerifyAttestation
-allOf:
-- $ref: verify-attestation-spec.yaml
-- type: object
-  required:
-    - publicKey
-  properties:
-    publicKey:
-      type: string   
-$schema: http://json-schema.org/draft-07/schema#
+type: object
+$ref: verify-attestation-spec.yaml
+required:
+  - publicKey
 properties:
+  publicKey:
+    type: string   
   description:
-    desc: This is the description for CosignVerifyAttestation
+    type: string
+    description: This is the description for CosignVerifyAttestation
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/custom/verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/verify-attestation.yaml
@@ -8,6 +8,14 @@ properties:
   description:
     desc: This is the description for VerifyAttestation
 $schema: http://json-schema.org/draft-07/schema#
-oneOf:
-  - $ref: cosign-verify-attestation.yaml
-  - $ref: cosign-secret-manager-verify-attestation.yaml
+allOf:
+  - if:
+      properties:
+        type:
+          const: cosign
+    then:
+      properties:
+        spec:
+          oneOf:
+            - $ref: cosign-verify-attestation.yaml
+            - $ref: cosign-secret-manager-verify-attestation.yaml

--- a/v0/pipeline/steps/custom/verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/verify-attestation.yaml
@@ -19,3 +19,4 @@ allOf:
           oneOf:
             - $ref: cosign-verify-attestation.yaml
             - $ref: cosign-secret-manager-verify-attestation.yaml
+additionalProperties: false

--- a/v0/pipeline/steps/custom/verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/verify-attestation.yaml
@@ -18,16 +18,18 @@ allOf:
     then:
       properties:
         spec:
+          type: object
           oneOf:
             - $ref: cosign-verify-attestation.yaml
             - $ref: cosign-secret-manager-verify-attestation.yaml
-          cosignVariables:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string  
+          properties:
+            cosignVariables:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
 additionalProperties: false

--- a/v0/pipeline/steps/custom/verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/verify-attestation.yaml
@@ -7,6 +7,8 @@ properties:
       - cosign
   description:
     desc: This is the description for VerifyAttestation
+  spec:
+    type: object
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
   - if:
@@ -17,6 +19,10 @@ allOf:
       properties:
         spec:
           oneOf:
-            - $ref: cosign-verify-attestation.yaml
-            - $ref: cosign-secret-manager-verify-attestation.yaml
+            - allOf:
+                - required: [publicKey]
+                - $ref: cosign-verify-attestation.yaml
+            - allOf:
+                - required: [connector, keyName]
+                - $ref: cosign-secret-manager-verify-attestation.yaml
 additionalProperties: false

--- a/v0/pipeline/steps/custom/verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/verify-attestation.yaml
@@ -19,10 +19,15 @@ allOf:
       properties:
         spec:
           oneOf:
-            - allOf:
-                - required: [publicKey]
-                - $ref: cosign-verify-attestation.yaml
-            - allOf:
-                - required: [connector, keyName]
-                - $ref: cosign-secret-manager-verify-attestation.yaml
+            - $ref: cosign-verify-attestation.yaml
+            - $ref: cosign-secret-manager-verify-attestation.yaml
+          cosignVariables:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string  
 additionalProperties: false

--- a/v0/pipeline/steps/custom/verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/verify-attestation.yaml
@@ -1,28 +1,13 @@
 title: VerifyAttestation
 type: object
 properties:
-  attestWith:
+  type:
     type: string
     enum:
       - cosign
-      - cosignWithSecretManager
   description:
     desc: This is the description for VerifyAttestation
 $schema: http://json-schema.org/draft-07/schema#
-allOf:
-  - if:
-      properties:
-        attestWith:
-          const: cosign
-    then:
-      properties:
-        spec:
-          $ref: cosign-verify-attestation.yaml
-  - if:
-      properties:
-        attestWith:
-          const: cosignWithSecretManager
-    then:
-      properties:
-        spec:
-          $ref: cosign-secret-manager-verify-attestation.yaml
+oneOf:
+  - $ref: cosign-verify-attestation.yaml
+  - $ref: cosign-secret-manager-verify-attestation.yaml

--- a/v0/pipeline/steps/custom/verify-attestation.yaml
+++ b/v0/pipeline/steps/custom/verify-attestation.yaml
@@ -1,19 +1,28 @@
 title: VerifyAttestation
 type: object
 properties:
-  type:
+  attestWith:
     type: string
     enum:
-    - cosign
+      - cosign
+      - cosignWithSecretManager
   description:
     desc: This is the description for VerifyAttestation
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
-- if:
-    properties:
-      type:
-        const: cosign
-  then:
-    properties:
-      spec:
-        $ref: cosign-verify-attestation.yaml
+  - if:
+      properties:
+        attestWith:
+          const: cosign
+    then:
+      properties:
+        spec:
+          $ref: cosign-verify-attestation.yaml
+  - if:
+      properties:
+        attestWith:
+          const: cosignWithSecretManager
+    then:
+      properties:
+        spec:
+          $ref: cosign-secret-manager-verify-attestation.yaml

--- a/v0/template.json
+++ b/v0/template.json
@@ -31439,21 +31439,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }
@@ -31544,21 +31547,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }
@@ -53292,21 +53298,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }
@@ -77187,7 +77196,8 @@
                 "enum" : [ "cosign" ]
               },
               "description" : {
-                "desc" : "This is the description for AttestationV1"
+                "type" : "string",
+                "description" : "This is the description for AttestationV1"
               },
               "spec" : {
                 "type" : "object"
@@ -77205,21 +77215,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
                     }, {
                       "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }

--- a/v0/template.json
+++ b/v0/template.json
@@ -31422,6 +31422,9 @@
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -31437,9 +31440,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "publicKey" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                      } ]
                     } ]
                   }
                 }
@@ -31538,6 +31549,9 @@
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -31553,9 +31567,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                      "allOf" : [ {
+                        "required" : [ "privateKey", "password" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                      } ]
                     } ]
                   }
                 }
@@ -53297,6 +53319,9 @@
               },
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -53312,9 +53337,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "public_key" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                      } ]
                     } ]
                   }
                 }
@@ -77221,6 +77254,9 @@
               },
               "description" : {
                 "desc" : "This is the description for AttestationV1"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -77235,11 +77271,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
-                    "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
+                    "oneOf" : [ {
+                      "allOf" : [ {
+                        "required" : [ "privateKey", "password" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
+                      } ]
+                    }, {
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
+                      } ]
+                    } ]
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignAttestationV1" : {
             "title" : "CosignAttestationV1",
@@ -77247,12 +77296,27 @@
               "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
             }, {
               "type" : "object",
+              "required" : [ "private_key", "password" ],
               "properties" : {
                 "password" : {
                   "type" : "string"
                 },
                 "private_key" : {
                   "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -77270,6 +77334,43 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for AttestationSpecV1"
+              }
+            }
+          },
+          "CosignSecretManagerAttestation" : {
+            "title" : "CosignSecretManagerAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "keyName" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Attestation with Secret Manager V1"
               }
             }
           },

--- a/v0/template.json
+++ b/v0/template.json
@@ -31444,7 +31444,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignVerifyAttestation" : {
             "title" : "CosignVerifyAttestation",
@@ -31452,6 +31453,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "publicKey", "cosignVariables" ],
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
@@ -31495,6 +31497,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -31557,7 +31560,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignAttestation" : {
             "title" : "CosignAttestation",
@@ -31565,6 +31569,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "privateKey", "password" ],
               "properties" : {
                 "privateKey" : {
                   "type" : "string"
@@ -31611,6 +31616,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -53313,7 +53319,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignSlsaVerifyAttestation" : {
             "title" : "CosignSlsaVerifyAttestation",
@@ -53321,6 +53328,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "public_key" ],
               "properties" : {
                 "public_key" : {
                   "type" : "string"

--- a/v0/template.json
+++ b/v0/template.json
@@ -31453,7 +31453,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
-              "required" : [ "publicKey", "cosignVariables" ],
+              "required" : [ "publicKey" ],
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
@@ -53372,6 +53372,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"

--- a/v0/template.json
+++ b/v0/template.json
@@ -31416,9 +31416,9 @@
             "title" : "VerifyAttestation",
             "type" : "object",
             "properties" : {
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
@@ -31428,7 +31428,7 @@
             "allOf" : [ {
               "if" : {
                 "properties" : {
-                  "type" : {
+                  "attestWith" : {
                     "const" : "cosign"
                   }
                 }
@@ -31437,6 +31437,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                   }
                 }
               }
@@ -31451,6 +31466,20 @@
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -31471,16 +31500,49 @@
               }
             }
           },
+          "CosignSecretManagerVerifyAttestation" : {
+            "title" : "CosignSecretManagerVerifyAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
+              }
+            }
+          },
           "Attestation" : {
             "title" : "Attestation",
             "type" : "object",
             "properties" : {
-              "privateKey" : {
-                "type" : "string"
-              },
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
@@ -31490,7 +31552,7 @@
             "allOf" : [ {
               "if" : {
                 "properties" : {
-                  "type" : {
+                  "attestWith" : {
                     "const" : "cosign"
                   }
                 }
@@ -31499,6 +31561,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
                   }
                 }
               }
@@ -31511,11 +31588,25 @@
             }, {
               "type" : "object",
               "properties" : {
-                "password" : {
-                  "type" : "string"
-                },
                 "privateKey" : {
                   "type" : "string"
+                },
+                "privateKeyPassword" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -31533,6 +31624,42 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for AttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerAttestation" : {
+            "title" : "CosignSecretManagerAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Attestation with Secret Manager"
               }
             }
           },
@@ -53180,9 +53307,9 @@
             "title" : "SlsaVerifyAttestation",
             "type" : "object",
             "properties" : {
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestation"
@@ -53204,6 +53331,21 @@
                   }
                 }
               }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                  }
+                }
+              }
             } ]
           },
           "CosignSlsaVerifyAttestation" : {
@@ -53215,6 +53357,20 @@
               "properties" : {
                 "public_key" : {
                   "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -53232,6 +53388,42 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerVerifyAttestation" : {
+            "title" : "CosignSecretManagerVerifyAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
             }
           },

--- a/v0/template.json
+++ b/v0/template.json
@@ -31440,18 +31440,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "publicKey" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -31468,20 +31474,6 @@
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -31515,20 +31507,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -31567,18 +31545,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "privateKey", "password" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -31598,20 +31582,6 @@
                 },
                 "password" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -31645,20 +31615,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -53337,18 +53293,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "public_key" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -53365,20 +53327,6 @@
               "properties" : {
                 "public_key" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -53412,20 +53360,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -77272,18 +77206,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "privateKey", "password" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/stages/ci/CosignAttestationV1"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/stages/ci/CosignSecretManagerAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -77303,20 +77243,6 @@
                 },
                 "private_key" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -77350,20 +77276,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],

--- a/v0/template.json
+++ b/v0/template.json
@@ -31469,23 +31469,20 @@
           },
           "CosignVerifyAttestation" : {
             "title" : "CosignVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "publicKey" ],
-              "properties" : {
-                "publicKey" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "publicKey" ],
             "properties" : {
+              "publicKey" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignVerifyAttestation"
+                "type" : "string",
+                "description" : "This is the description for CosignVerifyAttestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
           },
           "VerifyAttestationSpec" : {
             "title" : "VerifyAttestationSpec",
@@ -31499,26 +31496,23 @@
           },
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
           },
           "Attestation" : {
             "title" : "Attestation",
@@ -31577,26 +31571,23 @@
           },
           "CosignAttestation" : {
             "title" : "CosignAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "privateKey", "password" ],
-              "properties" : {
-                "privateKey" : {
-                  "type" : "string"
-                },
-                "password" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "privateKey", "password" ],
             "properties" : {
+              "privateKey" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignAttestation"
+                "type" : "string",
+                "description" : "This is the description for CosignAttestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
           },
           "AttestationSpec" : {
             "title" : "AttestationSpec",
@@ -31610,26 +31601,23 @@
           },
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
           },
           "SbomOrchestrationTool" : {
             "title" : "SbomOrchestrationTool",
@@ -53328,23 +53316,20 @@
           },
           "CosignSlsaVerifyAttestation" : {
             "title" : "CosignSlsaVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "public_key" ],
-              "properties" : {
-                "public_key" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "public_key" ],
             "properties" : {
+              "public_key" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignSlsaVerifyAttestation"
+                "type" : "string",
+                "description" : "This is the description for Cosign SLSA Verify Attestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
           },
           "SlsaVerifyAttestationSpec" : {
             "title" : "SlsaVerifyAttestationSpec",
@@ -53358,26 +53343,23 @@
           },
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
           },
           "WizScanNode_template" : {
             "title" : "WizScanNode_template",
@@ -77245,26 +77227,23 @@
           },
           "CosignAttestationV1" : {
             "title" : "CosignAttestationV1",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
-            }, {
-              "type" : "object",
-              "required" : [ "private_key", "password" ],
-              "properties" : {
-                "password" : {
-                  "type" : "string"
-                },
-                "private_key" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "private_key", "password" ],
             "properties" : {
+              "password" : {
+                "type" : "string"
+              },
+              "private_key" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignAttestationV1"
+                "type" : "string",
+                "description" : "This is the description for CosignAttestationV1"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
           },
           "AttestationSpecV1" : {
             "title" : "AttestationSpecV1",
@@ -77278,26 +77257,23 @@
           },
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Attestation with Secret Manager V1"
+                "type" : "string",
+                "description" : "This is the description for Cosign Attestation with Secret Manager V1"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/stages/ci/AttestationSpecV1"
           },
           "IntegrationStageNode" : {
             "title" : "IntegrationStageNode",

--- a/v0/template.json
+++ b/v0/template.json
@@ -31416,45 +31416,19 @@
             "title" : "VerifyAttestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
             } ]
           },
           "CosignVerifyAttestation" : {
@@ -31540,45 +31514,19 @@
             "title" : "Attestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
             } ]
           },
           "CosignAttestation" : {
@@ -31591,7 +31539,7 @@
                 "privateKey" : {
                   "type" : "string"
                 },
-                "privateKeyPassword" : {
+                "password" : {
                   "type" : "string"
                 },
                 "cosignVariables" : {
@@ -53307,45 +53255,19 @@
             "title" : "SlsaVerifyAttestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for SlsaVerifyAttestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
             } ]
           },
           "CosignSlsaVerifyAttestation" : {

--- a/v0/template.json
+++ b/v0/template.json
@@ -31497,12 +31497,12 @@
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {
@@ -31602,12 +31602,12 @@
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {
@@ -53344,12 +53344,12 @@
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {
@@ -77258,12 +77258,12 @@
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {

--- a/v0/template.json
+++ b/v0/template.json
@@ -31425,10 +31425,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignVerifyAttestation" : {
@@ -31523,10 +31538,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignAttestation" : {
@@ -53264,10 +53294,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignSlsaVerifyAttestation" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7513,21 +7513,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }
@@ -8126,21 +8129,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7574,12 +7574,12 @@
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
             "type" : "object",
-            "required" : [ "connector", "key_name" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "key_name" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {
@@ -8181,12 +8181,12 @@
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
             "type" : "object",
-            "required" : [ "connector", "key_name" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "key_name" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7518,7 +7518,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignAttestation" : {
             "title" : "CosignAttestation",
@@ -7526,6 +7527,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "privateKey", "password" ],
               "properties" : {
                 "privateKey" : {
                   "type" : "string"
@@ -8139,7 +8141,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignVerifyAttestation" : {
             "title" : "CosignVerifyAttestation",
@@ -8147,6 +8150,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "publicKey", "cosignVariables" ],
               "properties" : {
                 "publicKey" : {
                   "type" : "string"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7496,6 +7496,9 @@
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -7511,9 +7514,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                      "allOf" : [ {
+                        "required" : [ "privateKey", "password" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                      } ]
                     } ]
                   }
                 }
@@ -8120,6 +8131,9 @@
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -8135,9 +8149,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "publicKey" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                      } ]
                     } ]
                   }
                 }

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7574,6 +7574,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -8150,7 +8151,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
-              "required" : [ "publicKey", "cosignVariables" ],
+              "required" : [ "publicKey" ],
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
@@ -8194,6 +8195,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7490,45 +7490,19 @@
             "title" : "Attestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
             } ]
           },
           "CosignAttestation" : {
@@ -7541,7 +7515,7 @@
                 "privateKey" : {
                   "type" : "string"
                 },
-                "privateKeyPassword" : {
+                "password" : {
                   "type" : "string"
                 },
                 "cosignVariables" : {
@@ -8122,45 +8096,19 @@
             "title" : "VerifyAttestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
             } ]
           },
           "CosignVerifyAttestation" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7490,12 +7490,9 @@
             "title" : "Attestation",
             "type" : "object",
             "properties" : {
-              "privateKey" : {
-                "type" : "string"
-              },
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
@@ -7505,7 +7502,7 @@
             "allOf" : [ {
               "if" : {
                 "properties" : {
-                  "type" : {
+                  "attestWith" : {
                     "const" : "cosign"
                   }
                 }
@@ -7514,6 +7511,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
                   }
                 }
               }
@@ -7526,11 +7538,25 @@
             }, {
               "type" : "object",
               "properties" : {
-                "password" : {
-                  "type" : "string"
-                },
                 "privateKey" : {
                   "type" : "string"
+                },
+                "privateKeyPassword" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -7548,6 +7574,42 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for AttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerAttestation" : {
+            "title" : "CosignSecretManagerAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Attestation with Secret Manager"
               }
             }
           },
@@ -8060,9 +8122,9 @@
             "title" : "VerifyAttestation",
             "type" : "object",
             "properties" : {
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
@@ -8072,7 +8134,7 @@
             "allOf" : [ {
               "if" : {
                 "properties" : {
-                  "type" : {
+                  "attestWith" : {
                     "const" : "cosign"
                   }
                 }
@@ -8081,6 +8143,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                   }
                 }
               }
@@ -8095,6 +8172,20 @@
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -8112,6 +8203,42 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for VerifyAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerVerifyAttestation" : {
+            "title" : "CosignSecretManagerVerifyAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
             }
           },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7543,26 +7543,23 @@
           },
           "CosignAttestation" : {
             "title" : "CosignAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "privateKey", "password" ],
-              "properties" : {
-                "privateKey" : {
-                  "type" : "string"
-                },
-                "password" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "privateKey", "password" ],
             "properties" : {
+              "privateKey" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignAttestation"
+                "type" : "string",
+                "description" : "This is the description for CosignAttestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
           },
           "AttestationSpec" : {
             "title" : "AttestationSpec",
@@ -7576,26 +7573,23 @@
           },
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
           },
           "ContainerK8sInfra" : {
             "title" : "ContainerK8sInfra",
@@ -8159,23 +8153,20 @@
           },
           "CosignVerifyAttestation" : {
             "title" : "CosignVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "publicKey" ],
-              "properties" : {
-                "publicKey" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "publicKey" ],
             "properties" : {
+              "publicKey" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignVerifyAttestation"
+                "type" : "string",
+                "description" : "This is the description for CosignVerifyAttestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
           },
           "VerifyAttestationSpec" : {
             "title" : "VerifyAttestationSpec",
@@ -8189,26 +8180,23 @@
           },
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
           },
           "HttpStepNode" : {
             "title" : "HttpStepNode",

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7574,12 +7574,12 @@
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key_name" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key_name" : {
                 "type" : "string"
               },
               "description" : {
@@ -8181,12 +8181,12 @@
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key_name" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key_name" : {
                 "type" : "string"
               },
               "description" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7499,10 +7499,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignAttestation" : {
@@ -8105,10 +8120,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignVerifyAttestation" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -7514,18 +7514,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "privateKey", "password" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -7545,20 +7551,6 @@
                 },
                 "password" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -7592,20 +7584,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -8149,18 +8127,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "publicKey" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -8177,20 +8161,6 @@
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -8224,20 +8194,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],

--- a/v1/pipeline/steps/custom/attestation.yaml
+++ b/v1/pipeline/steps/custom/attestation.yaml
@@ -8,6 +8,14 @@ properties:
   description:
     desc: This is the description for Attestation
 $schema: http://json-schema.org/draft-07/schema#
-oneOf:
-  - $ref: cosign-attestation.yaml
-  - $ref: cosign-secret-manager-attestation.yaml
+allOf:
+  - if:
+      properties:
+        type:
+          const: cosign
+    then:
+      properties:
+        spec:
+          oneOf:
+            - $ref: cosign-attestation.yaml
+            - $ref: cosign-secret-manager-attestation.yaml

--- a/v1/pipeline/steps/custom/attestation.yaml
+++ b/v1/pipeline/steps/custom/attestation.yaml
@@ -18,16 +18,18 @@ allOf:
     then:
       properties:
         spec:
+          type: object
           oneOf:
             - $ref: cosign-attestation.yaml
             - $ref: cosign-secret-manager-attestation.yaml
-          cosignVariables:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
+          properties:
+            cosignVariables:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
 additionalProperties: false

--- a/v1/pipeline/steps/custom/attestation.yaml
+++ b/v1/pipeline/steps/custom/attestation.yaml
@@ -19,10 +19,15 @@ allOf:
       properties:
         spec:
           oneOf:
-            - allOf:
-                - required: [privateKey, password]
-                - $ref: cosign-attestation.yaml
-            - allOf:
-                - required: [connector, keyName]
-                - $ref: cosign-secret-manager-attestation.yaml
+            - $ref: cosign-attestation.yaml
+            - $ref: cosign-secret-manager-attestation.yaml
+          cosignVariables:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
 additionalProperties: false

--- a/v1/pipeline/steps/custom/attestation.yaml
+++ b/v1/pipeline/steps/custom/attestation.yaml
@@ -1,21 +1,28 @@
 title: Attestation
 type: object
 properties:
-  privateKey:
-    type: string
-  type:
+  attestWith:
     type: string
     enum:
-    - cosign
+      - cosign
+      - cosignWithSecretManager
   description:
     desc: This is the description for Attestation
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
-- if:
-    properties:
-      type:
-        const: cosign
-  then:
-    properties:
-      spec:
-        $ref: cosign-attestation.yaml
+  - if:
+      properties:
+        attestWith:
+          const: cosign
+    then:
+      properties:
+        spec:
+          $ref: cosign-attestation.yaml
+  - if:
+      properties:
+        attestWith:
+          const: cosignWithSecretManager
+    then:
+      properties:
+        spec:
+          $ref: cosign-secret-manager-attestation.yaml

--- a/v1/pipeline/steps/custom/attestation.yaml
+++ b/v1/pipeline/steps/custom/attestation.yaml
@@ -1,28 +1,13 @@
 title: Attestation
 type: object
 properties:
-  attestWith:
+  type:
     type: string
     enum:
       - cosign
-      - cosignWithSecretManager
   description:
     desc: This is the description for Attestation
 $schema: http://json-schema.org/draft-07/schema#
-allOf:
-  - if:
-      properties:
-        attestWith:
-          const: cosign
-    then:
-      properties:
-        spec:
-          $ref: cosign-attestation.yaml
-  - if:
-      properties:
-        attestWith:
-          const: cosignWithSecretManager
-    then:
-      properties:
-        spec:
-          $ref: cosign-secret-manager-attestation.yaml
+oneOf:
+  - $ref: cosign-attestation.yaml
+  - $ref: cosign-secret-manager-attestation.yaml

--- a/v1/pipeline/steps/custom/attestation.yaml
+++ b/v1/pipeline/steps/custom/attestation.yaml
@@ -7,6 +7,8 @@ properties:
       - cosign
   description:
     desc: This is the description for Attestation
+  spec:
+    type: object
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
   - if:
@@ -17,6 +19,10 @@ allOf:
       properties:
         spec:
           oneOf:
-            - $ref: cosign-attestation.yaml
-            - $ref: cosign-secret-manager-attestation.yaml
+            - allOf:
+                - required: [privateKey, password]
+                - $ref: cosign-attestation.yaml
+            - allOf:
+                - required: [connector, keyName]
+                - $ref: cosign-secret-manager-attestation.yaml
 additionalProperties: false

--- a/v1/pipeline/steps/custom/attestation.yaml
+++ b/v1/pipeline/steps/custom/attestation.yaml
@@ -19,3 +19,4 @@ allOf:
           oneOf:
             - $ref: cosign-attestation.yaml
             - $ref: cosign-secret-manager-attestation.yaml
+additionalProperties: false

--- a/v1/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-attestation.yaml
@@ -5,7 +5,7 @@ allOf:
   properties:
     privateKey:
       type: string
-    privateKeyPassword:
+    password:
       type: string
     cosignVariables:
       type: array

--- a/v1/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-attestation.yaml
@@ -1,17 +1,17 @@
 title: CosignAttestation
-allOf:
-- $ref: attestation-spec.yaml
-- type: object
-  required:
-    - privateKey
-    - password
-  properties:
-    privateKey:
-      type: string
-    password:
-      type: string
+type: object
+$ref: attestation-spec.yaml
+required:
+  - privateKey
+  - password
+properties:
+  privateKey:
+    type: string
+  password:
+    type: string
+  description:
+    type: string
+    description: This is the description for CosignAttestation
 
 $schema: http://json-schema.org/draft-07/schema#
-properties:
-  description:
-    desc: This is the description for CosignAttestation
+additionalProperties: false

--- a/v1/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-attestation.yaml
@@ -10,15 +10,7 @@ allOf:
       type: string
     password:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
+
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v1/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-attestation.yaml
@@ -3,10 +3,19 @@ allOf:
 - $ref: attestation-spec.yaml
 - type: object
   properties:
-    password:
-      type: string
     privateKey:
       type: string
+    privateKeyPassword:
+      type: string
+    cosignVariables:
+      type: array
+      items:
+        type: object
+        properties:
+          key:
+            type: string
+          value:
+            type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v1/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-attestation.yaml
@@ -2,6 +2,9 @@ title: CosignAttestation
 allOf:
 - $ref: attestation-spec.yaml
 - type: object
+  required:
+    - privateKey
+    - password
   properties:
     privateKey:
       type: string

--- a/v1/pipeline/steps/custom/cosign-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-attestation.yaml
@@ -12,6 +12,5 @@ properties:
   description:
     type: string
     description: This is the description for CosignAttestation
-
 $schema: http://json-schema.org/draft-07/schema#
 additionalProperties: false

--- a/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -3,11 +3,11 @@ type: object
 $ref: attestation-spec.yaml
 required:
   - connector
-  - key_name
+  - key
 properties:
   connector:
     type: string
-  key_name:
+  key:
     type: string
   description:
     type: string

--- a/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -2,6 +2,9 @@ title: CosignSecretManagerAttestation
 allOf:
 - $ref: attestation-spec.yaml
 - type: object
+  required:
+    - connector
+    - keyName
   properties:
     connector:
       type: string

--- a/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -1,17 +1,17 @@
 title: CosignSecretManagerAttestation
-allOf:
-- $ref: attestation-spec.yaml
-- type: object
-  required:
-    - connector
-    - keyName
-  properties:
-    connector:
-      type: string
-    keyName:
-      type: string
+type: object
+$ref: attestation-spec.yaml
+required:
+  - connector
+  - keyName
+properties:
+  connector:
+    type: string
+  keyName:
+    type: string
+  description:
+    type: string
+    description: This is the description for Cosign Attestation with Secret Manager
 
 $schema: http://json-schema.org/draft-07/schema#
-properties:
-  description:
-    desc: This is the description for Cosign Attestation with Secret Manager
+additionalProperties: false

--- a/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -3,15 +3,14 @@ type: object
 $ref: attestation-spec.yaml
 required:
   - connector
-  - keyName
+  - key_name
 properties:
   connector:
     type: string
-  keyName:
+  key_name:
     type: string
   description:
     type: string
     description: This is the description for Cosign Attestation with Secret Manager
-
 $schema: http://json-schema.org/draft-07/schema#
 additionalProperties: false

--- a/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -10,15 +10,7 @@ allOf:
       type: string
     keyName:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
+
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-attestation.yaml
@@ -1,9 +1,11 @@
-title: CosignVerifyAttestation
+title: CosignSecretManagerAttestation
 allOf:
-- $ref: verify-attestation-spec.yaml
+- $ref: attestation-spec.yaml
 - type: object
   properties:
-    publicKey:
+    connector:
+      type: string
+    keyName:
       type: string
     cosignVariables:
       type: array
@@ -17,4 +19,4 @@ allOf:
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:
-    desc: This is the description for CosignVerifyAttestation
+    desc: This is the description for Cosign Attestation with Secret Manager

--- a/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -3,11 +3,11 @@ type: object
 $ref: verify-attestation-spec.yaml
 required:
   - connector
-  - keyName
+  - key_name
 properties:
   connector:
     type: string
-  keyName:
+  key_name:
     type: string
   description:
     type: string

--- a/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -2,6 +2,9 @@ title: CosignSecretManagerVerifyAttestation
 allOf:
 - $ref: verify-attestation-spec.yaml
 - type: object
+  required:
+    - connector
+    - keyName
   properties:
     connector:
       type: string

--- a/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -3,11 +3,11 @@ type: object
 $ref: verify-attestation-spec.yaml
 required:
   - connector
-  - key_name
+  - key
 properties:
   connector:
     type: string
-  key_name:
+  key:
     type: string
   description:
     type: string

--- a/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -1,9 +1,11 @@
-title: CosignVerifyAttestation
+title: CosignSecretManagerVerifyAttestation
 allOf:
 - $ref: verify-attestation-spec.yaml
 - type: object
   properties:
-    publicKey:
+    connector:
+      type: string
+    keyName:
       type: string
     cosignVariables:
       type: array
@@ -17,4 +19,4 @@ allOf:
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:
-    desc: This is the description for CosignVerifyAttestation
+    desc: This is the description for Cosign Verify Attestation with Secret Manager

--- a/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -10,15 +10,7 @@ allOf:
       type: string
     keyName:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
+
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-secret-manager-verify-attestation.yaml
@@ -1,17 +1,16 @@
 title: CosignSecretManagerVerifyAttestation
-allOf:
-- $ref: verify-attestation-spec.yaml
-- type: object
-  required:
-    - connector
-    - keyName
-  properties:
-    connector:
-      type: string
-    keyName:
-      type: string
-
-$schema: http://json-schema.org/draft-07/schema#
+type: object
+$ref: verify-attestation-spec.yaml
+required:
+  - connector
+  - keyName
 properties:
+  connector:
+    type: string
+  keyName:
+    type: string
   description:
-    desc: This is the description for Cosign Verify Attestation with Secret Manager
+    type: string
+    description: This is the description for Cosign Verify Attestation with Secret Manager
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v1/pipeline/steps/custom/cosign-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-verify-attestation.yaml
@@ -4,7 +4,6 @@ allOf:
 - type: object
   required:
     - publicKey
-    - cosignVariables
   properties:
     publicKey:
       type: string

--- a/v1/pipeline/steps/custom/cosign-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-verify-attestation.yaml
@@ -1,14 +1,13 @@
 title: CosignVerifyAttestation
-allOf:
-- $ref: verify-attestation-spec.yaml
-- type: object
-  required:
-    - publicKey
-  properties:
-    publicKey:
-      type: string
-
-$schema: http://json-schema.org/draft-07/schema#
+type: object
+$ref: verify-attestation-spec.yaml
+required:
+  - publicKey
 properties:
+  publicKey:
+    type: string
   description:
-    desc: This is the description for CosignVerifyAttestation
+    type: string
+    description: This is the description for CosignVerifyAttestation
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v1/pipeline/steps/custom/cosign-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-verify-attestation.yaml
@@ -2,6 +2,9 @@ title: CosignVerifyAttestation
 allOf:
 - $ref: verify-attestation-spec.yaml
 - type: object
+  required:
+    - publicKey
+    - cosignVariables
   properties:
     publicKey:
       type: string

--- a/v1/pipeline/steps/custom/cosign-verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/cosign-verify-attestation.yaml
@@ -7,15 +7,7 @@ allOf:
   properties:
     publicKey:
       type: string
-    cosignVariables:
-      type: array
-      items:
-        type: object
-        properties:
-          key:
-            type: string
-          value:
-            type: string
+
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v1/pipeline/steps/custom/verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/verify-attestation.yaml
@@ -8,6 +8,14 @@ properties:
   description:
     desc: This is the description for VerifyAttestation
 $schema: http://json-schema.org/draft-07/schema#
-oneOf:
-  - $ref: cosign-verify-attestation.yaml
-  - $ref: cosign-secret-manager-verify-attestation.yaml
+allOf:
+  - if:
+      properties:
+        type:
+          const: cosign
+    then:
+      properties:
+        spec:
+          oneOf:
+            - $ref: cosign-verify-attestation.yaml
+            - $ref: cosign-secret-manager-verify-attestation.yaml

--- a/v1/pipeline/steps/custom/verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/verify-attestation.yaml
@@ -19,3 +19,4 @@ allOf:
           oneOf:
             - $ref: cosign-verify-attestation.yaml
             - $ref: cosign-secret-manager-verify-attestation.yaml
+additionalProperties: false

--- a/v1/pipeline/steps/custom/verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/verify-attestation.yaml
@@ -18,16 +18,18 @@ allOf:
     then:
       properties:
         spec:
+          type: object
           oneOf:
             - $ref: cosign-verify-attestation.yaml
             - $ref: cosign-secret-manager-verify-attestation.yaml
-          cosignVariables:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
+          properties:
+            cosignVariables:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
 additionalProperties: false

--- a/v1/pipeline/steps/custom/verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/verify-attestation.yaml
@@ -7,6 +7,8 @@ properties:
       - cosign
   description:
     desc: This is the description for VerifyAttestation
+  spec:
+    type: object
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
   - if:
@@ -17,6 +19,10 @@ allOf:
       properties:
         spec:
           oneOf:
-            - $ref: cosign-verify-attestation.yaml
-            - $ref: cosign-secret-manager-verify-attestation.yaml
+            - allOf:
+                - required: [publicKey]
+                - $ref: cosign-verify-attestation.yaml
+            - allOf:
+                - required: [connector, keyName]
+                - $ref: cosign-secret-manager-verify-attestation.yaml
 additionalProperties: false

--- a/v1/pipeline/steps/custom/verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/verify-attestation.yaml
@@ -1,28 +1,13 @@
 title: VerifyAttestation
 type: object
 properties:
-  attestWith:
+  type:
     type: string
     enum:
       - cosign
-      - cosignWithSecretManager
   description:
     desc: This is the description for VerifyAttestation
 $schema: http://json-schema.org/draft-07/schema#
-allOf:
-  - if:
-      properties:
-        attestWith:
-          const: cosign
-    then:
-      properties:
-        spec:
-          $ref: cosign-verify-attestation.yaml
-  - if:
-      properties:
-        attestWith:
-          const: cosignWithSecretManager
-    then:
-      properties:
-        spec:
-          $ref: cosign-secret-manager-verify-attestation.yaml
+oneOf:
+  - $ref: cosign-verify-attestation.yaml
+  - $ref: cosign-secret-manager-verify-attestation.yaml

--- a/v1/pipeline/steps/custom/verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/verify-attestation.yaml
@@ -1,19 +1,28 @@
 title: VerifyAttestation
 type: object
 properties:
-  type:
+  attestWith:
     type: string
     enum:
-    - cosign
+      - cosign
+      - cosignWithSecretManager
   description:
     desc: This is the description for VerifyAttestation
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
-- if:
-    properties:
-      type:
-        const: cosign
-  then:
-    properties:
-      spec:
-        $ref: cosign-verify-attestation.yaml
+  - if:
+      properties:
+        attestWith:
+          const: cosign
+    then:
+      properties:
+        spec:
+          $ref: cosign-verify-attestation.yaml
+  - if:
+      properties:
+        attestWith:
+          const: cosignWithSecretManager
+    then:
+      properties:
+        spec:
+          $ref: cosign-secret-manager-verify-attestation.yaml

--- a/v1/pipeline/steps/custom/verify-attestation.yaml
+++ b/v1/pipeline/steps/custom/verify-attestation.yaml
@@ -19,10 +19,15 @@ allOf:
       properties:
         spec:
           oneOf:
-            - allOf:
-                - required: [publicKey]
-                - $ref: cosign-verify-attestation.yaml
-            - allOf:
-                - required: [connector, keyName]
-                - $ref: cosign-secret-manager-verify-attestation.yaml
+            - $ref: cosign-verify-attestation.yaml
+            - $ref: cosign-secret-manager-verify-attestation.yaml
+          cosignVariables:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
 additionalProperties: false

--- a/v1/template.json
+++ b/v1/template.json
@@ -36537,6 +36537,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -36936,7 +36937,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
-              "required" : [ "publicKey", "cosignVariables" ],
+              "required" : [ "publicKey" ],
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
@@ -36980,6 +36981,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "connector", "keyName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"

--- a/v1/template.json
+++ b/v1/template.json
@@ -36476,21 +36476,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }
@@ -36912,21 +36915,24 @@
               "then" : {
                 "properties" : {
                   "spec" : {
+                    "type" : "object",
                     "oneOf" : [ {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
                       "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                     } ],
-                    "cosignVariables" : {
-                      "type" : "array",
-                      "items" : {
-                        "type" : "object",
-                        "properties" : {
-                          "key" : {
-                            "type" : "string"
-                          },
-                          "value" : {
-                            "type" : "string"
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
                           }
                         }
                       }

--- a/v1/template.json
+++ b/v1/template.json
@@ -36453,12 +36453,9 @@
             "title" : "Attestation",
             "type" : "object",
             "properties" : {
-              "privateKey" : {
-                "type" : "string"
-              },
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
@@ -36468,7 +36465,7 @@
             "allOf" : [ {
               "if" : {
                 "properties" : {
-                  "type" : {
+                  "attestWith" : {
                     "const" : "cosign"
                   }
                 }
@@ -36477,6 +36474,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
                   }
                 }
               }
@@ -36489,11 +36501,25 @@
             }, {
               "type" : "object",
               "properties" : {
-                "password" : {
-                  "type" : "string"
-                },
                 "privateKey" : {
                   "type" : "string"
+                },
+                "privateKeyPassword" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -36511,6 +36537,42 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for AttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerAttestation" : {
+            "title" : "CosignSecretManagerAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Attestation with Secret Manager"
               }
             }
           },
@@ -36846,9 +36908,9 @@
             "title" : "VerifyAttestation",
             "type" : "object",
             "properties" : {
-              "type" : {
+              "attestWith" : {
                 "type" : "string",
-                "enum" : [ "cosign" ]
+                "enum" : [ "cosign", "cosignWithSecretManager" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
@@ -36858,7 +36920,7 @@
             "allOf" : [ {
               "if" : {
                 "properties" : {
-                  "type" : {
+                  "attestWith" : {
                     "const" : "cosign"
                   }
                 }
@@ -36867,6 +36929,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "attestWith" : {
+                    "const" : "cosignWithSecretManager"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
                   }
                 }
               }
@@ -36881,6 +36958,20 @@
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
                 }
               }
             } ],
@@ -36898,6 +36989,42 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for VerifyAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerVerifyAttestation" : {
+            "title" : "CosignSecretManagerVerifyAttestation",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "keyName" : {
+                  "type" : "string"
+                },
+                "cosignVariables" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "key" : {
+                        "type" : "string"
+                      },
+                      "value" : {
+                        "type" : "string"
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
             }
           },

--- a/v1/template.json
+++ b/v1/template.json
@@ -36506,26 +36506,23 @@
           },
           "CosignAttestation" : {
             "title" : "CosignAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "privateKey", "password" ],
-              "properties" : {
-                "privateKey" : {
-                  "type" : "string"
-                },
-                "password" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "privateKey", "password" ],
             "properties" : {
+              "privateKey" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignAttestation"
+                "type" : "string",
+                "description" : "This is the description for CosignAttestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
           },
           "AttestationSpec" : {
             "title" : "AttestationSpec",
@@ -36539,26 +36536,23 @@
           },
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
           },
           "SbomSource" : {
             "title" : "SbomSource",
@@ -36945,23 +36939,20 @@
           },
           "CosignVerifyAttestation" : {
             "title" : "CosignVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "publicKey" ],
-              "properties" : {
-                "publicKey" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "publicKey" ],
             "properties" : {
+              "publicKey" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for CosignVerifyAttestation"
+                "type" : "string",
+                "description" : "This is the description for CosignVerifyAttestation"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
           },
           "VerifyAttestationSpec" : {
             "title" : "VerifyAttestationSpec",
@@ -36975,26 +36966,23 @@
           },
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "keyName" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "keyName" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "connector", "keyName" ],
             "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "keyName" : {
+                "type" : "string"
+              },
               "description" : {
-                "desc" : "This is the description for Cosign Verify Attestation with Secret Manager"
+                "type" : "string",
+                "description" : "This is the description for Cosign Verify Attestation with Secret Manager"
               }
-            }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
           },
           "HttpStepNode" : {
             "title" : "HttpStepNode",

--- a/v1/template.json
+++ b/v1/template.json
@@ -36537,12 +36537,12 @@
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
             "type" : "object",
-            "required" : [ "connector", "key_name" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "key_name" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {
@@ -36967,12 +36967,12 @@
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
             "type" : "object",
-            "required" : [ "connector", "key_name" ],
+            "required" : [ "connector", "key" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "key_name" : {
+              "key" : {
                 "type" : "string"
               },
               "description" : {

--- a/v1/template.json
+++ b/v1/template.json
@@ -36453,45 +36453,19 @@
             "title" : "Attestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
             } ]
           },
           "CosignAttestation" : {
@@ -36504,7 +36478,7 @@
                 "privateKey" : {
                   "type" : "string"
                 },
-                "privateKeyPassword" : {
+                "password" : {
                   "type" : "string"
                 },
                 "cosignVariables" : {
@@ -36908,45 +36882,19 @@
             "title" : "VerifyAttestation",
             "type" : "object",
             "properties" : {
-              "attestWith" : {
+              "type" : {
                 "type" : "string",
-                "enum" : [ "cosign", "cosignWithSecretManager" ]
+                "enum" : [ "cosign" ]
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-                  }
-                }
-              }
+            "oneOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
             }, {
-              "if" : {
-                "properties" : {
-                  "attestWith" : {
-                    "const" : "cosignWithSecretManager"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                  }
-                }
-              }
+              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
             } ]
           },
           "CosignVerifyAttestation" : {

--- a/v1/template.json
+++ b/v1/template.json
@@ -36481,7 +36481,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignAttestation" : {
             "title" : "CosignAttestation",
@@ -36489,6 +36490,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/AttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "privateKey", "password" ],
               "properties" : {
                 "privateKey" : {
                   "type" : "string"
@@ -36925,7 +36927,8 @@
                   }
                 }
               }
-            } ]
+            } ],
+            "additionalProperties" : false
           },
           "CosignVerifyAttestation" : {
             "title" : "CosignVerifyAttestation",
@@ -36933,6 +36936,7 @@
               "$ref" : "#/definitions/pipeline/steps/custom/VerifyAttestationSpec"
             }, {
               "type" : "object",
+              "required" : [ "publicKey", "cosignVariables" ],
               "properties" : {
                 "publicKey" : {
                   "type" : "string"

--- a/v1/template.json
+++ b/v1/template.json
@@ -36462,10 +36462,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignAttestation" : {
@@ -36891,10 +36906,25 @@
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
-            "oneOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-            }, {
-              "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                    } ]
+                  }
+                }
+              }
             } ]
           },
           "CosignVerifyAttestation" : {

--- a/v1/template.json
+++ b/v1/template.json
@@ -36477,18 +36477,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "privateKey", "password" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -36508,20 +36514,6 @@
                 },
                 "password" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -36555,20 +36547,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -36935,18 +36913,24 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "allOf" : [ {
-                        "required" : [ "publicKey" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
-                      } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
                     }, {
-                      "allOf" : [ {
-                        "required" : [ "connector", "keyName" ]
-                      }, {
-                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
-                      } ]
-                    } ]
+                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                    } ],
+                    "cosignVariables" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "key" : {
+                            "type" : "string"
+                          },
+                          "value" : {
+                            "type" : "string"
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
@@ -36963,20 +36947,6 @@
               "properties" : {
                 "publicKey" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],
@@ -37010,20 +36980,6 @@
                 },
                 "keyName" : {
                   "type" : "string"
-                },
-                "cosignVariables" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "object",
-                    "properties" : {
-                      "key" : {
-                        "type" : "string"
-                      },
-                      "value" : {
-                        "type" : "string"
-                      }
-                    }
-                  }
                 }
               }
             } ],

--- a/v1/template.json
+++ b/v1/template.json
@@ -36459,6 +36459,9 @@
               },
               "description" : {
                 "desc" : "This is the description for Attestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -36474,9 +36477,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                      "allOf" : [ {
+                        "required" : [ "privateKey", "password" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerAttestation"
+                      } ]
                     } ]
                   }
                 }
@@ -36906,6 +36917,9 @@
               },
               "description" : {
                 "desc" : "This is the description for VerifyAttestation"
+              },
+              "spec" : {
+                "type" : "object"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",
@@ -36921,9 +36935,17 @@
                 "properties" : {
                   "spec" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "publicKey" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignVerifyAttestation"
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                      "allOf" : [ {
+                        "required" : [ "connector", "keyName" ]
+                      }, {
+                        "$ref" : "#/definitions/pipeline/steps/custom/CosignSecretManagerVerifyAttestation"
+                      } ]
                     } ]
                   }
                 }

--- a/v1/template.json
+++ b/v1/template.json
@@ -36537,12 +36537,12 @@
           "CosignSecretManagerAttestation" : {
             "title" : "CosignSecretManagerAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key_name" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key_name" : {
                 "type" : "string"
               },
               "description" : {
@@ -36967,12 +36967,12 @@
           "CosignSecretManagerVerifyAttestation" : {
             "title" : "CosignSecretManagerVerifyAttestation",
             "type" : "object",
-            "required" : [ "connector", "keyName" ],
+            "required" : [ "connector", "key_name" ],
             "properties" : {
               "connector" : {
                 "type" : "string"
               },
-              "keyName" : {
+              "key_name" : {
                 "type" : "string"
               },
               "description" : {


### PR DESCRIPTION
**Description**
1. Modified schema for SSCA orchestration step to add vault attestation
2. Modify schema for SSCA Enforcement step to add vault attestation
3. Modify schema for SLSA Verification step to add vault attestation

I have tested the changes for backward compatibility all the steps are working fine . Here's the execution link 
https://kartikey366.pr2.harness.io/ng/account/WcI4OiuJTr-o2PSZwXuYkA/all/orgs/default/projects/Humanshu_Testing/pipelines/SSCA_and_SLSA/executions/1vYXiWGKStyf3le8jmmuOg/pipeline