### PR TITLE
feat: [SSCA-2576]: Adding spec for slsa generation step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -8421,6 +8421,8 @@
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepNode"
@@ -34163,6 +34165,548 @@
               },
               "resources" : {
                 "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              }
+            }
+          },
+          "ProvenanceStepNode" : {
+            "title" : "ProvenanceStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ProvenanceStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "provenance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "provenance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ProvenanceStepInfo" : {
+            "title" : "ProvenanceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "if" : {
+                "properties" : {
+                  "source" : {
+                    "properties" : {
+                      "type" : {
+                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr" ]
+                      }
+                    }
+                  }
+                }
+              },
+              "then" : {
+                "required" : [ "attestation" ],
+                "properties" : {
+                  "attestation" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
+                  }
+                }
+              }
+            } ],
+            "additonalProperties" : false,
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSource"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaGenerationStepInfo"
+              }
+            }
+          },
+          "AttestationV1" : {
+            "title" : "AttestationV1",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "cosign" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestation"
+              },
+              "spec" : {
+                "type" : "object"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerProvenanceAttestation"
+                    } ]
+                  }
+                }
+              }
+            } ],
+            "additionalProperties" : false
+          },
+          "CosignAttestation" : {
+            "title" : "CosignAttestation",
+            "type" : "object",
+            "required" : [ "privateKey", "password" ],
+            "properties" : {
+              "privateKey" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for CosignAttestation"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
+          },
+          "AttestationSpecV1" : {
+            "title" : "AttestationSpecV1",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerProvenanceAttestation" : {
+            "title" : "CosignSecretManagerProvenanceAttestation",
+            "type" : "object",
+            "required" : [ "connector", "key" ],
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "key" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for Cosign Provenance Attestation with Secret Manager"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
+          },
+          "ProvenanceSource" : {
+            "title" : "ProvenanceSource",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "others" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaGenerationSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "docker"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gcr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ecr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "acr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gar"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "others"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/OthersSourceSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "DockerSourceSpec" : {
+            "title" : "DockerSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "repo", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repo" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ProvenanceSourceSpec" : {
+            "title" : "ProvenanceSourceSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceSourceSpec"
+              }
+            }
+          },
+          "GcrSourceSpec" : {
+            "title" : "GcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectId", "imageName", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectId" : {
+                  "type" : "string"
+                },
+                "iamgeName" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gcr source spec"
+              }
+            }
+          },
+          "EcrSourceSpec" : {
+            "title" : "EcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "region" : {
+                  "type" : "string"
+                },
+                "account" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Ecr source spec"
+              }
+            }
+          },
+          "AcrSourceSpec" : {
+            "title" : "AcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "repository", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repository" : {
+                  "type" : "string"
+                },
+                "subscriptionId" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Acr source spec"
+              }
+            }
+          },
+          "GarSourceSpec" : {
+            "title" : "GarSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectId", "image", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectId" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gar source spec"
+              }
+            }
+          },
+          "OthersSourceSpec" : {
+            "title" : "OthersSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "artifacts" ],
+              "properties" : {
+                "artifacts" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceArtifact"
+                  },
+                  "minItems" : 1
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ProvenanceArtifact" : {
+            "title" : "ProvenanceArtifact",
+            "allOf" : [ {
+              "type" : "object",
+              "required" : [ "name", "digest" ],
+              "properties" : {
+                "name" : {
+                  "type" : "string"
+                },
+                "digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Provenance Artifact"
               }
             }
           }

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -34617,6 +34617,12 @@
                 },
                 "artifact_digest" : {
                   "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
                 }
               }
             } ],

--- a/v0/pipeline/stages/ci/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/ci/execution-wrapper-config.yaml
@@ -78,6 +78,7 @@ properties:
       - $ref: ../../steps/custom/template-step-node.yaml
       - $ref: ../../steps/custom/wait-step-node.yaml
       - $ref: ../../steps/common/slsa-verification-step-node.yaml
+      - $ref: ../../steps/common/provenance-step-node.yaml
       - $ref: ../../steps/common/wiz-scan-node.yaml
       - $ref: ../../steps/common/ssca-compliance-step-node.yaml
   stepGroup:

