### PR TITLE
feat: [CDS-101268]:Schema changes for sevice/env failure strategy override

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -1424,6 +1424,18 @@
                   "$ref" : "#/definitions/pipeline/stages/cd/ServiceOverrideInputsYaml"
                 }
               },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
               "description" : {
                 "desc" : "This is the description for EnvironmentYamlV2"
               }
@@ -2322,6 +2334,18 @@
               "metadata" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupMetadata"
               },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
               "description" : {
                 "desc" : "This is the description for EnvironmentGroupYaml"
               }
@@ -2375,6 +2399,18 @@
                 }, {
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
                   "minLength" : 1
                 } ]
               },
@@ -3822,6 +3858,18 @@
               },
               "useFromStage" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/ServiceUseFromStageV2"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for ServiceYamlV2"
@@ -7376,6 +7424,18 @@
                 }, {
                   "type" : "string",
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
                   "minLength" : 1
                 } ]
               },

--- a/v0/pipeline/stages/cd/environment-group-yaml.yaml
+++ b/v0/pipeline/stages/cd/environment-group-yaml.yaml
@@ -32,6 +32,14 @@ properties:
       minLength: 1
   metadata:
     $ref: environment-group-metadata.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
   description:
     desc: This is the description for EnvironmentGroupYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/stages/cd/environment-yaml-v2.yaml
+++ b/v0/pipeline/stages/cd/environment-yaml-v2.yaml
@@ -59,6 +59,14 @@ properties:
     type: array
     items:
       $ref: service-override-inputs-yaml.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
   description:
     desc: This is the description for EnvironmentYamlV2
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/stages/cd/environments-yaml.yaml
+++ b/v0/pipeline/stages/cd/environments-yaml.yaml
@@ -20,6 +20,14 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
   description:
     desc: This is the description for EnvironmentsYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/stages/cd/service-yaml-v2.yaml
+++ b/v0/pipeline/stages/cd/service-yaml-v2.yaml
@@ -13,6 +13,14 @@ properties:
     type: string
   useFromStage:
     $ref: service-use-from-stage-v2.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
   description:
     desc: This is the description for ServiceYamlV2
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/stages/cd/services-yaml.yaml
+++ b/v0/pipeline/stages/cd/services-yaml.yaml
@@ -13,6 +13,14 @@ properties:
     - type: string
       pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|selectOneFrom|default|regex)\(.+?\)))*$
       minLength: 1
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
   description:
     desc: This is the description for ServicesYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/template.json
+++ b/v0/template.json
@@ -70566,6 +70566,18 @@
                   "$ref" : "#/definitions/pipeline/stages/cd/ServiceOverrideInputsYaml"
                 }
               },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
               "description" : {
                 "desc" : "This is the description for EnvironmentYamlV2"
               }
@@ -71230,6 +71242,18 @@
               "metadata" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupMetadata"
               },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
               "description" : {
                 "desc" : "This is the description for EnvironmentGroupYaml"
               }
@@ -71283,6 +71307,18 @@
                 }, {
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
                   "minLength" : 1
                 } ]
               },
@@ -72730,6 +72766,18 @@
               },
               "useFromStage" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/ServiceUseFromStageV2"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
               },
               "description" : {
                 "desc" : "This is the description for ServiceYamlV2"
@@ -76284,6 +76332,18 @@
                 }, {
                   "type" : "string",
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                  "minLength" : 1
+                } ]
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
                   "minLength" : 1
                 } ]
               },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -1446,6 +1446,9 @@
               "metadata" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupMetadata"
               },
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
+              },
               "description" : {
                 "desc" : "This is the description for EnvironmentGroupYaml"
               }
@@ -1531,6 +1534,9 @@
                 "items" : {
                   "$ref" : "#/definitions/pipeline/stages/cd/ServiceOverrideInputsYaml"
                 }
+              },
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
               },
               "desc" : {
                 "description" : "This is the description for SimplifiedEnvironmentYaml"
@@ -2707,6 +2713,9 @@
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)"
                 } ]
+              },
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
               }
             },
             "anyOf" : [ "values", "inherit", "filters" ],
@@ -2796,6 +2805,9 @@
                 }, {
                   "type" : "string"
                 } ]
