### PR TITLE
feat:[SSCA-3129]: Modified required fields in Gar and GCR Source spec

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -35380,7 +35380,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "project", "image" ],
+              "required" : [ "connector", "host", "project_id", "image" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -35464,7 +35464,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "project", "image" ],
+              "required" : [ "connector", "host", "project_id", "image" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"

--- a/v0/pipeline/steps/common/gar-source-spec.yaml
+++ b/v0/pipeline/steps/common/gar-source-spec.yaml
@@ -5,7 +5,7 @@ allOf:
   required:
   - connector
   - host
-  - project
+  - project_id
   - image
   properties:
     connector:

--- a/v0/pipeline/steps/common/gcr-source-spec.yaml
+++ b/v0/pipeline/steps/common/gcr-source-spec.yaml
@@ -5,7 +5,7 @@ allOf:
   required:
   - connector
   - host
-  - project
+  - project_id
   - image
   properties:
     connector:

--- a/v0/template.json
+++ b/v0/template.json
@@ -63474,7 +63474,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "project", "image" ],
+              "required" : [ "connector", "host", "project_id", "image" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -63558,7 +63558,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "project", "image" ],
+              "required" : [ "connector", "host", "project_id", "image" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"


### PR DESCRIPTION
This pull request includes changes to update the required properties for various pipeline specifications by replacing `project` with `project_id`. The changes affect multiple JSON and YAML files.

Updates to required properties:

* [`v0/pipeline.json`](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L35383-R35383): Changed "required" property from `project` to `project_id` in two instances. [[1]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L35383-R35383) [[2]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L35467-R35467)
* [`v0/pipeline/steps/common/gar-source-spec.yaml`](diffhunk://#diff-253b340e597784bddc02ce88323ad1eb334d2ae7914aaf3672f6fc4e3d59bdf5L8-R8): Changed "required" property from `project` to `project_id`.
* [`v0/pipeline/steps/common/gcr-source-spec.yaml`](diffhunk://#diff-fb56ba66c47b88add476b5b8413517cbac8f13f15103ab9865bca556edd3929cL8-R8): Changed "required" property from `project` to `project_id`.
* [`v0/template.json`](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL63477-R63477): Changed "required" property from `project` to `project_id` in two instances. [[1]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL63477-R63477) [[2]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL63561-R63561)