### PR TITLE
feat: [CDS-103688]: schema update for allowEmptyCommit in gitops upda…

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -61007,6 +61007,24 @@
               "prTitle" : {
                 "type" : "string"
               },
+              "allowEmptyCommit" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "disableGitRestraint" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
               "stringMap" : {
                 "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
               },

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -40547,6 +40547,15 @@
                   "type" : "string"
                 } ]
               },
+              "disableGitRestraint" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
               "variables" : {
                 "type" : "array",
                 "items" : {
@@ -46884,6 +46893,15 @@
                 },
                 "prTitle" : {
                   "type" : "string"
+                },
+                "disableGitRestraint" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -60954,6 +60954,15 @@
                 "prTitle" : {
                   "type" : "string"
                 },
+                "allowEmptyCommit" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
                 "disableGitRestraint" : {
                   "oneOf" : [ {
                     "type" : "boolean"

--- a/v0/pipeline/steps/cd/merge-pr-step-info.yaml
+++ b/v0/pipeline/steps/cd/merge-pr-step-info.yaml
@@ -47,6 +47,12 @@ properties:
     oneOf:
     - type: boolean
     - type: string
+  disableGitRestraint:
+    oneOf:
+      - type: boolean
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
   variables:
     type: array
     items:

--- a/v0/pipeline/steps/cd/revert-pr-step-info.yaml
+++ b/v0/pipeline/steps/cd/revert-pr-step-info.yaml
@@ -17,6 +17,12 @@ allOf:
         type: string
       prTitle:
         type: string
+      disableGitRestraint:
+        oneOf:
+          - type: boolean
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:

--- a/v0/pipeline/steps/cd/update-release-repo-step-info.yaml
+++ b/v0/pipeline/steps/cd/update-release-repo-step-info.yaml
@@ -47,6 +47,18 @@ properties:
       minLength: 1
   prTitle:
     type: string
+  allowEmptyCommit: 
+    oneOf:
+      - type: boolean
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  disableGitRestraint:
+    oneOf:
+      - type: boolean
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
   stringMap:
     $ref: ../common/parameter-field-map-string-string.yaml
   variables:

--- a/v0/pipeline/steps/cd/update-release-repo-step-info.yaml
+++ b/v0/pipeline/steps/cd/update-release-repo-step-info.yaml
@@ -13,6 +13,12 @@ allOf:
         minLength: 1
     prTitle:
       type: string
+    allowEmptyCommit: 
+      oneOf:
+        - type: boolean
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
     disableGitRestraint:
       oneOf:
         - type: boolean

--- a/v0/template.json
+++ b/v0/template.json
@@ -21926,6 +21926,15 @@
                 "prTitle" : {
                   "type" : "string"
                 },
+                "allowEmptyCommit" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
                 "disableGitRestraint" : {
                   "oneOf" : [ {
                     "type" : "boolean"

--- a/v0/template.json
+++ b/v0/template.json
@@ -15437,6 +15437,15 @@
                   "type" : "string"
                 } ]
               },
+              "disableGitRestraint" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
               "variables" : {
                 "type" : "array",
                 "items" : {
@@ -15544,6 +15553,15 @@
                 },
                 "prTitle" : {
                   "type" : "string"
+                },
+                "disableGitRestraint" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],

--- a/v0/template.json
+++ b/v0/template.json
@@ -21979,6 +21979,24 @@
               "prTitle" : {
                 "type" : "string"
               },
+              "allowEmptyCommit" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "disableGitRestraint" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
               "stringMap" : {
                 "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
               },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -29698,6 +29698,15 @@
                     "type" : "string"
                   } ]
                 },
+                "disableGitRestraint" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
                 "variables" : {
                   "type" : "array",
                   "items" : {
@@ -36066,6 +36075,15 @@
                 },
                 "prTitle" : {
                   "type" : "string"
+                },
+                "disableGitRestraint" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -49526,6 +49526,24 @@
                 "prTitle" : {
                   "type" : "string"
                 },
+                "allowEmptyCommit" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "disableGitRestraint" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
                 "stringMap" : {
                   "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
                 },
@@ -49560,6 +49578,15 @@
               },
               "prTitle" : {
                 "type" : "string"
+              },
+              "allowEmptyCommit" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "disableGitRestraint" : {
                 "oneOf" : [ {

--- a/v1/pipeline/steps/cd/merge-pr-step-info.yaml
+++ b/v1/pipeline/steps/cd/merge-pr-step-info.yaml
@@ -17,6 +17,12 @@ allOf:
       oneOf:
       - type: boolean
       - type: string
+    disableGitRestraint:
+      oneOf:
+        - type: boolean
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
     variables:
       type: array
       items:

--- a/v1/pipeline/steps/cd/revert-pr-step-info.yaml
+++ b/v1/pipeline/steps/cd/revert-pr-step-info.yaml
@@ -17,6 +17,12 @@ allOf:
         type: string
       prTitle:
         type: string
+      disableGitRestraint:
+        oneOf:
+          - type: boolean
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:

--- a/v1/pipeline/steps/cd/update-release-repo-step-info.yaml
+++ b/v1/pipeline/steps/cd/update-release-repo-step-info.yaml
@@ -13,6 +13,18 @@ allOf:
         minLength: 1
     prTitle:
       type: string
+    allowEmptyCommit: 
+      oneOf:
+        - type: boolean
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
+    disableGitRestraint:
+      oneOf:
+        - type: boolean
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
     stringMap:
       $ref: ../common/parameter-field-map-string-string.yaml
     variables:
@@ -35,6 +47,12 @@ properties:
       minLength: 1
   prTitle:
     type: string
+  allowEmptyCommit: 
+    oneOf:
+      - type: boolean
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
   disableGitRestraint:
     oneOf:
       - type: boolean

--- a/v1/template.json
+++ b/v1/template.json
@@ -17163,6 +17163,15 @@
                     "type" : "string"
                   } ]
                 },
+                "disableGitRestraint" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
                 "variables" : {
                   "type" : "array",
                   "items" : {
@@ -17316,6 +17325,15 @@
                 },
                 "prTitle" : {
                   "type" : "string"
+                },
+                "disableGitRestraint" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],

--- a/v1/template.json
+++ b/v1/template.json
@@ -23878,6 +23878,24 @@
                 "prTitle" : {
                   "type" : "string"
                 },
+                "allowEmptyCommit" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "disableGitRestraint" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
                 "stringMap" : {
                   "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
                 },
@@ -23912,6 +23930,15 @@
               },
               "prTitle" : {
                 "type" : "string"
+              },
+              "allowEmptyCommit" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
               },
               "disableGitRestraint" : {
                 "oneOf" : [ {


### PR DESCRIPTION
…tereleaserepostep

**Changes and points**
* New boolean option **allowEmptyCommit** for Gitops Update release repo CD step.
* Field is not mandatory
* Field controls behaviour of step whether an empty commit will fail the step or continue with creating a PR with empty commit.

**Other changes**
* The schema change for disableGitRestraint was missed in a few places. This is added.

Testing Done with schema validator:
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/9a24c27a-e8d7-41ef-81fc-9ae948309b69">
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/7df98bb2-5d04-4961-bd49-6c6a3c189f20">
<img width="1719" alt="image" src="https://github.com/user-attachments/assets/ac52a48e-7847-44ae-bd61-de5ef38aec35">