--- a/v0/pipeline/steps/common/cosign-provenance-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-provenance-attestation.yaml
@@ -1,0 +1,16 @@
+title: CosignAttestation
+type: object
+$ref: provenance-attestation-spec.yaml
+required:
+  - privateKey
+  - password
+properties:
+  privateKey:
+    type: string
+  password:
+    type: string
+  description:
+    type: string
+    description: This is the description for CosignAttestation
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/common/cosign-secret-manager-provenance-attestation.yaml
+++ b/v0/pipeline/steps/common/cosign-secret-manager-provenance-attestation.yaml
@@ -1,0 +1,16 @@
+title: CosignSecretManagerProvenanceAttestation
+type: object
+$ref: provenance-attestation-spec.yaml
+required:
+  - connector
+  - key
+properties:
+  connector:
+    type: string
+  key:
+    type: string
+  description:
+    type: string
+    description: This is the description for Cosign Provenance Attestation with Secret Manager
+$schema: http://json-schema.org/draft-07/schema#
+additionalProperties: false

--- a/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
@@ -1,0 +1,21 @@
+title: AcrSourceSpec
+allOf:
+  - $ref: provenance-source-spec.yaml
+  - type: object
+    required:
+      - connector
+      - repository
+      - artifact_digest
+    properties:
+      connector:
+        type: string
+      repository:
+        type: string
+      subscriptionId:
+        type: string
+      artifact_digest:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: Acr source spec

--- a/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
@@ -15,6 +15,10 @@ allOf:
         type: string
       artifact_digest:
         type: string
+      tags:
+        type: array
+        items:
+          type: string
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/pipeline/steps/common/provenance-artifact.yaml
+++ b/v0/pipeline/steps/common/provenance-artifact.yaml
@@ -1,0 +1,15 @@
+title: ProvenanceArtifact
+allOf:
+- type: object
+  required:
+  - name
+  - digest
+  properties:
+    name:
+      type: string
+    digest:
+      type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: Provenance Artifact

--- a/v0/pipeline/steps/common/provenance-attestation-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-attestation-spec.yaml
@@ -1,0 +1,6 @@
+title: AttestationSpecV1
+type: object
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for ProvenanceAttestationSpec

--- a/v0/pipeline/steps/common/provenance-attestation.yaml
+++ b/v0/pipeline/steps/common/provenance-attestation.yaml
@@ -1,0 +1,25 @@
+title: AttestationV1
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - cosign
+  description:
+    desc: This is the description for ProvenanceAttestation
+  spec:
+    type: object
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: cosign
+    then:
+      properties:
+        spec:
+          type: object
+          oneOf:
+            - $ref: cosign-provenance-attestation.yaml
+            - $ref: cosign-secret-manager-provenance-attestation.yaml
+additionalProperties: false

--- a/v0/pipeline/steps/common/provenance-docker-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-docker-source-spec.yaml
@@ -1,0 +1,22 @@
+title: DockerSourceSpec
+allOf:
+- $ref: provenance-source-spec.yaml
+- type: object
+  required:
+    - repo
+    - artifact_digest
+  properties:
+    connector:
+      type: string
+    repo:
+      type: string
+    artifact_digest:
+      type: string
+    tags:
+      type: array
+      items:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for DockerSourceSpec

--- a/v0/pipeline/steps/common/provenance-ecr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-ecr-source-spec.yaml
@@ -1,0 +1,26 @@
+title: EcrSourceSpec
+allOf:
+  - $ref: provenance-source-spec.yaml
+  - type: object
+    required:
+      - image
+      - artifact_digest
+    properties:
+      connector:
+        type: string
+      region:
+        type: string
+      account:
+        type: string
+      image:
+        type: string
+      artifact_digest:
+        type: string
+      tags:
+        type: array
+        items:
+          type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: Ecr source spec

--- a/v0/pipeline/steps/common/provenance-gar-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-gar-source-spec.yaml
@@ -1,0 +1,29 @@
+title: GarSourceSpec
+allOf:
+- $ref: provenance-source-spec.yaml
+- type: object
+  required:
+  - connector
+  - host
+  - projectId
+  - image
+  - artifact_digest
+  properties:
+    connector:
+      type: string
+    host:
+      type: string
+    projectId:
+      type: string
+    image:
+      type: string
+    artifact_digest:
+      type: string
+    tags:
+      type: array
+      items:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: Gar source spec

--- a/v0/pipeline/steps/common/provenance-gcr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-gcr-source-spec.yaml
@@ -1,0 +1,29 @@
+title: GcrSourceSpec
+allOf:
+- $ref: provenance-source-spec.yaml
+- type: object
+  required:
+  - connector
+  - host
+  - projectId
+  - imageName
+  - artifact_digest
+  properties:
+    connector:
+      type: string
+    host:
+      type: string
+    projectId:
+      type: string
+    iamgeName:
+      type: string
+    artifact_digest:
+      type: string
+    tags:
+      type: array
+      items:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: Gcr source spec

