### PR TITLE
feat: [CDS-100629]: on_failure support for strategy config

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -10343,6 +10343,9 @@
             "repeat" : {
               "$ref" : "#/definitions/pipeline/common/HarnessForConfig"
             },
+            "onFailure" : {
+              "$ref" : "#/definitions/pipeline/common/StrategyOnFailureType"
+            },
             "description" : {
               "desc" : "This is the description for StrategyConfig"
             }
@@ -10515,6 +10518,13 @@
               "required" : [ "items" ]
             } ]
           } ]
+        },
+        "StrategyOnFailureType" : {
+          "title" : "StrategyOnFailureType",
+          "type" : "string",
+          "description" : "Defines behaviour of execution strategy if one of the children fails.",
+          "enum" : [ "RunAll", "SkipQueued" ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
         },
         "NumberNGVariable" : {
           "title" : "NumberNGVariable",
@@ -11018,13 +11028,6 @@
               "desc" : "This is the description for StepGroupInfra"
             }
           },
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "StrategyOnFailureType" : {
-          "title" : "StrategyOnFailureType",
-          "type" : "string",
-          "description" : "Defines behaviour of execution strategy if one of the children fails.",
-          "enum" : [ "RunAll", "SkipQueued" ],
           "$schema" : "http://json-schema.org/draft-07/schema#"
         }
       },

--- a/v0/pipeline/common/strategy-config.yaml
+++ b/v0/pipeline/common/strategy-config.yaml
@@ -20,6 +20,8 @@ properties:
       minLength: 1
   repeat:
     $ref: harness-for-config.yaml
+  onFailure:
+    $ref: strategy-on-failure-type.yaml
   description:
     desc: This is the description for StrategyConfig
 metadata:

--- a/v0/template.json
+++ b/v0/template.json
@@ -68125,6 +68125,9 @@
             "repeat" : {
               "$ref" : "#/definitions/pipeline/common/HarnessForConfig"
             },
+            "onFailure" : {
+              "$ref" : "#/definitions/pipeline/common/StrategyOnFailureType"
+            },
             "description" : {
               "desc" : "This is the description for StrategyConfig"
             }
@@ -68297,6 +68300,13 @@
               "required" : [ "items" ]
             } ]
           } ]
+        },
+        "StrategyOnFailureType" : {
+          "title" : "StrategyOnFailureType",
+          "type" : "string",
+          "description" : "Defines behaviour of execution strategy if one of the children fails.",
+          "enum" : [ "RunAll", "SkipQueued" ],
+          "$schema" : "http://json-schema.org/draft-07/schema#"
         },
         "StepWhenCondition" : {
           "title" : "StepWhenCondition",
@@ -68771,13 +68781,6 @@
               "desc" : "This is the description for StepGroupInfra"
             }
           },
-          "$schema" : "http://json-schema.org/draft-07/schema#"
-        },
-        "StrategyOnFailureType" : {
-          "title" : "StrategyOnFailureType",
-          "type" : "string",
-          "description" : "Defines behaviour of execution strategy if one of the children fails.",
-          "enum" : [ "RunAll", "SkipQueued" ],
           "$schema" : "http://json-schema.org/draft-07/schema#"
         }
       },


### PR DESCRIPTION
- Added the following in CD stage
```
strategy:
      onFailure: RunAll || SkipQueued
      repeat/matrix/parallelism:
           ...
```

- Enum added in commons to be used at `strategy` level as well
- Product Spec: https://harness.atlassian.net/wiki/spaces/~62ac065cbfade2006967096e/pages/21966258289/Product+Spec+-+Matrix+Loop+Repeat+Failure+Handling

Local Testing
- In pipeline studio, only valid enum values should be allowed. 
![Screenshot 2024-08-31 at 5 07 13 AM](https://github.com/user-attachments/assets/ab2a6a51-33e1-41b6-b624-d8a34e47e982)



- In pipeline studio, optional `onFailure` field
![Screenshot 2024-08-31 at 5 07 33 AM](https://github.com/user-attachments/assets/399958cc-e22a-46d0-b8f2-41f5fdb2fffa)

- In template studio, only valid enum values should be allowed. 
![Screenshot 2024-08-31 at 5 18 33 AM](https://github.com/user-attachments/assets/02c89049-9b6b-4a4c-aa70-f4ffdb4bf707)


- In template studio, optional `onFailure` field
![Screenshot 2024-08-31 at 5 23 41 AM](https://github.com/user-attachments/assets/e6b3fa6a-94c5-446c-b2da-2551b7dcfff7)


