### PR TITLE
feat: [IAC-2478]: Add Terraform Variable Files to Schema, Move Variables to Spec

### DIFF
--- a/v0/template.json
+++ b/v0/template.json
@@ -965,30 +965,6 @@
               "type" : "string",
               "pattern" : "^[0-9a-zA-Z][^\\s/&]{0,127}$"
             },
-            "variables" : {
-              "type" : "array",
-              "items" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/numberVariable"
-                }, {
-                  "$ref" : "#/definitions/pipeline/stringVariable"
-                }, {
-                  "$ref" : "#/definitions/pipeline/secretVariable"
-                } ]
-              }
-            },
-            "terraform_variables" : {
-              "type" : "array",
-              "items" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/numberVariable"
-                }, {
-                  "$ref" : "#/definitions/pipeline/stringVariable"
-                }, {
-                  "$ref" : "#/definitions/pipeline/secretVariable"
-                } ]
-              }
-            },
             "spec" : {
               "type" : "object",
               "properties" : {
@@ -1038,6 +1014,37 @@
                     "path" : {
                       "type" : "string"
                     }
+                  }
+                },
+                "variables" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/numberVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/stringVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/secretVariable"
+                    } ]
+                  }
+                },
+                "terraform_variables" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/numberVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/stringVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/secretVariable"
+                    } ]
+                  }
+                },
+                "terraform_variable_files" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "pattern" : "^.*\\.tf$"
                   }
                 }
               }

--- a/v0/template.json
+++ b/v0/template.json
@@ -1044,7 +1044,7 @@
                   "type" : "array",
                   "items" : {
                     "type" : "string",
-                    "pattern" : "^.*\\.tf$"
+                    "pattern" : "^.*\\.(tf|tofu)$"
                   }
                 }
               }

--- a/v0/template/workspace/template.yaml
+++ b/v0/template/workspace/template.yaml
@@ -19,20 +19,6 @@ properties:
   versionLabel:
     type: string
     pattern: "^[0-9a-zA-Z][^\\s/&]{0,127}$"
-  variables:
-    type: array
-    items:
-      oneOf:
-        - "$ref": "../../pipeline/number_variable.yaml"
-        - "$ref": "../../pipeline/string_variable.yaml"
-        - "$ref": "../../pipeline/secret_variable.yaml"
-  terraform_variables:
-    type: array
-    items:
-      oneOf:
-        - "$ref": "../../pipeline/number_variable.yaml"
-        - "$ref": "../../pipeline/string_variable.yaml"
-        - "$ref": "../../pipeline/secret_variable.yaml"
   spec:
     type: object
     properties:
@@ -67,3 +53,22 @@ properties:
             type: string
           path:
             type: string
+      variables:
+        type: array
+        items:
+          oneOf:
+            - "$ref": "../../pipeline/number_variable.yaml"
+            - "$ref": "../../pipeline/string_variable.yaml"
+            - "$ref": "../../pipeline/secret_variable.yaml"
+      terraform_variables:
+        type: array
+        items:
+          oneOf:
+            - "$ref": "../../pipeline/number_variable.yaml"
+            - "$ref": "../../pipeline/string_variable.yaml"
+            - "$ref": "../../pipeline/secret_variable.yaml"
+      terraform_variable_files:
+        type: array
+        items:
+          type: string
+          pattern: "^.*\\.tf$"

--- a/v0/template/workspace/template.yaml
+++ b/v0/template/workspace/template.yaml
@@ -71,4 +71,4 @@ properties:
         type: array
         items:
           type: string
-          pattern: "^.*\\.tf$"
+          pattern: "^.*\\.(tf|tofu)$"

--- a/v1/template.json
+++ b/v1/template.json
@@ -1251,7 +1251,7 @@
                   "type" : "array",
                   "items" : {
                     "type" : "string",
-                    "pattern" : "^.*\\.tf$"
+                    "pattern" : "^.*\\.(tf|tofu)$"
                   }
                 }
               }

--- a/v1/template.json
+++ b/v1/template.json
@@ -1172,30 +1172,6 @@
               "type" : "string",
               "pattern" : "^[0-9a-zA-Z][^\\s/&]{0,127}$"
             },
-            "variables" : {
-              "type" : "array",
-              "items" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/numberVariable"
-                }, {
-                  "$ref" : "#/definitions/pipeline/stringVariable"
-                }, {
-                  "$ref" : "#/definitions/pipeline/secretVariable"
-                } ]
-              }
-            },
-            "terraform_variables" : {
-              "type" : "array",
-              "items" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/numberVariable"
-                }, {
-                  "$ref" : "#/definitions/pipeline/stringVariable"
-                }, {
-                  "$ref" : "#/definitions/pipeline/secretVariable"
-                } ]
-              }
-            },
             "spec" : {
               "type" : "object",
               "properties" : {
@@ -1245,6 +1221,37 @@
                     "path" : {
                       "type" : "string"
                     }
+                  }
+                },
+                "variables" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/numberVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/stringVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/secretVariable"
+                    } ]
+                  }
+                },
+                "terraform_variables" : {
+                  "type" : "array",
+                  "items" : {
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/numberVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/stringVariable"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/secretVariable"
+                    } ]
+                  }
+                },
+                "terraform_variable_files" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string",
+                    "pattern" : "^.*\\.tf$"
                   }
                 }
               }

--- a/v1/template/workspace/template.yaml
+++ b/v1/template/workspace/template.yaml
@@ -19,20 +19,6 @@ properties:
   versionLabel:
     type: string
     pattern: "^[0-9a-zA-Z][^\\s/&]{0,127}$"
-  variables:
-    type: array
-    items:
-      oneOf:
-        - "$ref": "../../pipeline/number_variable.yaml"
-        - "$ref": "../../pipeline/string_variable.yaml"
-        - "$ref": "../../pipeline/secret_variable.yaml"
-  terraform_variables:
-    type: array
-    items:
-      oneOf:
-        - "$ref": "../../pipeline/number_variable.yaml"
-        - "$ref": "../../pipeline/string_variable.yaml"
-        - "$ref": "../../pipeline/secret_variable.yaml"
   spec:
     type: object
     properties:
@@ -67,3 +53,22 @@ properties:
             type: string
           path:
             type: string
+      variables:
+        type: array
+        items:
+          oneOf:
+            - "$ref": "../../pipeline/number_variable.yaml"
+            - "$ref": "../../pipeline/string_variable.yaml"
+            - "$ref": "../../pipeline/secret_variable.yaml"
+      terraform_variables:
+        type: array
+        items:
+          oneOf:
+            - "$ref": "../../pipeline/number_variable.yaml"
+            - "$ref": "../../pipeline/string_variable.yaml"
+            - "$ref": "../../pipeline/secret_variable.yaml"
+      terraform_variable_files:
+        type: array
+        items:
+          type: string
+          pattern: "^.*\\.tf$"

--- a/v1/template/workspace/template.yaml
+++ b/v1/template/workspace/template.yaml
@@ -71,4 +71,4 @@ properties:
         type: array
         items:
           type: string
-          pattern: "^.*\\.tf$"
+          pattern: "^.*\\.(tf|tofu)$"


### PR DESCRIPTION
What
Adds Terraform File Variables as an array of strings each with a file extension of .tf 
Moves Terraform Variables and Env Variables to Spec

Why
To Allow us to store terraform files in the template
To keep consistency 