### PR TITLE
feat: [SSCA-2576]: Adding the schema for the Provenance Step.

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -8409,6 +8409,8 @@
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepNode"
@@ -33800,6 +33802,489 @@
                 "$ref" : "#/definitions/pipeline/common/ContainerResource"
               }
             }
+          },
+          "ProvenanceStepNode" : {
+            "title" : "ProvenanceStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ProvenanceStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "provenance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "provenance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ProvenanceStepInfo" : {
+            "title" : "ProvenanceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSource"
+                },
+                "attestation" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSource"
+              },
+              "attestation" : {
+                "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaGenerationStepInfo"
+              }
+            }
+          },
+          "ProvenanceSource" : {
+            "title" : "ProvenanceSource",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaVerificationSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "docker"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gcr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ecr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "acr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gar"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "DockerSourceSpec" : {
+            "title" : "DockerSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "repo", "tags" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repo" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ProvenanceSourceSpec" : {
+            "title" : "ProvenanceSourceSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceSourceSpec"
+              }
+            }
+          },
+          "GcrSourceSpec" : {
+            "title" : "GcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectId", "imageName", "tags" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectId" : {
+                  "type" : "string"
+                },
+                "imageName" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gcr source spec"
+              }
+            }
+          },
+          "EcrSourceSpec" : {
+            "title" : "EcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "region" : {
+                  "type" : "string"
+                },
+                "account" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Ecr source spec"
+              }
+            }
+          },
+          "AcrSourceSpec" : {
+            "title" : "AcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "repository", "tags" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repository" : {
+                  "type" : "string"
+                },
+                "subscriptionId" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Acr source spec"
+              }
+            }
+          },
+          "GarSourceSpec" : {
+            "title" : "GarSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectId", "imageName", "tags" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectId" : {
+                  "type" : "string"
+                },
+                "imageName" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gar source spec"
+              }
+            }
+          },
+          "AttestationV1" : {
+            "title" : "AttestationV1",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "cosign" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestation"
+              },
+              "spec" : {
+                "type" : "object"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerProvenanceAttestation"
+                    } ],
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "additionalProperties" : false
+          },
+          "CosignAttestation" : {
+            "title" : "CosignAttestation",
+            "type" : "object",
+            "required" : [ "privateKey", "password" ],
+            "properties" : {
+              "privateKey" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for CosignAttestation"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
+          },
+          "AttestationSpecV1" : {
+            "title" : "AttestationSpecV1",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerProvenanceAttestation" : {
+            "title" : "CosignSecretManagerProvenanceAttestation",
+            "type" : "object",
+            "required" : [ "connector", "key" ],
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "key" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for Cosign Provenance Attestation with Secret Manager"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
           }
         },
         "ci" : {

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -33924,7 +33924,7 @@
                 "enum" : [ "docker", "gcr", "ecr", "acr", "gar" ]
               },
               "description" : {
-                "desc" : "This is the description for SlsaVerificationSource"
+                "desc" : "This is the description for SlsaGenerationSource"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -34011,19 +34011,13 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "repo", "tags" ],
+              "required" : [ "repo" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
                 },
                 "repo" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],
@@ -34050,7 +34044,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "projectId", "imageName", "tags" ],
+              "required" : [ "connector", "host", "projectId", "imageName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -34063,12 +34057,6 @@
                 },
                 "imageName" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],
@@ -34098,12 +34086,6 @@
                 },
                 "account" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],
@@ -34120,7 +34102,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "repository", "tags" ],
+              "required" : [ "connector", "repository" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -34130,12 +34112,6 @@
                 },
                 "subscriptionId" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],
@@ -34152,7 +34128,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "projectId", "imageName", "tags" ],
+              "required" : [ "connector", "host", "projectId", "imageName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -34165,12 +34141,6 @@
                 },
                 "imageName" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],

--- a/v0/pipeline/stages/ci/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/ci/execution-wrapper-config.yaml
@@ -77,6 +77,7 @@ properties:
       - $ref: ../../steps/custom/template-step-node.yaml
       - $ref: ../../steps/custom/wait-step-node.yaml
       - $ref: ../../steps/common/slsa-verification-step-node.yaml
+      - $ref: ../../steps/common/provenance-step-node.yaml
       - $ref: ../../steps/common/wiz-scan-node.yaml
       - $ref: ../../steps/common/ssca-compliance-step-node.yaml
   stepGroup:

--- a/v0/pipeline/steps/common/cosign-provenance-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-provenance-attestation.yaml
@@ -1,0 +1,16 @@
+title: CosignAttestation
+type: object
+$ref: provenance-attestation-spec.yaml
+required:
+  - privateKey
+  - password
+properties:
+  privateKey:
+    type: string
+  password:
+    type: string
+  description:
+    type: string
+    description: This is the description for CosignAttestation
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/common/cosign-secret-manager-provenance-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-secret-manager-provenance-attestation.yaml
@@ -1,0 +1,16 @@
+title: CosignSecretManagerProvenanceAttestation
+type: object
+$ref: provenance-attestation-spec.yaml
+required:
+  - connector
+  - key
+properties:
+  connector:
+    type: string
+  key:
+    type: string
+  description:
+    type: string
+    description: This is the description for Cosign Provenance Attestation with Secret Manager
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
@@ -5,7 +5,6 @@ allOf:
     required:
       - connector
       - repository
-      - tags
     properties:
       connector:
         type: string
@@ -13,10 +12,6 @@ allOf:
         type: string
       subscriptionId:
         type: string
-      tags:
-        type: array
-        items:
-          type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
@@ -1,0 +1,23 @@
+title: AcrSourceSpec
+allOf:
+  - $ref: provenance-source-spec.yaml
+  - type: object
+    required:
+      - connector
+      - repository
+      - tags
+    properties:
+      connector:
+        type: string
+      repository:
+        type: string
+      subscriptionId:
+        type: string
+      tags:
+        type: array
+        items:
+          type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: Acr source spec

--- a/v0/pipeline/steps/common/provenance-attestation-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-attestation-spec.yaml
@@ -1,0 +1,6 @@
+title: AttestationSpecV1
+type: object
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for ProvenanceAttestationSpec

--- a/v0/pipeline/steps/common/provenance-attestation.yaml
+++ b/v0/pipeline/steps/common/provenance-attestation.yaml
@@ -1,0 +1,35 @@
+title: AttestationV1
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - cosign
+  description:
+    desc: This is the description for ProvenanceAttestation
+  spec:
+    type: object
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: cosign
+    then:
+      properties:
+        spec:
+          type: object
+          oneOf:
+            - $ref: cosign-provenance-attestation.yaml
+            - $ref: cosign-secret-manager-provenance-attestation.yaml
+          properties:
+            cosignVariables:
+              type: array
+              items:
+                type: object
+                properties:
+                  key:
+                    type: string
+                  value:
+                    type: string
+additionalProperties: false

--- a/v0/pipeline/steps/common/provenance-docker-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-docker-source-spec.yaml
@@ -4,16 +4,11 @@ allOf:
 - type: object
   required:
   - repo
-  - tags
   properties:
     connector:
       type: string
     repo:
       type: string
-    tags:
-      type: array
-      items:
-        type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/common/provenance-docker-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-docker-source-spec.yaml
@@ -1,0 +1,20 @@
+title: DockerSourceSpec
+allOf:
+- $ref: provenance-source-spec.yaml
+- type: object
+  required:
+  - repo
+  - tags
+  properties:
+    connector:
+      type: string
+    repo:
+      type: string
+    tags:
+      type: array
+      items:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for DockerSourceSpec

--- a/v0/pipeline/steps/common/provenance-ecr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-ecr-source-spec.yaml
@@ -13,10 +13,6 @@ allOf:
         type: string
       account:
         type: string
-      tags:
-        type: array
-        items:
-          type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/common/provenance-ecr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-ecr-source-spec.yaml
@@ -1,0 +1,23 @@
+title: EcrSourceSpec
+allOf:
+  - $ref: provenance-source-spec.yaml
+  - type: object
+    required:
+      - image
+    properties:
+      connector:
+        type: string
+      image:
+        type: string
+      region:
+        type: string
+      account:
+        type: string
+      tags:
+        type: array
+        items:
+          type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: Ecr source spec

--- a/v0/pipeline/steps/common/provenance-gar-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-gar-source-spec.yaml
@@ -1,0 +1,27 @@
+title: GarSourceSpec
+allOf:
+- $ref: provenance-source-spec.yaml
+- type: object
+  required:
+  - connector
+  - host
+  - projectId
+  - imageName
+  - tags
+  properties:
+    connector:
+      type: string
+    host:
+      type: string
+    projectId:
+      type: string
+    imageName:
+      type: string
+    tags:
+      type: array
+      items:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: Gar source spec

--- a/v0/pipeline/steps/common/provenance-gar-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-gar-source-spec.yaml
@@ -7,7 +7,6 @@ allOf:
   - host
   - projectId
   - imageName
-  - tags
   properties:
     connector:
       type: string
@@ -17,10 +16,6 @@ allOf:
       type: string
     imageName:
       type: string
