### PR TITLE
feat: [CDS-105732]: Allow array references (square brackets) in Updat…

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -41489,54 +41489,6 @@
           },
           "MergePRStepInfo" : {
             "title" : "MergePRStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "deleteSourceBranch" ],
-              "properties" : {
-                "delegateSelectors" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "deleteSourceBranch" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string"
-                  } ]
-                },
-                "disableGitRestraint" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "variables" : {
-                  "type" : "array",
-                  "items" : {
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
-                    } ]
-                  }
-                }
-              }
-            } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
             "required" : [ "deleteSourceBranch" ],
@@ -41584,7 +41536,8 @@
               "description" : {
                 "desc" : "This is the description for MergePRStepInfo"
               }
-            }
+            },
+            "$ref" : "#/definitions/pipeline/common/StepSpecType"
           },
           "HelmDeployStepNode" : {
             "title" : "HelmDeployStepNode",
@@ -61900,63 +61853,8 @@
           },
           "UpdateReleaseRepoStepInfo" : {
             "title" : "UpdateReleaseRepoStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "properties" : {
-                "delegateSelectors" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "prTitle" : {
-                  "type" : "string"
-                },
-                "allowEmptyCommit" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "disableGitRestraint" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "stringMap" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
-                },
-                "variables" : {
-                  "type" : "array",
-                  "items" : {
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
-                    } ]
-                  }
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
             "properties" : {
               "delegateSelectors" : {
                 "oneOf" : [ {
@@ -61998,16 +61896,117 @@
                 "type" : "array",
                 "items" : {
                   "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoStringNGVariable"
                   }, {
-                    "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoNumberNGVariable"
                   }, {
-                    "$ref" : "#/definitions/pipeline/common/StringNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoSecretNGVariable"
                   } ]
                 }
-              },
+              }
+            },
+            "$ref" : "#/definitions/pipeline/common/StepSpecType"
+          },
+          "UpdateReleaseRepoStringNGVariable" : {
+            "title" : "UpdateReleaseRepoStringNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "String" ]
+                },
+                "value" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
               "description" : {
-                "desc" : "This is the description for UpdateReleaseRepoStepInfo"
+                "desc" : "This is the description for UpdateReleaseRepoStringNGVariable"
+              }
+            }
+          },
+          "UpdateReleaseRepoNumberNGVariable" : {
+            "title" : "UpdateReleaseRepoNumberNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "number",
+                  "format" : "double"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "Number" ]
+                },
+                "value" : {
+                  "oneOf" : [ {
+                    "type" : "number",
+                    "format" : "double"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+                  }, {
+                    "type" : "string",
+                    "maxLength" : 0
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoNumberNGVariable"
+              }
+            }
+          },
+          "UpdateReleaseRepoSecretNGVariable" : {
+            "title" : "UpdateReleaseRepoSecretNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "Secret" ]
+                },
+                "value" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoSecretNGVariable"
               }
             }
           },

--- a/v0/pipeline/steps/cd/merge-pr-step-info.yaml
+++ b/v0/pipeline/steps/cd/merge-pr-step-info.yaml
@@ -1,35 +1,5 @@
 title: MergePRStepInfo
-allOf:
-- $ref: ../../common/step-spec-type.yaml
-- type: object
-  required:
-  - deleteSourceBranch
-  properties:
-    delegateSelectors:
-      oneOf:
-      - type: array
-        items:
-          type: string
-      - type: string
-        pattern: (<\+.+>.*)
-        minLength: 1
-    deleteSourceBranch:
-      oneOf:
-      - type: boolean
-      - type: string
-    disableGitRestraint:
-      oneOf:
-        - type: boolean
-        - type: string
-          pattern: (<\+.+>.*)
-          minLength: 1
-    variables:
-      type: array
-      items:
-        oneOf:
-        - $ref: ../../common/number-ng-variable.yaml
-        - $ref: ../../common/secret-ng-variable.yaml
-        - $ref: ../../common/string-ng-variable.yaml
+$ref: ../../common/step-spec-type.yaml
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:

