### PR TITLE
IAC-2689 - Add locking and change variable file format

### DIFF
--- a/v0/template.json
+++ b/v0/template.json
@@ -986,6 +986,9 @@
                     },
                     "budget" : {
                       "type" : "number"
+                    },
+                    "locked" : {
+                      "type" : "boolean"
                     }
                   }
                 },
@@ -1000,6 +1003,9 @@
                     },
                     "connector" : {
                       "type" : "string"
+                    },
+                    "locked" : {
+                      "type" : "boolean"
                     }
                   }
                 },
@@ -1023,6 +1029,9 @@
                     },
                     "path" : {
                       "type" : "string"
+                    },
+                    "locked" : {
+                      "type" : "boolean"
                     }
                   }
                 },
@@ -1030,11 +1039,38 @@
                   "type" : "array",
                   "items" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/numberVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/stringVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/stringVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/numberVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/secretVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/secretVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     } ]
                   }
                 },
@@ -1042,19 +1078,73 @@
                   "type" : "array",
                   "items" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/numberVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/stringVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/stringVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/numberVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/secretVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/secretVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     } ]
                   }
                 },
                 "terraform_variable_files" : {
                   "type" : "array",
                   "items" : {
-                    "type" : "string",
-                    "pattern" : "^.*\\.(tf|tofu)$"
+                    "type" : "object",
+                    "properties" : {
+                      "repository" : {
+                        "type" : "string"
+                      },
+                      "repository_branch" : {
+                        "type" : "string"
+                      },
+                      "repository_connector" : {
+                        "type" : "string"
+                      },
+                      "repository_path" : {
+                        "type" : "string"
+                      },
+                      "gitFetchType" : {
+                        "type" : "string",
+                        "enum" : [ "branch", "commitId", "sha" ]
+                      },
+                      "provider" : {
+                        "type" : "string",
+                        "enum" : [ "third-party", "harness" ]
+                      },
+                      "repoInputEnabled" : {
+                        "type" : "boolean"
+                      },
+                      "locked" : {
+                        "type" : "boolean"
+                      }
+                    }
                   }
                 }
               }

--- a/v0/template/workspace/template.yaml
+++ b/v0/template/workspace/template.yaml
@@ -29,6 +29,8 @@ properties:
             type: boolean
           budget:
             type: number
+          locked:
+            type: boolean
       provisioner:
         type: object
         properties:
@@ -38,6 +40,8 @@ properties:
             type: string
           connector:
             type: string
+          locked:
+            type: boolean
       repository:
         type: object
         properties:
@@ -53,22 +57,77 @@ properties:
             type: string
           path:
             type: string
+          locked:
+            type: boolean
       variables:
         type: array
         items:
           oneOf:
-            - "$ref": "../../pipeline/number_variable.yaml"
-            - "$ref": "../../pipeline/string_variable.yaml"
-            - "$ref": "../../pipeline/secret_variable.yaml"
+            - allOf:
+                - "$ref": "../../pipeline/string_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
+            - allOf:
+                - "$ref": "../../pipeline/number_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
+            - allOf:
+                - "$ref": "../../pipeline/secret_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
       terraform_variables:
         type: array
         items:
           oneOf:
-            - "$ref": "../../pipeline/number_variable.yaml"
-            - "$ref": "../../pipeline/string_variable.yaml"
-            - "$ref": "../../pipeline/secret_variable.yaml"
+            - allOf:
+                - "$ref": "../../pipeline/string_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
+            - allOf:
+                - "$ref": "../../pipeline/number_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
+            - allOf:
+                - "$ref": "../../pipeline/secret_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
       terraform_variable_files:
         type: array
         items:
