### PR TITLE
feat: [CDS-100884]: Added allowed values,regex,required field to harness approval inputs

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -14369,7 +14369,20 @@
                 "type" : "string",
                 "minLength" : 1
               },
+              "required" : {
+                "type" : "boolean"
+              },
+              "regex" : {
+                "type" : "string"
+              },
+              "allowedValues" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
               "description" : {
+                "type" : "string",
                 "desc" : "This is the description for ApproverInputInfo"
               }
             },

--- a/v0/pipeline/steps/custom/approver-input-info.yaml
+++ b/v0/pipeline/steps/custom/approver-input-info.yaml
@@ -6,6 +6,15 @@ properties:
   name:
     type: string
     minLength: 1
+  required:
+    type: boolean
+  regex:
+    type: string
+  allowedValues:
+    type: array
+    items:
+      type: string
   description:
+    type: string
     desc: This is the description for ApproverInputInfo
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/template.json
+++ b/v0/template.json
@@ -33328,7 +33328,20 @@
                 "type" : "string",
                 "minLength" : 1
               },
+              "required" : {
+                "type" : "boolean"
+              },
+              "regex" : {
+                "type" : "string"
+              },
+              "allowedValues" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
               "description" : {
+                "type" : "string",
                 "desc" : "This is the description for ApproverInputInfo"
               }
             },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -9439,7 +9439,20 @@
                 "type" : "string",
                 "minLength" : 1
               },
+              "required" : {
+                "type" : "boolean"
+              },
+              "regex" : {
+                "type" : "string"
+              },
+              "allowedValues" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
               "description" : {
+                "type" : "string",
                 "desc" : "This is the description for ApproverInputInfo"
               }
             },

--- a/v1/pipeline/steps/custom/approver-input-info.yaml
+++ b/v1/pipeline/steps/custom/approver-input-info.yaml
@@ -8,6 +8,15 @@ properties:
   name:
     type: string
     minLength: 1
+  required:
+    type: boolean
+  regex:
+    type: string
+  allowedValues:
+    type: array
+    items:
+      type: string
   description:
+    type: string
     desc: This is the description for ApproverInputInfo
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/template.json
+++ b/v1/template.json
@@ -34853,7 +34853,20 @@
                 "type" : "string",
                 "minLength" : 1
               },
+              "required" : {
+                "type" : "boolean"
+              },
+              "regex" : {
+                "type" : "string"
+              },
+              "allowedValues" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
               "description" : {
+                "type" : "string",
                 "desc" : "This is the description for ApproverInputInfo"
               }
             },


### PR DESCRIPTION
Problem: For harness approval, currently we do not have regex or allowed values constraints on the approver inputs. Working on a feature to support that.

Changes:  
Added following fields : 
- allowedValues : List of values that have to be allowed for the variable. Individual values can be expression
- regex: Regex pattern to match with the variable. Pattern can be an expression 
- required : Boolean if the variable is a required field. It can be an expression. This is an optional field with the default as false.

Testing:
Tested locally with final pipeline to see that the yaml is working as expected for the added fields.
<img width="588" alt="Screenshot 2024-09-10 at 4 01 54 PM" src="https://github.com/user-attachments/assets/f373509d-3fc6-4e1a-baab-82b436ee8af8">