--- a/v0/pipeline/steps/cd/update-release-repo-number-ng-variable.yaml
+++ b/v0/pipeline/steps/cd/update-release-repo-number-ng-variable.yaml
@@ -1,0 +1,29 @@
+title: UpdateReleaseRepoNumberNGVariable
+allOf:
+  - $ref: ../../common/ng-variable.yaml
+  - type: object
+    required:
+      - value
+    properties:
+      default:
+        type: number
+        format: double
+      name:
+        type: string
+        pattern: ^[a-zA-Z_][0-9a-zA-Z_\.\[\]$-]{0,127}$
+      type:
+        type: string
+        enum:
+          - Number
+      value:
+        oneOf:
+          - type: number
+            format: double
+          - type: string
+            pattern: ((^[+-]?[0-9]*\.?[0-9]+$)|(<\+.+>.*))
+          - type: string
+            maxLength: 0
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for UpdateReleaseRepoNumberNGVariable

--- a/v0/pipeline/steps/cd/update-release-repo-secret-ng-variable.yaml
+++ b/v0/pipeline/steps/cd/update-release-repo-secret-ng-variable.yaml
@@ -1,0 +1,22 @@
+title: UpdateReleaseRepoSecretNGVariable
+allOf:
+  - $ref: ../../common/ng-variable.yaml
+  - type: object
+    required:
+      - value
+    properties:
+      default:
+        type: string
+      name:
+        type: string
+        pattern: ^[a-zA-Z_][0-9a-zA-Z_\.\[\]$-]{0,127}$
+      type:
+        type: string
+        enum:
+          - Secret
+      value:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for UpdateReleaseRepoSecretNGVariable

--- a/v0/pipeline/steps/cd/update-release-repo-step-info.yaml
+++ b/v0/pipeline/steps/cd/update-release-repo-step-info.yaml
@@ -1,41 +1,7 @@
 title: UpdateReleaseRepoStepInfo
-allOf:
-- $ref: ../../common/step-spec-type.yaml
-- type: object
-  properties:
-    delegateSelectors:
-      oneOf:
-      - type: array
-        items:
-          type: string
-      - type: string
-        pattern: (<\+.+>.*)
-        minLength: 1
-    prTitle:
-      type: string
-    allowEmptyCommit: 
-      oneOf:
-        - type: boolean
-        - type: string
-          pattern: (<\+.+>.*)
-          minLength: 1
-    disableGitRestraint:
-      oneOf:
-        - type: boolean
-        - type: string
-          pattern: (<\+.+>.*)
-          minLength: 1
-    stringMap:
-      $ref: ../common/parameter-field-map-string-string.yaml
-    variables:
-      type: array
-      items:
-        oneOf:
-        - $ref: ../../common/number-ng-variable.yaml
-        - $ref: ../../common/secret-ng-variable.yaml
-        - $ref: ../../common/string-ng-variable.yaml
-$schema: http://json-schema.org/draft-07/schema#
+$ref: ../../common/step-spec-type.yaml
 type: object
+$schema: http://json-schema.org/draft-07/schema#
 properties:
   delegateSelectors:
     oneOf:
@@ -65,8 +31,6 @@ properties:
     type: array
     items:
       oneOf:
-      - $ref: ../../common/number-ng-variable.yaml
-      - $ref: ../../common/secret-ng-variable.yaml
-      - $ref: ../../common/string-ng-variable.yaml
-  description:
-    desc: This is the description for UpdateReleaseRepoStepInfo
+        - $ref: ./update-release-repo-string-ng-variable.yaml
+        - $ref: ./update-release-repo-number-ng-variable.yaml
+        - $ref: ./update-release-repo-secret-ng-variable.yaml

