### PR TITLE
Fix notification template reference for the schema parser

### DIFF
--- a/v0/template.json
+++ b/v0/template.json
@@ -22,7 +22,7 @@
       }, {
         "$ref" : "#/definitions/template/workspace/template"
       }, {
-        "$ref" : "#/definitions/template/notification/notification"
+        "$ref" : "#/definitions/template/notification/template"
       } ]
     }
   },
@@ -1216,9 +1216,9 @@
         }
       },
       "notification" : {
-        "notification" : {
+        "template" : {
           "type" : "object",
-          "title" : "notification",
+          "title" : "template",
           "required" : [ "identifier", "name", "type", "versionLabel", "spec" ],
           "properties" : {
             "identifier" : {
@@ -73124,6 +73124,22 @@
               }
             }
           },
+          "ImportCommandParameterField" : {
+            "title" : "ImportCommandParameterField",
+            "type" : "object",
+            "required" : [ "id", "address" ],
+            "properties" : {
+              "id" : {
+                "type" : "string",
+                "desc" : "This is the id for ImportCommandParameterField"
+              },
+              "address" : {
+                "type" : "string",
+                "desc" : "This is the address for ImportCommandParameterField"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
           "IACMOpenTofuPluginStepNode_template" : {
             "title" : "IACMOpenTofuPluginStepNode_template",
             "type" : "object",
@@ -74367,26 +74383,6 @@
                 }
               }
             } ]
-          },
-          "ImportCommandParameterField" : {
-            "title" : "ImportCommandParameterField",
-            "type" : "object",
-            "required" : [
-              "id",
-              "address"
-            ],
-            "properties" : {
-              "id" : {
-                "type" : "string"
-              },
-              "address" : {
-                "type" : "string"
-              },
-              "description" : {
-                "desc" : "This is the description for ImportCommandParameterField"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
           }
         }
       },

--- a/v0/template/notification/template.yaml
+++ b/v0/template/notification/template.yaml
@@ -1,5 +1,5 @@
 type: object
-title: notification
+title: template
 required:
   - identifier
   - name


### PR DESCRIPTION
The schema parser expects the schema in a specific format. While theh crud operations were working as expected, the templateSchema API which the UI uses in the local env, was returning no data for notification templates.
The title of the notification template was changed so that the ref generated can be parsed by the parser.