--- a/v0/pipeline/steps/common/provenance-others-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-others-source-spec.yaml
@@ -1,0 +1,16 @@
+title: OthersSourceSpec
+allOf:
+- $ref: provenance-source-spec.yaml
+- type: object
+  required:
+    - artifacts
+  properties:
+    artifacts:
+      type: array
+      items:
+        $ref: provenance-artifact.yaml
+      minItems: 1
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for DockerSourceSpec

--- a/v0/pipeline/steps/common/provenance-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-source-spec.yaml
@@ -1,0 +1,6 @@
+title: ProvenanceSourceSpec
+type: object
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for ProvenanceSourceSpec

--- a/v0/pipeline/steps/common/provenance-source.yaml
+++ b/v0/pipeline/steps/common/provenance-source.yaml
@@ -1,0 +1,64 @@
+title: ProvenanceSource
+type: object
+properties:
+  type:
+    type: string
+    enum:
+    - docker
+    - gcr
+    - ecr
+    - acr
+    - gar
+    - others
+  description:
+    desc: This is the description for SlsaGenerationSource
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: docker
+  then:
+    properties:
+      spec:
+        $ref: provenance-docker-source-spec.yaml
+- if:
+    properties:
+      type:
+        const: gcr
+  then:
+    properties:
+      spec:
+        $ref: provenance-gcr-source-spec.yaml
+- if:
+    properties:
+      type:
+        const: ecr
+  then:
+    properties:
+      spec:
+        $ref: provenance-ecr-source-spec.yaml
+- if:
+    properties:
+      type:
+        const: acr
+  then:
+    properties:
+      spec:
+        $ref: provenance-acr-source-spec.yaml
+- if:
+    properties:
+      type:
+        const: gar
+  then:
+    properties:
+      spec:
+        $ref: provenance-gar-source-spec.yaml
+- if:
+    properties:
+      type:
+        const: others
+  then:
+    properties:
+      spec:
+        $ref: provenance-others-source-spec.yaml

--- a/v0/pipeline/steps/common/provenance-step-info.yaml
+++ b/v0/pipeline/steps/common/provenance-step-info.yaml
@@ -1,0 +1,25 @@
+title: ProvenanceStepInfo
+allOf:
+- $ref: ../../common/step-spec-type.yaml
+- type: object
+  if:
+    properties:
+      source:
+        properties:
+          type:
+            enum: ["ecr", "docker", "gar", "gcr", "acr"]
+  then:
+    required: ["attestation"]
+    properties:
+      attestation:
+        $ref: "provenance-attestation.yaml"
+additonalProperties: false
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+properties:
+  source:
+    $ref: provenance-source.yaml
+  resources:
+    $ref: ../../common/container-resource.yaml
+  description:
+    desc: This is the description for SlsaGenerationStepInfo

--- a/v0/pipeline/steps/common/provenance-step-node.yaml
+++ b/v0/pipeline/steps/common/provenance-step-node.yaml
@@ -1,0 +1,55 @@
+title: ProvenanceStepNode
+type: object
+required:
+- identifier
+- name
+- spec
+properties:
+  description:
+    type: string
+    desc: This is the description for ProvenanceStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+    - type: array
+      items:
+        $ref: ../../common/failure-strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+    - $ref: ../../common/strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+    - provenance
+  when:
+    oneOf:
+    - $ref: ../../common/step-when-condition.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: provenance
+  then:
+    properties:
+      spec:
+        $ref: provenance-step-info.yaml

--- a/v0/template.json
+++ b/v0/template.json
@@ -60416,6 +60416,12 @@
                 },
                 "artifact_digest" : {
                   "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
                 }
               }
             } ],

--- a/v0/template.json
+++ b/v0/template.json
@@ -59967,6 +59967,548 @@
               }
             } ]
           },