--- a/v0/pipeline/steps/cd/update-release-repo-string-ng-variable.yaml
+++ b/v0/pipeline/steps/cd/update-release-repo-string-ng-variable.yaml
@@ -1,0 +1,22 @@
+title: UpdateReleaseRepoStringNGVariable
+allOf:
+  - $ref: ../../common/ng-variable.yaml
+  - type: object
+    required:
+      - value
+    properties:
+      default:
+        type: string
+      name:
+        type: string
+        pattern: ^[a-zA-Z_][0-9a-zA-Z_\.\[\]$-]{0,127}$
+      type:
+        type: string
+        enum:
+          - String
+      value:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for UpdateReleaseRepoStringNGVariable

--- a/v0/template.json
+++ b/v0/template.json
@@ -15426,54 +15426,6 @@
           },
           "MergePRStepInfo" : {
             "title" : "MergePRStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "deleteSourceBranch" ],
-              "properties" : {
-                "delegateSelectors" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "deleteSourceBranch" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string"
-                  } ]
-                },
-                "disableGitRestraint" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "variables" : {
-                  "type" : "array",
-                  "items" : {
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
-                    } ]
-                  }
-                }
-              }
-            } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
             "required" : [ "deleteSourceBranch" ],
@@ -15521,7 +15473,8 @@
               "description" : {
                 "desc" : "This is the description for MergePRStepInfo"
               }
-            }
+            },
+            "$ref" : "#/definitions/pipeline/common/StepSpecType"
           },
           "RevertPRStepNode_template" : {
             "title" : "RevertPRStepNode_template",
@@ -21910,63 +21863,8 @@
           },
           "UpdateReleaseRepoStepInfo" : {
             "title" : "UpdateReleaseRepoStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "properties" : {
-                "delegateSelectors" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "prTitle" : {
-                  "type" : "string"
-                },
-                "allowEmptyCommit" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "disableGitRestraint" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "stringMap" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
-                },
-                "variables" : {
-                  "type" : "array",
-                  "items" : {
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
-                    } ]
-                  }
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
             "properties" : {
               "delegateSelectors" : {
                 "oneOf" : [ {
@@ -22008,16 +21906,117 @@
                 "type" : "array",
                 "items" : {
                   "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoStringNGVariable"
                   }, {
-                    "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoNumberNGVariable"
                   }, {
-                    "$ref" : "#/definitions/pipeline/common/StringNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoSecretNGVariable"
                   } ]
                 }
-              },
+              }
+            },
+            "$ref" : "#/definitions/pipeline/common/StepSpecType"
+          },
+          "UpdateReleaseRepoStringNGVariable" : {
+            "title" : "UpdateReleaseRepoStringNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "String" ]
+                },
+                "value" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
               "description" : {
-                "desc" : "This is the description for UpdateReleaseRepoStepInfo"
+                "desc" : "This is the description for UpdateReleaseRepoStringNGVariable"
+              }
+            }
+          },
+          "UpdateReleaseRepoNumberNGVariable" : {
+            "title" : "UpdateReleaseRepoNumberNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "number",
+                  "format" : "double"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "Number" ]
+                },
+                "value" : {
+                  "oneOf" : [ {
+                    "type" : "number",
+                    "format" : "double"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+                  }, {
+                    "type" : "string",
+                    "maxLength" : 0
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoNumberNGVariable"
+              }
+            }
+          },
+          "UpdateReleaseRepoSecretNGVariable" : {
+            "title" : "UpdateReleaseRepoSecretNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "Secret" ]
+                },
+                "value" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoSecretNGVariable"
               }
             }
           },

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -29746,54 +29746,6 @@
           },
           "MergePRStepInfo" : {
             "title" : "MergePRStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "deleteSourceBranch" ],
-              "properties" : {
-                "delegateSelectors" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "deleteSourceBranch" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string"
-                  } ]
-                },
-                "disableGitRestraint" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "variables" : {
-                  "type" : "array",
-                  "items" : {
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
-                    } ]
-                  }
-                }
-              }
-            } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
             "required" : [ "deleteSourceBranch" ],
@@ -29841,7 +29793,8 @@
               "description" : {
                 "desc" : "This is the description for MergePRStepInfo"
               }
