### PR TITLE
feat: [CDS-100123]: On failure support for CD multi deployment

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -1074,6 +1074,9 @@
               "services" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/ServicesYaml"
               },
+              "multiDeploymentConfig" : {
+                "$ref" : "#/definitions/pipeline/stages/cd/MultiDeploymentConfig"
+              },
               "description" : {
                 "desc" : "This is the description for DeploymentStageConfig"
               }
@@ -7282,6 +7285,17 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
+          "MultiDeploymentConfig" : {
+            "title" : "MultiDeploymentConfig",
+            "type" : "object",
+            "description" : "Optional configuration for multiple service environment deployment.",
+            "properties" : {
+              "onFailure" : {
+                "$ref" : "#/definitions/pipeline/common/StrategyOnFailureType"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
           "AwsSamDeploymentMetaData" : {
             "title" : "AwsSamDeploymentMetaData",
             "allOf" : [ {
@@ -10895,6 +10909,13 @@
               "desc" : "This is the description for StepGroupInfra"
             }
           },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "StrategyOnFailureType" : {
+          "title" : "StrategyOnFailureType",
+          "type" : "string",
+          "description" : "Defines behaviour of execution strategy if one of the children fails.",
+          "enum" : [ "RunAll", "SkipQueued" ],
           "$schema" : "http://json-schema.org/draft-07/schema#"
         }
       },

--- a/v0/pipeline/common/strategy-on-failure-type.yaml
+++ b/v0/pipeline/common/strategy-on-failure-type.yaml
@@ -1,0 +1,7 @@
+title: StrategyOnFailureType
+type: string
+description: Defines behaviour of execution strategy if one of the children fails.
+enum:
+    - RunAll
+    - SkipQueued
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/stages/cd/deployment-stage-config.yaml
+++ b/v0/pipeline/stages/cd/deployment-stage-config.yaml
@@ -40,6 +40,8 @@ properties:
     $ref: service-config.yaml
   services:
     $ref: services-yaml.yaml
+  multiDeploymentConfig:
+    $ref: multi-deployment-config.yaml
   description:
     desc: This is the description for DeploymentStageConfig
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/stages/cd/multi-deployment-config.yaml
+++ b/v0/pipeline/stages/cd/multi-deployment-config.yaml
@@ -1,0 +1,7 @@
+title: MultiDeploymentConfig
+type: object
+description: Optional configuration for multiple service environment deployment.
+properties:
+  onFailure:
+    $ref: ../../common/strategy-on-failure-type.yaml
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/template.json
+++ b/v0/template.json
@@ -68705,6 +68705,13 @@
             }
           },
           "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "StrategyOnFailureType" : {
+          "title" : "StrategyOnFailureType",
+          "type" : "string",
+          "description" : "Defines behaviour of execution strategy if one of the children fails.",
+          "enum" : [ "RunAll", "SkipQueued" ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
         }
       },
       "stages" : {
@@ -69100,6 +69107,9 @@
               },
               "services" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/ServicesYaml"
+              },
+              "multiDeploymentConfig" : {
+                "$ref" : "#/definitions/pipeline/stages/cd/MultiDeploymentConfig"
               },
               "description" : {
                 "desc" : "This is the description for DeploymentStageConfig"
@@ -75071,6 +75081,17 @@
               },
               "description" : {
                 "desc" : "This is the description for ServicesMetadata"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "MultiDeploymentConfig" : {
+            "title" : "MultiDeploymentConfig",
+            "type" : "object",
+            "description" : "Optional configuration for multiple service environment deployment.",
+            "properties" : {
+              "onFailure" : {
+                "$ref" : "#/definitions/pipeline/common/StrategyOnFailureType"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"


### PR DESCRIPTION
- Added the following in CD stage
```
multiDeploymentConfig:
      onFailure: RunAll || SkipQueued
```

- Enum added in commons to be used at `strategy` level as well
- Product Spec: https://harness.atlassian.net/wiki/spaces/~62ac065cbfade2006967096e/pages/21966258289/Product+Spec+-+Matrix+Loop+Repeat+Failure+Handling

Local Testing
- In pipeline studio, only valid enum values should be allowed. 
![Screenshot 2024-08-21 at 12 54 50 PM](https://github.com/user-attachments/assets/9b0ddf01-ec6c-4bb1-858b-cbddba759de0)

- In pipeline studio, optional `onFailure` field
![Screenshot 2024-08-21 at 12 55 13 PM](https://github.com/user-attachments/assets/2066a700-60cd-4d7a-807c-5f0d404016a9)

- In pipeline studio, optional `multiDeploymentConfig` field

- In template studio, only valid enum values should be allowed. 
![Screenshot 2024-08-21 at 12 53 07 PM](https://github.com/user-attachments/assets/ae27acd0-195e-476b-8e82-888e6b7d7969)
- In template studio, optional `onFailure` field
![Screenshot 2024-08-21 at 12 53 58 PM](https://github.com/user-attachments/assets/a00dd0ab-f011-47ad-8fe6-af046ee85868)

- In template studio, optional `multiDeploymentConfig` field



