### PR TITLE
[fix]: [DBOPS-807]: Validation for rollback actions in DB-DevOps steps failure strategy

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -11370,6 +11370,63 @@
           },
           "$schema" : "http://json-schema.org/draft-07/schema#"
         },
+        "DBDevOpsFailureStrategyConfig" : {
+          "title" : "DBDevOpsFailureStrategyConfig",
+          "type" : "object",
+          "required" : [ "onFailure" ],
+          "properties" : {
+            "onFailure" : {
+              "$ref" : "#/definitions/pipeline/common/DBDevOpsOnFailureConfig"
+            },
+            "description" : {
+              "desc" : "This is the description for FailureStrategyConfig"
+            }
+          },
+          "metadata" : {
+            "inputProperties" : {
+              "type" : "string",
+              "internalType" : "failure_strategy"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "DBDevOpsOnFailureConfig" : {
+          "title" : "DBDevOpsOnFailureConfig",
+          "type" : "object",
+          "required" : [ "action", "errors" ],
+          "properties" : {
+            "action" : {
+              "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyActionConfig"
+            },
+            "errors" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string",
+                "enum" : [ "Unknown", "AllErrors", "Authentication", "Connectivity", "Timeout", "Authorization", "Verification", "DelegateProvisioning", "PolicyEvaluationFailure", "InputTimeoutError", "ApprovalRejection", "DelegateRestart", "UserMarkedFailure" ]
+              }
+            },
+            "description" : {
+              "desc" : "This is the description for OnFailureConfig"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "DBDevOpsFailureStrategyActionConfig" : {
+          "title" : "DBDevOpsFailureStrategyActionConfig",
+          "type" : "object",
+          "required" : [ "type" ],
+          "discriminator" : "type",
+          "properties" : {
+            "type" : {
+              "type" : "string",
+              "enum" : [ "StageRollback", "PipelineRollback" ]
+            },
+            "description" : {
+              "desc" : "This is the description for FailureStrategyActionConfig"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
         "K8sDirectInfra" : {
           "title" : "K8sDirectInfra",
           "allOf" : [ {
@@ -30598,7 +30655,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -30885,7 +30885,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",
@@ -31115,7 +31115,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",

--- a/v0/pipeline/common/db-devops-failure-strategy-action-config.yaml
+++ b/v0/pipeline/common/db-devops-failure-strategy-action-config.yaml
@@ -1,0 +1,14 @@
+title: DBDevOpsFailureStrategyActionConfig
+type: object
+required:
+  - type
+discriminator: type
+properties:
+  type:
+    type: string
+    enum:
+      - StageRollback
+      - PipelineRollback
+  description:
+    desc: This is the description for FailureStrategyActionConfig
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/common/db-devops-failure-strategy-config.yaml
+++ b/v0/pipeline/common/db-devops-failure-strategy-config.yaml
@@ -1,0 +1,14 @@
+title: DBDevOpsFailureStrategyConfig
+type: object
+required:
+  - onFailure
+properties:
+  onFailure:
+    $ref: db-devops-on-failure-config.yaml
+  description:
+    desc: This is the description for FailureStrategyConfig
+metadata:
+  inputProperties:
+    type: string
+    internalType: failure_strategy
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/common/db-devops-on-failure-config.yaml
+++ b/v0/pipeline/common/db-devops-on-failure-config.yaml
@@ -1,0 +1,29 @@
+title: DBDevOpsOnFailureConfig
+type: object
+required:
+  - action
+  - errors
+properties:
+  action:
+    $ref: db-devops-failure-strategy-action-config.yaml
+  errors:
+    type: array
+    items:
+      type: string
+      enum:
+        - Unknown
+        - AllErrors
+        - Authentication
+        - Connectivity
+        - Timeout
+        - Authorization
+        - Verification
+        - DelegateProvisioning
+        - PolicyEvaluationFailure
+        - InputTimeoutError
+        - ApprovalRejection
+        - DelegateRestart
+        - UserMarkedFailure
+  description:
+    desc: This is the description for OnFailureConfig
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/steps/common/dbops-apply-schema-step-node.yaml
+++ b/v0/pipeline/steps/common/dbops-apply-schema-step-node.yaml
@@ -14,7 +14,7 @@ properties:
     oneOf:
     - type: array
       items:
-        $ref: ../../common/failure-strategy-config.yaml
+        $ref: ../../common/db-devops-failure-strategy-config.yaml
     - type: string
       pattern: ^<\+input>$
       minLength: 1

--- a/v0/pipeline/steps/common/dbops-liquibase-command-step-node.yaml
+++ b/v0/pipeline/steps/common/dbops-liquibase-command-step-node.yaml
@@ -14,7 +14,7 @@ properties:
     oneOf:
     - type: array
       items:
-        $ref: ../../common/failure-strategy-config.yaml
+        $ref: ../../common/db-devops-failure-strategy-config.yaml
     - type: string
       pattern: ^<\+input>$
       minLength: 1

--- a/v0/pipeline/steps/common/dbops-rollback-schema-step-node.yaml
+++ b/v0/pipeline/steps/common/dbops-rollback-schema-step-node.yaml
@@ -14,7 +14,7 @@ properties:
     oneOf:
       - type: array
         items:
-          $ref: ../../common/failure-strategy-config.yaml
+          $ref: ../../common/db-devops-failure-strategy-config.yaml
       - type: string
         pattern: ^<\+input>$
         minLength: 1

--- a/v0/template.json
+++ b/v0/template.json
@@ -55678,7 +55678,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",
@@ -56802,7 +56802,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",
@@ -57752,7 +57752,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",
@@ -57983,7 +57983,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",

--- a/v0/template.json
+++ b/v0/template.json
@@ -55460,7 +55460,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",
@@ -57675,7 +57675,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",
@@ -73979,6 +73979,63 @@
             "inputProperties" : {
               "type" : "string",
               "internalType" : "duration"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "DBDevOpsFailureStrategyConfig" : {
+          "title" : "DBDevOpsFailureStrategyConfig",
+          "type" : "object",
+          "required" : [ "onFailure" ],
+          "properties" : {
+            "onFailure" : {
+              "$ref" : "#/definitions/pipeline/common/DBDevOpsOnFailureConfig"
+            },
+            "description" : {
+              "desc" : "This is the description for FailureStrategyConfig"
+            }
+          },
+          "metadata" : {
+            "inputProperties" : {
+              "type" : "string",
+              "internalType" : "failure_strategy"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "DBDevOpsOnFailureConfig" : {
+          "title" : "DBDevOpsOnFailureConfig",
+          "type" : "object",
+          "required" : [ "action", "errors" ],
+          "properties" : {
+            "action" : {
+              "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyActionConfig"
+            },
+            "errors" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string",
+                "enum" : [ "Unknown", "AllErrors", "Authentication", "Connectivity", "Timeout", "Authorization", "Verification", "DelegateProvisioning", "PolicyEvaluationFailure", "InputTimeoutError", "ApprovalRejection", "DelegateRestart", "UserMarkedFailure" ]
+              }
+            },
+            "description" : {
+              "desc" : "This is the description for OnFailureConfig"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "DBDevOpsFailureStrategyActionConfig" : {
+          "title" : "DBDevOpsFailureStrategyActionConfig",
+          "type" : "object",
+          "required" : [ "type" ],
+          "discriminator" : "type",
+          "properties" : {
+            "type" : {
+              "type" : "string",
+              "enum" : [ "StageRollback", "PipelineRollback" ]
+            },
+            "description" : {
+              "desc" : "This is the description for FailureStrategyActionConfig"
             }
           },
           "$schema" : "http://json-schema.org/draft-07/schema#"

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -23618,7 +23618,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -6927,6 +6927,63 @@
           },
           "$schema" : "http://json-schema.org/draft-07/schema#"
         },
+        "DBDevOpsFailureStrategyConfig" : {
+          "title" : "DBDevOpsFailureStrategyConfig",
+          "type" : "object",
+          "required" : [ "onFailure" ],
+          "properties" : {
+            "onFailure" : {
+              "$ref" : "#/definitions/pipeline/common/DBDevOpsOnFailureConfig"
+            },
+            "description" : {
+              "desc" : "This is the description for FailureStrategyConfig"
+            }
+          },
+          "metadata" : {
+            "inputProperties" : {
+              "type" : "string",
+              "internalType" : "failure_strategy"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "DBDevOpsOnFailureConfig" : {
+          "title" : "DBDevOpsOnFailureConfig",
+          "type" : "object",
+          "required" : [ "action", "errors" ],
+          "properties" : {
+            "action" : {
+              "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyActionConfig"
+            },
+            "errors" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string",
+                "enum" : [ "Unknown", "AllErrors", "Authentication", "Connectivity", "Timeout", "Authorization", "Verification", "DelegateProvisioning", "PolicyEvaluationFailure", "InputTimeoutError", "ApprovalRejection", "DelegateRestart", "UserMarkedFailure" ]
+              }
+            },
+            "description" : {
+              "desc" : "This is the description for OnFailureConfig"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "DBDevOpsFailureStrategyActionConfig" : {
+          "title" : "DBDevOpsFailureStrategyActionConfig",
+          "type" : "object",
+          "required" : [ "type" ],
+          "discriminator" : "type",
+          "properties" : {
+            "type" : {
+              "type" : "string",
+              "enum" : [ "StageRollback", "PipelineRollback" ]
+            },
+            "description" : {
+              "desc" : "This is the description for FailureStrategyActionConfig"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
         "Inputs" : {
           "title" : "Inputs",
           "type" : "object",
@@ -23331,7 +23388,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",

--- a/v1/pipeline/common/db-devops-failure-strategy-action-config.yaml
+++ b/v1/pipeline/common/db-devops-failure-strategy-action-config.yaml
@@ -1,0 +1,14 @@
+title: DBDevOpsFailureStrategyActionConfig
+type: object
+required:
+  - type
+discriminator: type
+properties:
+  type:
+    type: string
+    enum:
+      - StageRollback
+      - PipelineRollback
+  description:
+    desc: This is the description for FailureStrategyActionConfig
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/common/db-devops-failure-strategy-config.yaml
+++ b/v1/pipeline/common/db-devops-failure-strategy-config.yaml
@@ -1,0 +1,14 @@
+title: DBDevOpsFailureStrategyConfig
+type: object
+required:
+  - onFailure
+properties:
+  onFailure:
+    $ref: db-devops-on-failure-config.yaml
+  description:
+    desc: This is the description for FailureStrategyConfig
+metadata:
+  inputProperties:
+    type: string
+    internalType: failure_strategy
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/common/db-devops-on-failure-config.yaml
+++ b/v1/pipeline/common/db-devops-on-failure-config.yaml
@@ -1,0 +1,29 @@
+title: DBDevOpsOnFailureConfig
+type: object
+required:
+  - action
+  - errors
+properties:
+  action:
+    $ref: db-devops-failure-strategy-action-config.yaml
+  errors:
+    type: array
+    items:
+      type: string
+      enum:
+        - Unknown
+        - AllErrors
+        - Authentication
+        - Connectivity
+        - Timeout
+        - Authorization
+        - Verification
+        - DelegateProvisioning
+        - PolicyEvaluationFailure
+        - InputTimeoutError
+        - ApprovalRejection
+        - DelegateRestart
+        - UserMarkedFailure
+  description:
+    desc: This is the description for OnFailureConfig
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/steps/common/dbops-apply-schema-step-node.yaml
+++ b/v1/pipeline/steps/common/dbops-apply-schema-step-node.yaml
@@ -15,7 +15,7 @@ properties:
     oneOf:
     - type: array
       items:
-        $ref: ../../common/failure-strategy-config.yaml
+        $ref: ../../common/db-devops-failure-strategy-config.yaml
     - type: string
       pattern: ^<\+input>$
       minLength: 1

--- a/v1/pipeline/steps/common/dbops-rollback-schema-step-node.yaml
+++ b/v1/pipeline/steps/common/dbops-rollback-schema-step-node.yaml
@@ -15,7 +15,7 @@ properties:
     oneOf:
       - type: array
         items:
-          $ref: ../../common/failure-strategy-config.yaml
+          $ref: ../../common/db-devops-failure-strategy-config.yaml
       - type: string
         pattern: ^<\+input>$
         minLength: 1

--- a/v1/template.json
+++ b/v1/template.json
@@ -58306,7 +58306,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",

--- a/v1/template.json
+++ b/v1/template.json
@@ -3256,6 +3256,63 @@
           "$schema" : "http://json-schema.org/draft-07/schema#",
           "allOf" : [ ]
         },
+        "DBDevOpsFailureStrategyConfig" : {
+          "title" : "DBDevOpsFailureStrategyConfig",
+          "type" : "object",
+          "required" : [ "onFailure" ],
+          "properties" : {
+            "onFailure" : {
+              "$ref" : "#/definitions/pipeline/common/DBDevOpsOnFailureConfig"
+            },
+            "description" : {
+              "desc" : "This is the description for FailureStrategyConfig"
+            }
+          },
+          "metadata" : {
+            "inputProperties" : {
+              "type" : "string",
+              "internalType" : "failure_strategy"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "DBDevOpsOnFailureConfig" : {
+          "title" : "DBDevOpsOnFailureConfig",
+          "type" : "object",
+          "required" : [ "action", "errors" ],
+          "properties" : {
+            "action" : {
+              "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyActionConfig"
+            },
+            "errors" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string",
+                "enum" : [ "Unknown", "AllErrors", "Authentication", "Connectivity", "Timeout", "Authorization", "Verification", "DelegateProvisioning", "PolicyEvaluationFailure", "InputTimeoutError", "ApprovalRejection", "DelegateRestart", "UserMarkedFailure" ]
+              }
+            },
+            "description" : {
+              "desc" : "This is the description for OnFailureConfig"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
+        "DBDevOpsFailureStrategyActionConfig" : {
+          "title" : "DBDevOpsFailureStrategyActionConfig",
+          "type" : "object",
+          "required" : [ "type" ],
+          "discriminator" : "type",
+          "properties" : {
+            "type" : {
+              "type" : "string",
+              "enum" : [ "StageRollback", "PipelineRollback" ]
+            },
+            "description" : {
+              "desc" : "This is the description for FailureStrategyActionConfig"
+            }
+          },
+          "$schema" : "http://json-schema.org/draft-07/schema#"
+        },
         "Inputs" : {
           "title" : "Inputs",
           "type" : "object",
@@ -58019,7 +58076,7 @@
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                    "$ref" : "#/definitions/pipeline/common/DBDevOpsFailureStrategyConfig"
                   }
                 }, {
                   "type" : "string",


### PR DESCRIPTION
Adding schema validations to only allow Pipeline and Stage Rollback actions in DB-DevOps steps failure strategy.