### PR TITLE
fix:[CDS-105573]: Add skipValidationBlueGreenService field to the ECS BG Create

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -49181,6 +49181,15 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "skipValidationBlueGreenService" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -49234,6 +49243,15 @@
                 "type" : "string"
               },
               "updateGreenService" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "skipValidationBlueGreenService" : {
                 "oneOf" : [ {
                   "type" : "boolean"
                 }, {

--- a/v0/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
+++ b/v0/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
@@ -45,6 +45,12 @@ allOf:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
+    skipValidationBlueGreenService:
+      oneOf:
+      - type: boolean
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1        
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -90,5 +96,11 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
+  skipValidationBlueGreenService:
+    oneOf:
+    - type: boolean
+    - type: string
+      pattern: (<\+.+>.*)
+      minLength: 1      
   description:
     desc: This is the description for EcsBlueGreenCreateServiceStepInfo

--- a/v0/template.json
+++ b/v0/template.json
@@ -7944,6 +7944,15 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "skipValidationBlueGreenService" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -7997,6 +8006,15 @@
                 "type" : "string"
               },
               "updateGreenService" : {
+                "oneOf" : [ {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "skipValidationBlueGreenService" : {
                 "oneOf" : [ {
                   "type" : "boolean"
                 }, {
@@ -73111,22 +73129,6 @@
                 }
               }
             }
-          },
-          "ImportCommandParameterField" : {
-            "title" : "ImportCommandParameterField",
-            "type" : "object",
-            "required" : [ "id", "address" ],
-            "properties" : {
-              "id" : {
-                "type" : "string",
-                "desc" : "This is the id for ImportCommandParameterField"
-              },
-              "address" : {
-                "type" : "string",
-                "desc" : "This is the address for ImportCommandParameterField"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "IACMOpenTofuPluginStepNode_template" : {
             "title" : "IACMOpenTofuPluginStepNode_template",


### PR DESCRIPTION
As part of this change, we are introducing a new field skipValidationBlueGreenService to the step, and if this field is set to true, then we are going to skip the bg service validation.