+          "ProvenanceStepNode" : {
+            "title" : "ProvenanceStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ProvenanceStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "provenance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "provenance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ProvenanceStepInfo" : {
+            "title" : "ProvenanceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "if" : {
+                "properties" : {
+                  "source" : {
+                    "properties" : {
+                      "type" : {
+                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr" ]
+                      }
+                    }
+                  }
+                }
+              },
+              "then" : {
+                "required" : [ "attestation" ],
+                "properties" : {
+                  "attestation" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
+                  }
+                }
+              }
+            } ],
+            "additonalProperties" : false,
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSource"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaGenerationStepInfo"
+              }
+            }
+          },
+          "AttestationV1" : {
+            "title" : "AttestationV1",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "cosign" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestation"
+              },
+              "spec" : {
+                "type" : "object"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerProvenanceAttestation"
+                    } ]
+                  }
+                }
+              }
+            } ],
+            "additionalProperties" : false
+          },
+          "CosignAttestation" : {
+            "title" : "CosignAttestation",
+            "type" : "object",
+            "required" : [ "privateKey", "password" ],
+            "properties" : {
+              "privateKey" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for CosignAttestation"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
+          },
+          "AttestationSpecV1" : {
+            "title" : "AttestationSpecV1",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerProvenanceAttestation" : {
+            "title" : "CosignSecretManagerProvenanceAttestation",
+            "type" : "object",
+            "required" : [ "connector", "key" ],
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "key" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for Cosign Provenance Attestation with Secret Manager"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
+          },
+          "ProvenanceSource" : {
+            "title" : "ProvenanceSource",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "others" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaGenerationSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "docker"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gcr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ecr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "acr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gar"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "others"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/OthersSourceSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "DockerSourceSpec" : {
+            "title" : "DockerSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "repo", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repo" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ProvenanceSourceSpec" : {
+            "title" : "ProvenanceSourceSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceSourceSpec"
+              }
+            }
+          },
+          "GcrSourceSpec" : {
+            "title" : "GcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectId", "imageName", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectId" : {
+                  "type" : "string"
+                },
+                "iamgeName" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gcr source spec"
+              }
+            }
+          },
+          "EcrSourceSpec" : {
+            "title" : "EcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "region" : {
+                  "type" : "string"
+                },
+                "account" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Ecr source spec"
+              }
+            }
+          },
+          "AcrSourceSpec" : {
+            "title" : "AcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "repository", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repository" : {
+                  "type" : "string"
+                },
+                "subscriptionId" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Acr source spec"
+              }
+            }
+          },
+          "GarSourceSpec" : {
+            "title" : "GarSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectId", "image", "artifact_digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectId" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "artifact_digest" : {
+                  "type" : "string"
+                },
+                "tags" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gar source spec"
+              }
+            }
+          },
+          "OthersSourceSpec" : {
+            "title" : "OthersSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "artifacts" ],
+              "properties" : {
+                "artifacts" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceArtifact"
+                  },
+                  "minItems" : 1
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ProvenanceArtifact" : {
+            "title" : "ProvenanceArtifact",
+            "allOf" : [ {
+              "type" : "object",
+              "required" : [ "name", "digest" ],
+              "properties" : {
+                "name" : {
+                  "type" : "string"
+                },
+                "digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Provenance Artifact"
+              }
+            }
+          },
           "WizScanNode" : {
             "title" : "WizScanNode",
             "type" : "object",
@@ -78435,6 +78977,8 @@
                   "$ref" : "#/definitions/pipeline/steps/custom/WaitStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SlsaVerificationStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/WizScanNode"
                 }, {


### PR DESCRIPTION
Adding the schema for Slsa Generation step:

yaml for step when container type is selected :-
```
step:
  type: SlsaGeneration
  name: Generate SLSA
  identifier: SlsaGeneration_1
  spec:
    source:
      type: ecr | gcr | docker| acr | gar
      spec: 
        connector: string 
        host: string # Field name dependent on type
        projectId: string # Field name dependent on type
        image: string # Field name dependent on type -  To support backward compatibility kept name same as what is previously present in step
        tags: array # To support backward compatibility
        artifact_digest: string 
    attestation: # Will be same for all
      type: cosign
      spec:
        privateKey: account.KD_SSCA_Pvt_Key
        password: account.KD_SSCA_PWD
        connector: string
        key: string
    resources:
      limits:
      memory: 500Mi
      cpu: "0.5"
```

Yaml for step when 'others' type is selected:

```
step:
  type: SlsaGeneration
  name: Generate SLSA
  identifier: SlsaGeneration_1
  spec:
    source:
      type: Others
      spec: 
        artifact: # List of items in case of this type
          - name: string 
            digest: string 
  resources:
    limits:
    memory: 500Mi
    cpu: "0.5"
```