-    tags:
-      type: array
-      items:
-        type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/common/provenance-gcr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-gcr-source-spec.yaml
@@ -1,0 +1,27 @@
+title: GcrSourceSpec
+allOf:
+- $ref: provenance-source-spec.yaml
+- type: object
+  required:
+  - connector
+  - host
+  - projectId
+  - imageName
+  - tags
+  properties:
+    connector:
+      type: string
+    host:
+      type: string
+    projectId:
+      type: string
+    imageName:
+      type: string
+    tags:
+      type: array
+      items:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: Gcr source spec

--- a/v0/pipeline/steps/common/provenance-gcr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-gcr-source-spec.yaml
@@ -7,7 +7,6 @@ allOf:
   - host
   - projectId
   - imageName
-  - tags
   properties:
     connector:
       type: string
@@ -17,10 +16,6 @@ allOf:
       type: string
     imageName:
       type: string
-    tags:
-      type: array
-      items:
-        type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/common/provenance-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-source-spec.yaml
@@ -1,0 +1,6 @@
+title: ProvenanceSourceSpec
+type: object
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for ProvenanceSourceSpec

--- a/v0/pipeline/steps/common/provenance-source.yaml
+++ b/v0/pipeline/steps/common/provenance-source.yaml
@@ -10,7 +10,7 @@ properties:
     - acr
     - gar
   description:
-    desc: This is the description for SlsaVerificationSource
+    desc: This is the description for SlsaGenerationSource
 $schema: http://json-schema.org/draft-07/schema#
 allOf:
 - if:

--- a/v0/pipeline/steps/common/provenance-source.yaml
+++ b/v0/pipeline/steps/common/provenance-source.yaml
@@ -1,0 +1,56 @@
+title: ProvenanceSource
+type: object
+properties:
+  type:
+    type: string
+    enum:
+    - docker
+    - gcr
+    - ecr
+    - acr
+    - gar
+  description:
+    desc: This is the description for SlsaVerificationSource
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: docker
+  then:
+    properties:
+      spec:
+        $ref: provenance-docker-source-spec.yaml
+- if:
+    properties:
+      type:
+        const: gcr
+  then:
+    properties:
+      spec:
+        $ref: provenance-gcr-source-spec.yaml
+- if:
+    properties:
+      type:
+        const: ecr
+  then:
+    properties:
+      spec:
+        $ref: provenance-ecr-source-spec.yaml
+- if:
+    properties:
+      type:
+        const: acr
+  then:
+    properties:
+      spec:
+        $ref: provenance-acr-source-spec.yaml
+- if:
+    properties:
+      type:
+        const: gar
+  then:
+    properties:
+      spec:
+        $ref: provenance-gar-source-spec.yaml
+

--- a/v0/pipeline/steps/common/provenance-step-info.yaml
+++ b/v0/pipeline/steps/common/provenance-step-info.yaml
@@ -1,0 +1,22 @@
+title: ProvenanceStepInfo
+allOf:
+- $ref: ../../common/step-spec-type.yaml
+- type: object
+  properties:
+    source:
+      $ref: provenance-source.yaml
+    attestation:
+      $ref: provenance-attestation.yaml
+    resources:
+      $ref: ../../common/container-resource.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+properties:
+  source:
+    $ref: provenance-source.yaml
+  attestation:
+    $ref: provenance-attestation.yaml
+  resources:
+    $ref: ../../common/container-resource.yaml
+  description:
+    desc: This is the description for SlsaGenerationStepInfo

--- a/v0/pipeline/steps/common/provenance-step-node.yaml
+++ b/v0/pipeline/steps/common/provenance-step-node.yaml
@@ -1,0 +1,55 @@
+title: ProvenanceStepNode
+type: object
+required:
+- identifier
+- name
+- spec
+properties:
+  description:
+    type: string
+    desc: This is the description for ProvenanceStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+    - type: array
+      items:
+        $ref: ../../common/failure-strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+    - $ref: ../../common/strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+    - provenance
+  when:
+    oneOf:
+    - $ref: ../../common/step-when-condition.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: provenance
+  then:
+    properties:
+      spec:
+        $ref: provenance-step-info.yaml

--- a/v0/template.json
+++ b/v0/template.json
@@ -58941,6 +58941,489 @@
               }
             } ]
           },