-            }
+            },
+            "$ref" : "#/definitions/pipeline/common/StepSpecType"
           },
           "HelmDeployStepNode" : {
             "title" : "HelmDeployStepNode",
@@ -49532,61 +49485,6 @@
           },
           "UpdateReleaseRepoStepInfo" : {
             "title" : "UpdateReleaseRepoStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "properties" : {
-                "delegateSelectors" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "prTitle" : {
-                  "type" : "string"
-                },
-                "allowEmptyCommit" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "disableGitRestraint" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "stringMap" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
-                },
-                "variables" : {
-                  "type" : "array",
-                  "items" : {
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
-                    } ]
-                  }
-                }
-              }
-            } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
             "properties" : {
@@ -49630,16 +49528,120 @@
                 "type" : "array",
                 "items" : {
                   "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoStringNGVariable"
                   }, {
-                    "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoNumberNGVariable"
                   }, {
-                    "$ref" : "#/definitions/pipeline/common/StringNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoSecretNGVariable"
                   } ]
                 }
               },
               "description" : {
                 "desc" : "This is the description for UpdateReleaseRepoStepInfo"
+              }
+            },
+            "$ref" : "#/definitions/pipeline/common/StepSpecType"
+          },
+          "UpdateReleaseRepoStringNGVariable" : {
+            "title" : "UpdateReleaseRepoStringNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "String" ]
+                },
+                "value" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoStringNGVariable"
+              }
+            }
+          },
+          "UpdateReleaseRepoNumberNGVariable" : {
+            "title" : "UpdateReleaseRepoNumberNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "number",
+                  "format" : "double"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "Number" ]
+                },
+                "value" : {
+                  "oneOf" : [ {
+                    "type" : "number",
+                    "format" : "double"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+                  }, {
+                    "type" : "string",
+                    "maxLength" : 0
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoNumberNGVariable"
+              }
+            }
+          },
+          "UpdateReleaseRepoSecretNGVariable" : {
+            "title" : "UpdateReleaseRepoSecretNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "Secret" ]
+                },
+                "value" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoSecretNGVariable"
               }
             }
           },

--- a/v1/pipeline/steps/cd/merge-pr-step-info.yaml
+++ b/v1/pipeline/steps/cd/merge-pr-step-info.yaml
@@ -1,35 +1,5 @@
 title: MergePRStepInfo
-allOf:
-- $ref: ../../common/step-spec-type.yaml
-- type: object
-  required:
-  - deleteSourceBranch
-  properties:
-    delegateSelectors:
-      oneOf:
-      - type: array
-        items:
-          type: string
-      - type: string
-        pattern: (<\+.+>.*)
-        minLength: 1
-    deleteSourceBranch:
-      oneOf:
-      - type: boolean
-      - type: string
-    disableGitRestraint:
-      oneOf:
-        - type: boolean
-        - type: string
-          pattern: (<\+.+>.*)
-          minLength: 1
-    variables:
-      type: array
-      items:
-        oneOf:
-        - $ref: ../../common/number-ng-variable.yaml
-        - $ref: ../../common/secret-ng-variable.yaml
-        - $ref: ../../common/string-ng-variable.yaml
+$ref: ../../common/step-spec-type.yaml
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:

--- a/v1/pipeline/steps/cd/update-release-repo-number-ng-variable.yaml
+++ b/v1/pipeline/steps/cd/update-release-repo-number-ng-variable.yaml
@@ -1,0 +1,29 @@
+title: UpdateReleaseRepoNumberNGVariable
+allOf:
+  - $ref: ../../common/ng-variable.yaml
+  - type: object
+    required:
+      - value
+    properties:
+      default:
+        type: number
+        format: double
+      name:
+        type: string
+        pattern: ^[a-zA-Z_][0-9a-zA-Z_\.\[\]$-]{0,127}$
+      type:
+        type: string
+        enum:
+          - Number
+      value:
+        oneOf:
+          - type: number
+            format: double
+          - type: string
+            pattern: ((^[+-]?[0-9]*\.?[0-9]+$)|(<\+.+>.*))
+          - type: string
+            maxLength: 0
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for UpdateReleaseRepoNumberNGVariable

