### PR TITLE
feat: [CDS-100884]: Modified approver input schema to incorporate selectOneFrom

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -14372,21 +14372,47 @@
               "required" : {
                 "type" : "boolean"
               },
-              "regex" : {
+              "allowedValues" : {
                 "type" : "string"
               },
-              "allowedValues" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+              "selectOneFrom" : {
+                "type" : "string"
+              },
+              "regex" : {
+                "type" : "string"
               },
               "description" : {
                 "type" : "string",
                 "desc" : "This is the description for ApproverInputInfo"
               }
             },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "oneOf" : [ {
+              "required" : [ "regex" ],
+              "not" : {
+                "required" : [ "allowedValues", "selectOneFrom" ]
+              }
+            }, {
+              "required" : [ "allowedValues" ],
+              "not" : {
+                "required" : [ "regex", "selectOneFrom" ]
+              }
+            }, {
+              "required" : [ "selectOneFrom" ],
+              "not" : {
+                "required" : [ "allowedValues", "regex" ]
+              }
+            }, {
+              "not" : {
+                "anyOf" : [ {
+                  "required" : [ "regex" ]
+                }, {
+                  "required" : [ "allowedValues" ]
+                }, {
+                  "required" : [ "selectOneFrom" ]
+                } ]
+              }
+            } ]
           },
           "Approvers" : {
             "title" : "Approvers",

--- a/v0/pipeline/steps/custom/approver-input-info.yaml
+++ b/v0/pipeline/steps/custom/approver-input-info.yaml
@@ -8,13 +8,28 @@ properties:
     minLength: 1
   required:
     type: boolean
+  allowedValues:
+    type: string
+  selectOneFrom:
+    type: string
   regex:
     type: string
-  allowedValues:
-    type: array
-    items:
-      type: string
   description:
     type: string
     desc: This is the description for ApproverInputInfo
 $schema: http://json-schema.org/draft-07/schema#
+oneOf:
+  - required: [regex]
+    not:
+      required: [allowedValues, selectOneFrom]
+  - required: [allowedValues]
+    not:
+      required: [regex, selectOneFrom]
+  - required: [selectOneFrom]
+    not:
+      required: [allowedValues, regex]
+  - not:
+      anyOf:
+        - required: [regex]
+        - required: [allowedValues]
+        - required: [selectOneFrom]

--- a/v0/template.json
+++ b/v0/template.json
@@ -33331,21 +33331,47 @@
               "required" : {
                 "type" : "boolean"
               },
-              "regex" : {
+              "allowedValues" : {
                 "type" : "string"
               },
-              "allowedValues" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+              "selectOneFrom" : {
+                "type" : "string"
+              },
+              "regex" : {
+                "type" : "string"
               },
               "description" : {
                 "type" : "string",
                 "desc" : "This is the description for ApproverInputInfo"
               }
             },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "oneOf" : [ {
+              "required" : [ "regex" ],
+              "not" : {
+                "required" : [ "allowedValues", "selectOneFrom" ]
+              }
+            }, {
+              "required" : [ "allowedValues" ],
+              "not" : {
+                "required" : [ "regex", "selectOneFrom" ]
+              }
+            }, {
+              "required" : [ "selectOneFrom" ],
+              "not" : {
+                "required" : [ "allowedValues", "regex" ]
+              }
+            }, {
+              "not" : {
+                "anyOf" : [ {
+                  "required" : [ "regex" ]
+                }, {
+                  "required" : [ "allowedValues" ]
+                }, {
+                  "required" : [ "selectOneFrom" ]
+                } ]
+              }
+            } ]
           },
           "Approvers" : {
             "title" : "Approvers",

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -9430,9 +9430,8 @@
           "ApproverInputInfo" : {
             "title" : "ApproverInputInfo",
             "type" : "object",
-            "required" : [ "name" ],
             "properties" : {
-              "default" : {
+              "defaultValue" : {
                 "type" : "string"
               },
               "name" : {
@@ -9442,21 +9441,47 @@
               "required" : {
                 "type" : "boolean"
               },
-              "regex" : {
+              "allowedValues" : {
                 "type" : "string"
               },
-              "allowedValues" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+              "selectOneFrom" : {
+                "type" : "string"
+              },
+              "regex" : {
+                "type" : "string"
               },
               "description" : {
                 "type" : "string",
                 "desc" : "This is the description for ApproverInputInfo"
               }
             },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "oneOf" : [ {
+              "required" : [ "regex" ],
+              "not" : {
+                "required" : [ "allowedValues", "selectOneFrom" ]
+              }
+            }, {
+              "required" : [ "allowedValues" ],
+              "not" : {
+                "required" : [ "regex", "selectOneFrom" ]
+              }
+            }, {
+              "required" : [ "selectOneFrom" ],
+              "not" : {
+                "required" : [ "allowedValues", "regex" ]
+              }
+            }, {
+              "not" : {
+                "anyOf" : [ {
+                  "required" : [ "regex" ]
+                }, {
+                  "required" : [ "allowedValues" ]
+                }, {
+                  "required" : [ "selectOneFrom" ]
+                } ]
+              }
+            } ]
           },
           "Approvers" : {
             "title" : "Approvers",

--- a/v1/pipeline/steps/custom/approver-input-info.yaml
+++ b/v1/pipeline/steps/custom/approver-input-info.yaml
@@ -1,22 +1,35 @@
 title: ApproverInputInfo
 type: object
-required:
-  - name
 properties:
-  default:
+  defaultValue:
     type: string
   name:
     type: string
     minLength: 1
   required:
     type: boolean
+  allowedValues:
+    type: string
+  selectOneFrom:
+    type: string
   regex:
     type: string
-  allowedValues:
-    type: array
-    items:
-      type: string
   description:
     type: string
     desc: This is the description for ApproverInputInfo
 $schema: http://json-schema.org/draft-07/schema#
+oneOf:
+  - required: [regex]
+    not:
+      required: [allowedValues, selectOneFrom]
+  - required: [allowedValues]
+    not:
+      required: [regex, selectOneFrom]
+  - required: [selectOneFrom]
+    not:
+      required: [allowedValues, regex]
+  - not:
+      anyOf:
+        - required: [regex]
+        - required: [allowedValues]
+        - required: [selectOneFrom]

--- a/v1/template.json
+++ b/v1/template.json
@@ -34844,9 +34844,8 @@
           "ApproverInputInfo" : {
             "title" : "ApproverInputInfo",
             "type" : "object",
-            "required" : [ "name" ],
             "properties" : {
-              "default" : {
+              "defaultValue" : {
                 "type" : "string"
               },
               "name" : {
@@ -34856,21 +34855,47 @@
               "required" : {
                 "type" : "boolean"
               },
-              "regex" : {
+              "allowedValues" : {
                 "type" : "string"
               },
-              "allowedValues" : {
-                "type" : "array",
-                "items" : {
-                  "type" : "string"
-                }
+              "selectOneFrom" : {
+                "type" : "string"
+              },
+              "regex" : {
+                "type" : "string"
               },
               "description" : {
                 "type" : "string",
                 "desc" : "This is the description for ApproverInputInfo"
               }
             },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "oneOf" : [ {
+              "required" : [ "regex" ],
+              "not" : {
+                "required" : [ "allowedValues", "selectOneFrom" ]
+              }
+            }, {
+              "required" : [ "allowedValues" ],
+              "not" : {
+                "required" : [ "regex", "selectOneFrom" ]
+              }
+            }, {
+              "required" : [ "selectOneFrom" ],
+              "not" : {
+                "required" : [ "allowedValues", "regex" ]
+              }
+            }, {
+              "not" : {
+                "anyOf" : [ {
+                  "required" : [ "regex" ]
+                }, {
+                  "required" : [ "allowedValues" ]
+                }, {
+                  "required" : [ "selectOneFrom" ]
+                } ]
+              }
+            } ]
           },
           "Approvers" : {
             "title" : "Approvers",


### PR DESCRIPTION
Follow up of : https://github.com/harness/harness-schema/pull/440

Tech spec : https://harness.atlassian.net/wiki/spaces/CDNG/pages/22007154225/Tech+Spec+Runtime+Input+with+allowed+values+in+Manual+Approval+step

There were some changes made to yaml schema requirements. 

We have added another field selectOneFrom to support single select and multiselect

Added constraint that at most one of them can be present out of three: regex, allowedValues, selectOneFrom fields

Testing:
Tested locally by using the pipeline.json generated

Works as expected with at most one of the fields:

<img width="852" alt="Screenshot 2024-09-12 at 10 24 50 PM" src="https://github.com/user-attachments/assets/d5ccd876-a9f8-4bb0-8a00-4923a4f9da99">

Throws schema error when we trying saving more than one for the same approver inputs
<img width="997" alt="Screenshot 2024-09-12 at 10 25 11 PM" src="https://github.com/user-attachments/assets/2e723a5b-94f7-4787-a9d0-3a8b2baf79f8">