-          type: string
-          pattern: "^.*\\.(tf|tofu)$"
+          type: object
+          properties:
+            repository:
+              type: string
+            repository_branch:
+              type: string
+            repository_connector:
+              type: string
+            repository_path:
+              type: string
+            gitFetchType:
+              type: string
+              enum:
+                - branch
+                - commitId
+                - sha
+            provider:
+              type: string
+              enum:
+                - third-party
+                - harness
+            repoInputEnabled:
+              type: boolean
+            locked:
+              type: boolean

--- a/v1/template.json
+++ b/v1/template.json
@@ -1187,6 +1187,9 @@
                     },
                     "budget" : {
                       "type" : "number"
+                    },
+                    "locked" : {
+                      "type" : "boolean"
                     }
                   }
                 },
@@ -1201,6 +1204,9 @@
                     },
                     "connector" : {
                       "type" : "string"
+                    },
+                    "locked" : {
+                      "type" : "boolean"
                     }
                   }
                 },
@@ -1224,6 +1230,9 @@
                     },
                     "path" : {
                       "type" : "string"
+                    },
+                    "locked" : {
+                      "type" : "boolean"
                     }
                   }
                 },
@@ -1231,11 +1240,38 @@
                   "type" : "array",
                   "items" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/numberVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/stringVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/stringVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/numberVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/secretVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/secretVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     } ]
                   }
                 },
@@ -1243,19 +1279,73 @@
                   "type" : "array",
                   "items" : {
                     "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/numberVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/stringVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/stringVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/numberVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     }, {
-                      "$ref" : "#/definitions/pipeline/secretVariable"
+                      "allOf" : [ {
+                        "$ref" : "#/definitions/pipeline/secretVariable"
+                      }, {
+                        "type" : "object",
+                        "properties" : {
+                          "locked" : {
+                            "type" : "boolean"
+                          }
+                        }
+                      } ]
                     } ]
                   }
                 },
                 "terraform_variable_files" : {
                   "type" : "array",
                   "items" : {
-                    "type" : "string",
-                    "pattern" : "^.*\\.(tf|tofu)$"
+                    "type" : "object",
+                    "properties" : {
+                      "repository" : {
+                        "type" : "string"
+                      },
+                      "repository_branch" : {
+                        "type" : "string"
+                      },
+                      "repository_connector" : {
+                        "type" : "string"
+                      },
+                      "repository_path" : {
+                        "type" : "string"
+                      },
+                      "gitFetchType" : {
+                        "type" : "string",
+                        "enum" : [ "branch", "commitId", "sha" ]
+                      },
+                      "provider" : {
+                        "type" : "string",
+                        "enum" : [ "third-party", "harness" ]
+                      },
+                      "repoInputEnabled" : {
+                        "type" : "boolean"
+                      },
+                      "locked" : {
+                        "type" : "boolean"
+                      }
+                    }
                   }
                 }
               }
@@ -71828,6 +71918,37 @@
           }
         }
       },
+      "stringVariable" : {
+        "title" : "stringVariable",
+        "type" : "object",
+        "required" : [ "value" ],
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
+          },
+          "default" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string",
+            "enum" : [ "String" ]
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "required" : {
+            "type" : "boolean"
+          },
+          "metadata" : {
+            "type" : "string"
+          }
+        },
+        "$schema" : "http://json-schema.org/draft-07/schema#"
+      },
       "numberVariable" : {
         "title" : "numberVariable",
         "type" : "object",
@@ -71853,37 +71974,6 @@
               "type" : "string",
               "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
             } ]