--- a/v1/pipeline/steps/cd/update-release-repo-secret-ng-variable.yaml
+++ b/v1/pipeline/steps/cd/update-release-repo-secret-ng-variable.yaml
@@ -1,0 +1,22 @@
+title: UpdateReleaseRepoSecretNGVariable
+allOf:
+  - $ref: ../../common/ng-variable.yaml
+  - type: object
+    required:
+      - value
+    properties:
+      default:
+        type: string
+      name:
+        type: string
+        pattern: ^[a-zA-Z_][0-9a-zA-Z_\.\[\]$-]{0,127}$
+      type:
+        type: string
+        enum:
+          - Secret
+      value:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for UpdateReleaseRepoSecretNGVariable

--- a/v1/pipeline/steps/cd/update-release-repo-step-info.yaml
+++ b/v1/pipeline/steps/cd/update-release-repo-step-info.yaml
@@ -1,39 +1,5 @@
 title: UpdateReleaseRepoStepInfo
-allOf:
-- $ref: ../../common/step-spec-type.yaml
-- type: object
-  properties:
-    delegateSelectors:
-      oneOf:
-      - type: array
-        items:
-          type: string
-      - type: string
-        pattern: (<\+.+>.*)
-        minLength: 1
-    prTitle:
-      type: string
-    allowEmptyCommit: 
-      oneOf:
-        - type: boolean
-        - type: string
-          pattern: (<\+.+>.*)
-          minLength: 1
-    disableGitRestraint:
-      oneOf:
-        - type: boolean
-        - type: string
-          pattern: (<\+.+>.*)
-          minLength: 1
-    stringMap:
-      $ref: ../common/parameter-field-map-string-string.yaml
-    variables:
-      type: array
-      items:
-        oneOf:
-        - $ref: ../../common/number-ng-variable.yaml
-        - $ref: ../../common/secret-ng-variable.yaml
-        - $ref: ../../common/string-ng-variable.yaml
+$ref: ../../common/step-spec-type.yaml
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -65,8 +31,8 @@ properties:
     type: array
     items:
       oneOf:
-      - $ref: ../../common/number-ng-variable.yaml
-      - $ref: ../../common/secret-ng-variable.yaml
-      - $ref: ../../common/string-ng-variable.yaml
+        - $ref: ./update-release-repo-string-ng-variable.yaml
+        - $ref: ./update-release-repo-number-ng-variable.yaml
+        - $ref: ./update-release-repo-secret-ng-variable.yaml
   description:
     desc: This is the description for UpdateReleaseRepoStepInfo

--- a/v1/pipeline/steps/cd/update-release-repo-string-ng-variable.yaml
+++ b/v1/pipeline/steps/cd/update-release-repo-string-ng-variable.yaml
@@ -1,0 +1,22 @@
+title: UpdateReleaseRepoStringNGVariable
+allOf:
+  - $ref: ../../common/ng-variable.yaml
+  - type: object
+    required:
+      - value
+    properties:
+      default:
+        type: string
+      name:
+        type: string
+        pattern: ^[a-zA-Z_][0-9a-zA-Z_\.\[\]$-]{0,127}$
+      type:
+        type: string
+        enum:
+          - String
+      value:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for UpdateReleaseRepoStringNGVariable

--- a/v1/template.json
+++ b/v1/template.json
@@ -17206,54 +17206,6 @@
           },
           "MergePRStepInfo" : {
             "title" : "MergePRStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "deleteSourceBranch" ],
-              "properties" : {
-                "delegateSelectors" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "deleteSourceBranch" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string"
-                  } ]
-                },
-                "disableGitRestraint" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "variables" : {
-                  "type" : "array",
-                  "items" : {
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
-                    } ]
-                  }
-                }
-              }
-            } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
             "required" : [ "deleteSourceBranch" ],
@@ -17301,7 +17253,8 @@
               "description" : {
                 "desc" : "This is the description for MergePRStepInfo"
               }