+              },
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
               },
               "desc" : {
                 "description" : "This is the description for ServicesYaml"

--- a/v1/pipeline/stages/cd/environment-group-yaml.yaml
+++ b/v1/pipeline/stages/cd/environment-group-yaml.yaml
@@ -32,6 +32,8 @@ properties:
       minLength: 1
   metadata:
     $ref: environment-group-metadata.yaml
+  failure:
+    $ref: ../../common/failure_list.yaml
   description:
     desc: This is the description for EnvironmentGroupYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/environment-yaml-v2.yaml
+++ b/v1/pipeline/stages/cd/environment-yaml-v2.yaml
@@ -51,6 +51,8 @@ properties:
     type: array
     items:
       $ref: service-override-inputs-yaml.yaml
+  failure:
+    $ref: ../../common/failure_list.yaml
   desc:
     description: This is the description for SimplifiedEnvironmentYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/environments-yaml.yaml
+++ b/v1/pipeline/stages/cd/environments-yaml.yaml
@@ -19,6 +19,8 @@ properties:
       - type: boolean
       - type: string
         pattern: (<\+.+>.*)
+  failure:
+    $ref: ../../common/failure_list.yaml
 anyOf:
   - values
   - inherit

--- a/v1/pipeline/stages/cd/service-yaml-v2.yaml
+++ b/v1/pipeline/stages/cd/service-yaml-v2.yaml
@@ -11,6 +11,8 @@ properties:
     pattern: ^(?=\s*\S).*$
   use-from-stage:
     $ref: service-use-from-stage-v2.yaml
+  failure:
+    $ref: ../../common/failure_list.yaml
   desc:
     description: This is the description for SimplifiedServiceYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/stages/cd/services-yaml.yaml
+++ b/v1/pipeline/stages/cd/services-yaml.yaml
@@ -15,6 +15,8 @@ properties:
     oneOf:
       - type: boolean
       - type: string
+  failure:
+    $ref: ../../common/failure_list.yaml
   desc:
     description: This is the description for ServicesYaml
 $schema: http://json-schema.org/draft-07/schema#

--- a/v1/template.json
+++ b/v1/template.json
@@ -65246,6 +65246,9 @@
               "metadata" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/EnvironmentGroupMetadata"
               },
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
+              },
               "description" : {
                 "desc" : "This is the description for EnvironmentGroupYaml"
               }
@@ -65331,6 +65334,9 @@
                 "items" : {
                   "$ref" : "#/definitions/pipeline/stages/cd/ServiceOverrideInputsYaml"
                 }
+              },
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
               },
               "desc" : {
                 "description" : "This is the description for SimplifiedEnvironmentYaml"
@@ -66507,6 +66513,9 @@
                   "type" : "string",
                   "pattern" : "(<\\+.+>.*)"
                 } ]
+              },
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
               }
             },
             "anyOf" : [ "values", "inherit", "filters" ],
@@ -66596,6 +66605,9 @@
                 }, {
                   "type" : "string"
                 } ]
+              },
+              "failure" : {
+                "$ref" : "#/definitions/pipeline/common/FailureList"
               },
               "desc" : {
                 "description" : "This is the description for ServicesYaml"


### PR DESCRIPTION
Changes made:
Failure strategy added to following stage configurations:
1. Service
2. Services (for multiple services)
3. Environment
4. Environments (for multiple services)
5. EnvironmentGroup

Testing done:
Tested locally by using the generated pipeline.json 

If I change the configuration to provide improper error or action, validation fails.
<img width="1160" alt="Screenshot 2024-09-30 at 11 50 47 AM" src="https://github.com/user-attachments/assets/1eec51d1-0860-43b6-9e20-7f4ead7ec8b9">
<img width="1097" alt="Screenshot 2024-09-30 at 11 50 58 AM" src="https://github.com/user-attachments/assets/ba7b83aa-62c9-412c-8ed1-b680d53bf5c0">

Otherwise working fine for normal scenarios:
<img width="440" alt="Screenshot 2024-09-30 at 11 47 30 AM" src="https://github.com/user-attachments/assets/bb9b3093-8627-45c1-89fc-9d68f19f08b1">
<img width="485" alt="Screenshot 2024-09-30 at 11 49 50 AM" src="https://github.com/user-attachments/assets/149c4dee-5d88-4281-b54c-54c97cee8151">

These are optional fields, so not having them causes no change to the existing yaml ensuring backward compatibility.