-          },
-          "description" : {
-            "type" : "string"
-          },
-          "required" : {
-            "type" : "boolean"
-          },
-          "metadata" : {
-            "type" : "string"
-          }
-        },
-        "$schema" : "http://json-schema.org/draft-07/schema#"
-      },
-      "stringVariable" : {
-        "title" : "stringVariable",
-        "type" : "object",
-        "required" : [ "value" ],
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.$]{0,63}$"
-          },
-          "default" : {
-            "type" : "string"
-          },
-          "type" : {
-            "type" : "string",
-            "enum" : [ "String" ]
-          },
-          "value" : {
-            "type" : "string"
           },
           "description" : {
             "type" : "string"

--- a/v1/template/workspace/template.yaml
+++ b/v1/template/workspace/template.yaml
@@ -29,6 +29,8 @@ properties:
             type: boolean
           budget:
             type: number
+          locked:
+            type: boolean
       provisioner:
         type: object
         properties:
@@ -38,6 +40,8 @@ properties:
             type: string
           connector:
             type: string
+          locked:
+            type: boolean
       repository:
         type: object
         properties:
@@ -53,22 +57,77 @@ properties:
             type: string
           path:
             type: string
+          locked:
+            type: boolean
       variables:
         type: array
         items:
           oneOf:
-            - "$ref": "../../pipeline/number_variable.yaml"
-            - "$ref": "../../pipeline/string_variable.yaml"
-            - "$ref": "../../pipeline/secret_variable.yaml"
+            - allOf:
+                - "$ref": "../../pipeline/string_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
+            - allOf:
+                - "$ref": "../../pipeline/number_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
+            - allOf:
+                - "$ref": "../../pipeline/secret_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
       terraform_variables:
         type: array
         items:
           oneOf:
-            - "$ref": "../../pipeline/number_variable.yaml"
-            - "$ref": "../../pipeline/string_variable.yaml"
-            - "$ref": "../../pipeline/secret_variable.yaml"
+            - allOf:
+                - "$ref": "../../pipeline/string_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
+            - allOf:
+                - "$ref": "../../pipeline/number_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
+            - allOf:
+                - "$ref": "../../pipeline/secret_variable.yaml"
+                - type: object
+                  properties:
+                    locked:
+                      type: boolean
       terraform_variable_files:
         type: array
         items:
-          type: string
-          pattern: "^.*\\.(tf|tofu)$"
+          type: object
+          properties:
+            repository:
+              type: string
+            repository_branch:
+              type: string
+            repository_connector:
+              type: string
+            repository_path:
+              type: string
+            gitFetchType:
+              type: string
+              enum:
+                - branch
+                - commitId
+                - sha
+            provider:
+              type: string
+              enum:
+                - third-party
+                - harness
+            repoInputEnabled:
+              type: boolean
+            locked:
+              type: boolean


### PR DESCRIPTION
**What**
Adds locked to the required parts of the template
Updates the format of Terraform Variable files

**Why**
So we can implement usecase 2 of workspace templates

**Example Yaml**
```template:
  name: demo-1
  identifier: demo1
  projectIdentifier: "default"
  orgIdentifier: "default"
  versionLabel: "1"
  type: Workspace
  spec:
    cost_estimation:
      enabled: true
      budget: 1000
      locked: true
    provisioner:
      type: terraform
      version: 1.5.7
      connector: account.awsscott
      locked: false
    repository:
      isHarnessCode: false
      connector: account.BBE_Repo_Consul
      branch: master
      gitFetchType: branch
      path: /path/to/config
      locked: true
    variables:
      - key: var1
        value: "some value"
        type: String
        locked: true
      - key: var2
        value: 100
        type: Number
        locked: false
      - key: secretVar
        value: ENC[XXXXXX]
        type: Secret
    terraform_variables:
      - key: tf_var1
        value: "terraform value"
        type: String
        locked: true
      - key: tf_var2
        value: 200
        type: Number
      - key: tf_secret
        value: ENC[YYYYYY]
        type: Secret
        locked: false
    terraform_variable_files:
      - repository: Terraform-1
        repository_branch: main
        repository_connector: account.Terraform1Nasser
        repository_path: /terraform/path
        gitFetchType: branch
        provider: third-party
        repoInputEnabled: false
        locked: true
      - repository: Terraform-2
        repository_branch: develop
        repository_connector: account.Terraform2Nasser
        repository_path: /terraform/develop/path
        gitFetchType: commit
        provider: harness
        repoInputEnabled: true
```