-            }
+            },
+            "$ref" : "#/definitions/pipeline/common/StepSpecType"
           },
           "RevertPRStepNode_template" : {
             "title" : "RevertPRStepNode_template",
@@ -23870,61 +23823,6 @@
           },
           "UpdateReleaseRepoStepInfo" : {
             "title" : "UpdateReleaseRepoStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "properties" : {
-                "delegateSelectors" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "prTitle" : {
-                  "type" : "string"
-                },
-                "allowEmptyCommit" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "disableGitRestraint" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)",
-                    "minLength" : 1
-                  } ]
-                },
-                "stringMap" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/ParameterFieldMapStringString"
-                },
-                "variables" : {
-                  "type" : "array",
-                  "items" : {
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/common/StringNGVariable"
-                    } ]
-                  }
-                }
-              }
-            } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
             "properties" : {
@@ -23968,16 +23866,120 @@
                 "type" : "array",
                 "items" : {
                   "oneOf" : [ {
-                    "$ref" : "#/definitions/pipeline/common/NumberNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoStringNGVariable"
                   }, {
-                    "$ref" : "#/definitions/pipeline/common/SecretNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoNumberNGVariable"
                   }, {
-                    "$ref" : "#/definitions/pipeline/common/StringNGVariable"
+                    "$ref" : "#/definitions/pipeline/steps/cd/UpdateReleaseRepoSecretNGVariable"
                   } ]
                 }
               },
               "description" : {
                 "desc" : "This is the description for UpdateReleaseRepoStepInfo"
+              }
+            },
+            "$ref" : "#/definitions/pipeline/common/StepSpecType"
+          },
+          "UpdateReleaseRepoStringNGVariable" : {
+            "title" : "UpdateReleaseRepoStringNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "String" ]
+                },
+                "value" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoStringNGVariable"
+              }
+            }
+          },
+          "UpdateReleaseRepoNumberNGVariable" : {
+            "title" : "UpdateReleaseRepoNumberNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "number",
+                  "format" : "double"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "Number" ]
+                },
+                "value" : {
+                  "oneOf" : [ {
+                    "type" : "number",
+                    "format" : "double"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "((^[+-]?[0-9]*\\.?[0-9]+$)|(<\\+.+>.*))"
+                  }, {
+                    "type" : "string",
+                    "maxLength" : 0
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoNumberNGVariable"
+              }
+            }
+          },
+          "UpdateReleaseRepoSecretNGVariable" : {
+            "title" : "UpdateReleaseRepoSecretNGVariable",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/NGVariable"
+            }, {
+              "type" : "object",
+              "required" : [ "value" ],
+              "properties" : {
+                "default" : {
+                  "type" : "string"
+                },
+                "name" : {
+                  "type" : "string",
+                  "pattern" : "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
+                },
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "Secret" ]
+                },
+                "value" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for UpdateReleaseRepoSecretNGVariable"
               }
             }
           },


### PR DESCRIPTION
…eReleaseRepo step variable

What: Allow array references (square brackets) in UpdateReleaseRepo step variables

Why: We recently added support for array references in UpdateReleaseRepoStep where we can refer an array entry using the following format `spec.template.spec.container[0].image`. To allow this format, we need to allow the usage of square brackets in the UpdateReleaseRepo variable names.

Tested locally by replacing pipeline.json
<img width="585" alt="image" src="https://github.com/user-attachments/assets/0646edf9-2766-431d-8dfa-8e57bbee5541" />



note - 
1) also cleaned up duplicated schema for UpdateReleaseRepo and MergePR step
2) I tried merging the ng variables using $merge and $patch as below but it did not work. So I had to create separate variable schema for UpdateReleaseRepo step

``` 
        - $patch:
            source:
              $ref: ../../common/string-ng-variable.yaml
            with:
              op: add
              path: /properties/name/pattern
              value: "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
```
```              
        - $merge:
            source:
              $ref: ../../common/string-ng-variable.yaml
            with:
              properties:
                name:
                  pattern: "^[a-zA-Z_][0-9a-zA-Z_\\.\\[\\]$-]{0,127}$"
 ```