+          "ProvenanceStepNode" : {
+            "title" : "ProvenanceStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ProvenanceStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "provenance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "provenance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ProvenanceStepInfo" : {
+            "title" : "ProvenanceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSource"
+                },
+                "attestation" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSource"
+              },
+              "attestation" : {
+                "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaGenerationStepInfo"
+              }
+            }
+          },
+          "ProvenanceSource" : {
+            "title" : "ProvenanceSource",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaVerificationSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "docker"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gcr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ecr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "acr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gar"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "DockerSourceSpec" : {
+            "title" : "DockerSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "repo", "tags" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repo" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ProvenanceSourceSpec" : {
+            "title" : "ProvenanceSourceSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceSourceSpec"
+              }
+            }
+          },
+          "GcrSourceSpec" : {
+            "title" : "GcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectId", "imageName", "tags" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectId" : {
+                  "type" : "string"
+                },
+                "imageName" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gcr source spec"
+              }
+            }
+          },
+          "EcrSourceSpec" : {
+            "title" : "EcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "region" : {
+                  "type" : "string"
+                },
+                "account" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Ecr source spec"
+              }
+            }
+          },
+          "AcrSourceSpec" : {
+            "title" : "AcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "repository", "tags" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repository" : {
+                  "type" : "string"
+                },
+                "subscriptionId" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Acr source spec"
+              }
+            }
+          },
+          "GarSourceSpec" : {
+            "title" : "GarSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectId", "imageName", "tags" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectId" : {
+                  "type" : "string"
+                },
+                "imageName" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gar source spec"
+              }
+            }
+          },
+          "AttestationV1" : {
+            "title" : "AttestationV1",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "cosign" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestation"
+              },
+              "spec" : {
+                "type" : "object"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerProvenanceAttestation"
+                    } ],
+                    "properties" : {
+                      "cosignVariables" : {
+                        "type" : "array",
+                        "items" : {
+                          "type" : "object",
+                          "properties" : {
+                            "key" : {
+                              "type" : "string"
+                            },
+                            "value" : {
+                              "type" : "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            } ],
+            "additionalProperties" : false
+          },
+          "CosignAttestation" : {
+            "title" : "CosignAttestation",
+            "type" : "object",
+            "required" : [ "privateKey", "password" ],
+            "properties" : {
+              "privateKey" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for CosignAttestation"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
+          },
+          "AttestationSpecV1" : {
+            "title" : "AttestationSpecV1",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerProvenanceAttestation" : {
+            "title" : "CosignSecretManagerProvenanceAttestation",
+            "type" : "object",
+            "required" : [ "connector", "key" ],
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "key" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for Cosign Provenance Attestation with Secret Manager"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
+          },
           "WizScanNode" : {
             "title" : "WizScanNode",
             "type" : "object",
@@ -77399,6 +77882,8 @@
                   "$ref" : "#/definitions/pipeline/steps/custom/WaitStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
                 }, {

--- a/v0/template.json
+++ b/v0/template.json
@@ -59149,19 +59149,13 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "repo", "tags" ],
+              "required" : [ "repo" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
                 },
                 "repo" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],
@@ -59188,7 +59182,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "projectId", "imageName", "tags" ],
+              "required" : [ "connector", "host", "projectId", "imageName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -59201,12 +59195,6 @@
                 },
                 "imageName" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],
@@ -59236,12 +59224,6 @@
                 },
                 "account" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],
@@ -59258,7 +59240,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "repository", "tags" ],
+              "required" : [ "connector", "repository" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -59268,12 +59250,6 @@
                 },
                 "subscriptionId" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],
@@ -59290,7 +59266,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "projectId", "imageName", "tags" ],
+              "required" : [ "connector", "host", "projectId", "imageName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -59303,12 +59279,6 @@
                 },
                 "imageName" : {
                   "type" : "string"
-                },
-                "tags" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
                 }
               }
             } ],

--- a/v0/template.json
+++ b/v0/template.json
@@ -59062,7 +59062,7 @@
                 "enum" : [ "docker", "gcr", "ecr", "acr", "gar" ]
               },
               "description" : {
-                "desc" : "This is the description for SlsaVerificationSource"
+                "desc" : "This is the description for SlsaGenerationSource"
               }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#",


### PR DESCRIPTION
Adding the schema for the separate Provenance/ SLSA Generation Step.
Mocks: https://www.figma.com/design/XllTuoCMFBV8CWrT9bwd03/SSCA-2.0?node-id=3737-30256&t=ZVjdAFMgZanLex9x-1


```
step:
    type: provenance 
    name: SlsaGeneration
    identifier: SlsaGeneration
    spec:
      source:
        type: DockerRegistry / ECR / GCR / ACR / GAR
        spec:
          connector: connectorRef
          image_path: repo/imagePath
        attestation: // Optional
          type: cosign
          spec:
            private_key: private_key_for_att
            password: password_for_att
        resources:
          limits:
            memory: 500Mi
            cpu: "0.5"
```
