### PR TITLE
fix:[CI-13924]: update schema for docker secrets

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -36294,6 +36294,26 @@
                 "dockerfile" : {
                   "type" : "string"
                 },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+                "fileDockerSecrets" : {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
                 "labels" : {
                   "oneOf" : [ {
                     "type" : "object",
@@ -36593,6 +36613,26 @@
                     }
                   }, {
                     "type" : "string"
+                  } ]
+                },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+                "fileDockerSecrets" : {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
                   } ]
                 },
                 "labels" : {
@@ -36902,6 +36942,26 @@
                 },
                 "imageName" : {
                   "type" : "string"
+                },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+                "fileDockerSecrets" : {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
                 },
                 "labels" : {
                   "oneOf" : [ {
@@ -37213,6 +37273,26 @@
                 "imageName" : {
                   "type" : "string"
                 },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+                "fileDockerSecrets" : {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
                 "labels" : {
                   "oneOf" : [ {
                     "type" : "object",
@@ -37522,6 +37602,26 @@
                 },
                 "imageName" : {
                   "type" : "string"
+                },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+                "fileDockerSecrets" : {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
                 },
                 "labels" : {
                   "oneOf" : [ {

--- a/v0/pipeline/steps/ci/acrstep-info.yaml
+++ b/v0/pipeline/steps/ci/acrstep-info.yaml
@@ -25,6 +25,18 @@ allOf:
       type: string
     dockerfile:
       type: string
+    envDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
+    fileDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
     labels:
       oneOf:
       - type: object

--- a/v0/pipeline/steps/ci/docker-step-info.yaml
+++ b/v0/pipeline/steps/ci/docker-step-info.yaml
@@ -50,6 +50,18 @@ allOf:
         additionalProperties:
           type: string
       - type: string
+    envDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
+    fileDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
     labels:
       oneOf:
       - type: object

--- a/v0/pipeline/steps/ci/ecrstep-info.yaml
+++ b/v0/pipeline/steps/ci/ecrstep-info.yaml
@@ -49,6 +49,18 @@ allOf:
       type: string
     imageName:
       type: string
+    envDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
+    fileDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
     labels:
       oneOf:
       - type: object

--- a/v0/pipeline/steps/ci/garstep-info.yaml
+++ b/v0/pipeline/steps/ci/garstep-info.yaml
@@ -49,6 +49,18 @@ allOf:
       type: string
     imageName:
       type: string
+    envDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
+    fileDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
     labels:
       oneOf:
       - type: object

--- a/v0/pipeline/steps/ci/gcrstep-info.yaml
+++ b/v0/pipeline/steps/ci/gcrstep-info.yaml
@@ -49,6 +49,18 @@ allOf:
       type: string
     imageName:
       type: string
+    envDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
+    fileDockerSecrets:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: string
+        - type: string
     labels:
       oneOf:
       - type: object

--- a/v0/template.json
+++ b/v0/template.json
@@ -63937,6 +63937,26 @@
                 "dockerfile" : {
                   "type" : "string"
                 },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+               "fileDockerSecrets" : {
+                "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
                 "labels" : {
                   "oneOf" : [ {
                     "type" : "object",
@@ -64224,6 +64244,26 @@
                     }
                   }, {
                     "type" : "string"
+                  } ]
+                },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+               "fileDockerSecrets" : {
+                "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
                   } ]
                 },
                 "labels" : {
@@ -64521,6 +64561,26 @@
                 },
                 "imageName" : {
                   "type" : "string"
+                },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+               "fileDockerSecrets" : {
+                "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
                 },
                 "labels" : {
                   "oneOf" : [ {
@@ -64820,6 +64880,26 @@
                 "imageName" : {
                   "type" : "string"
                 },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+               "fileDockerSecrets" : {
+                "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
                 "labels" : {
                   "oneOf" : [ {
                     "type" : "object",
@@ -65117,6 +65197,26 @@
                 },
                 "imageName" : {
                   "type" : "string"
+                },
+                "envDockerSecrets": {
+                  "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
+                },
+               "fileDockerSecrets" : {
+                "oneOf": [{
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },{
+                    "type": "string"
+                  } ]
                 },
                 "labels" : {
                   "oneOf" : [ {


### PR DESCRIPTION
What: Added support to use env variables and haress secrets as docker secrets for all the build and push steps. Why: To prevent leaking secrets in any layer of dockers final image.

https://app.harness.io/ng/account/vpCkHKsDSxK9_KYfjCTMKA/module/code/orgs/HarnessHCRInternalUAT/projects/Harness_Code/repos/harness-core/pulls/6601