### PR TITLE
feat:[SSCA-3302]: Added artifact verification step to deploy stage

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -1937,6 +1937,8 @@
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SscaOrchestrationStepNode"
                 }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/ArtifactVerificationStepNode"
+                }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/HttpStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/EmailStepNode"
@@ -29473,6 +29475,455 @@
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },
+          "ArtifactVerificationStepNode" : {
+            "title" : "ArtifactVerificationStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ArtifactVerificationStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SscaArtifactVerification" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SscaArtifactVerification"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ArtifactVerificationStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ArtifactVerificationStepInfo" : {
+            "title" : "ArtifactVerificationStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
+                },
+                "verifySign" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
+              },
+              "verifySign" : {
+                "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "description" : {
+                "desc" : "This is the description for ArtifactVerificationStepInfo"
+              }
+            }
+          },
+          "ArtifactSigningSource" : {
+            "title" : "ArtifactSigningSource",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ArtifactSigningSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "docker"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gcr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ecr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "acr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gar"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "har"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/HarSbomSource"
+                  }
+                }
+              }
+            } ]
+          },
+          "DockerSourceSpec" : {
+            "title" : "DockerSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image", "connector" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ArtifactSigningSourceSpec" : {
+            "title" : "ArtifactSigningSourceSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ArtifactSigningSourceSpec"
+              }
+            }
+          },
+          "GcrSourceSpec" : {
+            "title" : "GcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "project_id", "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "project_id" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for GcrSourceSpec"
+              }
+            }
+          },
+          "EcrSourceSpec" : {
+            "title" : "EcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image", "connector", "region", "account" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "region" : {
+                  "type" : "string"
+                },
+                "account" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for EcrSourceSpec"
+              }
+            }
+          },
+          "AcrSourceSpec" : {
+            "title" : "AcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "subscription_id" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for AcrSourceSpec"
+              }
+            }
+          },
+          "GarSourceSpec" : {
+            "title" : "GarSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "project_id", "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "project_id" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for GarSourceSpec"
+              }
+            }
+          },
+          "SlsaVerifyAttestation" : {
+            "title" : "SlsaVerifyAttestation",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "cosign" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaVerifyAttestation"
+              },
+              "spec" : {
+                "type" : "object"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
+                    } ]
+                  }
+                }
+              }
+            } ],
+            "additionalProperties" : false
+          },
+          "CosignSlsaVerifyAttestation" : {
+            "title" : "CosignSlsaVerifyAttestation",
+            "type" : "object",
+            "required" : [ "public_key" ],
+            "properties" : {
+              "public_key" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for Cosign SLSA Verify Attestation"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
+          },
+          "SlsaVerifyAttestationSpec" : {
+            "title" : "SlsaVerifyAttestationSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SlsaVerifyAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerVerifyAttestation" : {
+            "title" : "CosignSecretManagerVerifyAttestation",
+            "type" : "object",
+            "required" : [ "connector", "key" ],
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "key" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for Cosign Verify Attestation with Secret Manager"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
+          },
           "AwsCdkBootstrapStepNode" : {
             "title" : "AwsCdkBootstrapStepNode",
             "type" : "object",
@@ -31352,92 +31803,6 @@
                 "desc" : "Slsa Har source spec"
               }
             }
-          },
-          "SlsaVerifyAttestation" : {
-            "title" : "SlsaVerifyAttestation",
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "cosign" ]
-              },
-              "description" : {
-                "desc" : "This is the description for SlsaVerifyAttestation"
-              },
-              "spec" : {
-                "type" : "object"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "type" : "object",
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/common/CosignSlsaVerifyAttestation"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerVerifyAttestation"
-                    } ]
-                  }
-                }
-              }
-            } ],
-            "additionalProperties" : false
-          },
-          "CosignSlsaVerifyAttestation" : {
-            "title" : "CosignSlsaVerifyAttestation",
-            "type" : "object",
-            "required" : [ "public_key" ],
-            "properties" : {
-              "public_key" : {
-                "type" : "string"
-              },
-              "description" : {
-                "type" : "string",
-                "description" : "This is the description for Cosign SLSA Verify Attestation"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "additionalProperties" : false,
-            "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
-          },
-          "SlsaVerifyAttestationSpec" : {
-            "title" : "SlsaVerifyAttestationSpec",
-            "type" : "object",
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for SlsaVerifyAttestationSpec"
-              }
-            }
-          },
-          "CosignSecretManagerVerifyAttestation" : {
-            "title" : "CosignSecretManagerVerifyAttestation",
-            "type" : "object",
-            "required" : [ "connector", "key" ],
-            "properties" : {
-              "connector" : {
-                "type" : "string"
-              },
-              "key" : {
-                "type" : "string"
-              },
-              "description" : {
-                "type" : "string",
-                "description" : "This is the description for Cosign Verify Attestation with Secret Manager"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "additionalProperties" : false,
-            "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestationSpec"
           },
           "DBApplySchemaStepNode" : {
             "title" : "DBApplySchemaStepNode",
@@ -36080,257 +36445,6 @@
             "additionalProperties" : false,
             "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
           },
-          "ArtifactSigningSource" : {
-            "title" : "ArtifactSigningSource",
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har" ]
-              },
-              "description" : {
-                "desc" : "This is the description for ArtifactSigningSource"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "docker"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "gcr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ecr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "acr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "gar"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "har"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/HarSbomSource"
-                  }
-                }
-              }
-            } ]
-          },
-          "DockerSourceSpec" : {
-            "title" : "DockerSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "image", "connector" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for DockerSourceSpec"
-              }
-            }
-          },
-          "ArtifactSigningSourceSpec" : {
-            "title" : "ArtifactSigningSourceSpec",
-            "type" : "object",
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for ArtifactSigningSourceSpec"
-              }
-            }
-          },
-          "GcrSourceSpec" : {
-            "title" : "GcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "host", "project_id", "image" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "host" : {
-                  "type" : "string"
-                },
-                "project_id" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for GcrSourceSpec"
-              }
-            }
-          },
-          "EcrSourceSpec" : {
-            "title" : "EcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "image", "connector", "region", "account" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "region" : {
-                  "type" : "string"
-                },
-                "account" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for EcrSourceSpec"
-              }
-            }
-          },
-          "AcrSourceSpec" : {
-            "title" : "AcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "image" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                },
-                "subscription_id" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for AcrSourceSpec"
-              }
-            }
-          },
-          "GarSourceSpec" : {
-            "title" : "GarSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "host", "project_id", "image" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "host" : {
-                  "type" : "string"
-                },
-                "project_id" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for GarSourceSpec"
-              }
-            }
-          },
           "UploadSignature" : {
             "title" : "UploadSignature",
             "type" : "object",
@@ -36338,118 +36452,6 @@
               "upload" : {
                 "type" : "boolean",
                 "description" : "Enable or disable to upload signature to the registry"
-              }
-            }
-          },
-          "ArtifactVerificationStepNode" : {
-            "title" : "ArtifactVerificationStepNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ArtifactVerificationStepNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "SscaArtifactVerification" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "SscaArtifactVerification"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/ArtifactVerificationStepInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ArtifactVerificationStepInfo" : {
-            "title" : "ArtifactVerificationStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "properties" : {
-                "source" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
-                },
-                "verifySign" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
-                },
-                "resources" : {
-                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "type" : "object",
-            "properties" : {
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
-              },
-              "verifySign" : {
-                "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
-              },
-              "resources" : {
-                "$ref" : "#/definitions/pipeline/common/ContainerResource"
-              },
-              "description" : {
-                "desc" : "This is the description for ArtifactVerificationStepInfo"
               }
             }
           },

--- a/v0/pipeline/stages/cd/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/cd/execution-wrapper-config.yaml
@@ -113,6 +113,7 @@ properties:
     - $ref: ../../steps/custom/cd-ssca-enforcement-step-node.yaml
     - $ref: ../../steps/common/ssca-enforcement-step-node.yaml
     - $ref: ../../steps/common/ssca-orchestration-step-node.yaml
+    - $ref: ../../steps/common/artifact-verification-step-node.yaml
     - $ref: ../../steps/custom/http-step-node.yaml
     - $ref: ../../steps/custom/email-step-node.yaml
     - $ref: ../../steps/custom/queue-step-node.yaml

--- a/v0/template.json
+++ b/v0/template.json
@@ -58944,6 +58944,369 @@
               }
             } ]
           },
+          "ArtifactVerificationStepNode" : {
+            "title" : "ArtifactVerificationStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ArtifactVerificationStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SscaArtifactVerification" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SscaArtifactVerification"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ArtifactVerificationStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ArtifactVerificationStepInfo" : {
+            "title" : "ArtifactVerificationStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
+                },
+                "verifySign" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
+              },
+              "verifySign" : {
+                "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "description" : {
+                "desc" : "This is the description for ArtifactVerificationStepInfo"
+              }
+            }
+          },
+          "ArtifactSigningSource" : {
+            "title" : "ArtifactSigningSource",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ArtifactSigningSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "docker"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gcr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ecr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "acr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gar"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "har"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/HarSbomSource"
+                  }
+                }
+              }
+            } ]
+          },
+          "DockerSourceSpec" : {
+            "title" : "DockerSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image", "connector" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ArtifactSigningSourceSpec" : {
+            "title" : "ArtifactSigningSourceSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ArtifactSigningSourceSpec"
+              }
+            }
+          },
+          "GcrSourceSpec" : {
+            "title" : "GcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "project_id", "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "project_id" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for GcrSourceSpec"
+              }
+            }
+          },
+          "EcrSourceSpec" : {
+            "title" : "EcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image", "connector", "region", "account" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "region" : {
+                  "type" : "string"
+                },
+                "account" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for EcrSourceSpec"
+              }
+            }
+          },
+          "AcrSourceSpec" : {
+            "title" : "AcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "subscription_id" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for AcrSourceSpec"
+              }
+            }
+          },
+          "GarSourceSpec" : {
+            "title" : "GarSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "project_id", "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "project_id" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for GarSourceSpec"
+              }
+            }
+          },
           "SlsaVerificationStepNode" : {
             "title" : "SlsaVerificationStepNode",
             "type" : "object",
@@ -64040,257 +64403,6 @@
               }
             }
           },
-          "ArtifactSigningSource" : {
-            "title" : "ArtifactSigningSource",
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har" ]
-              },
-              "description" : {
-                "desc" : "This is the description for ArtifactSigningSource"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "docker"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "gcr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ecr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "acr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "gar"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "har"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/HarSbomSource"
-                  }
-                }
-              }
-            } ]
-          },
-          "DockerSourceSpec" : {
-            "title" : "DockerSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "image", "connector" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for DockerSourceSpec"
-              }
-            }
-          },
-          "ArtifactSigningSourceSpec" : {
-            "title" : "ArtifactSigningSourceSpec",
-            "type" : "object",
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for ArtifactSigningSourceSpec"
-              }
-            }
-          },
-          "GcrSourceSpec" : {
-            "title" : "GcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "host", "project_id", "image" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "host" : {
-                  "type" : "string"
-                },
-                "project_id" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for GcrSourceSpec"
-              }
-            }
-          },
-          "EcrSourceSpec" : {
-            "title" : "EcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "image", "connector", "region", "account" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "region" : {
-                  "type" : "string"
-                },
-                "account" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for EcrSourceSpec"
-              }
-            }
-          },
-          "AcrSourceSpec" : {
-            "title" : "AcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "image" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                },
-                "subscription_id" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for AcrSourceSpec"
-              }
-            }
-          },
-          "GarSourceSpec" : {
-            "title" : "GarSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "host", "project_id", "image" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "host" : {
-                  "type" : "string"
-                },
-                "project_id" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for GarSourceSpec"
-              }
-            }
-          },
           "UploadSignature" : {
             "title" : "UploadSignature",
             "type" : "object",
@@ -64298,118 +64410,6 @@
               "upload" : {
                 "type" : "boolean",
                 "description" : "Enable or disable to upload signature to the registry"
-              }
-            }
-          },
-          "ArtifactVerificationStepNode" : {
-            "title" : "ArtifactVerificationStepNode",
-            "type" : "object",
-            "required" : [ "identifier", "name", "spec" ],
-            "properties" : {
-              "description" : {
-                "type" : "string",
-                "desc" : "This is the description for ArtifactVerificationStepNode"
-              },
-              "enforce" : {
-                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
-              },
-              "failureStrategies" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "identifier" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
-              },
-              "name" : {
-                "type" : "string",
-                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
-              },
-              "strategy" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              },
-              "timeout" : {
-                "type" : "string",
-                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
-              },
-              "type" : {
-                "type" : "string",
-                "enum" : [ "SscaArtifactVerification" ]
-              },
-              "when" : {
-                "oneOf" : [ {
-                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
-                }, {
-                  "type" : "string",
-                  "pattern" : "^<\\+input>$",
-                  "minLength" : 1
-                } ]
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "SscaArtifactVerification"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/ArtifactVerificationStepInfo"
-                  }
-                }
-              }
-            } ]
-          },
-          "ArtifactVerificationStepInfo" : {
-            "title" : "ArtifactVerificationStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "properties" : {
-                "source" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
-                },
-                "verifySign" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
-                },
-                "resources" : {
-                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "type" : "object",
-            "properties" : {
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
-              },
-              "verifySign" : {
-                "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
-              },
-              "resources" : {
-                "$ref" : "#/definitions/pipeline/common/ContainerResource"
-              },
-              "description" : {
-                "desc" : "This is the description for ArtifactVerificationStepInfo"
               }
             }
           },
@@ -76828,6 +76828,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/SscaEnforcementStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/SscaOrchestrationStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/common/ArtifactVerificationStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/custom/HttpStepNode"
                 }, {


### PR DESCRIPTION
This pull request includes a change to the `v0/pipeline/stages/cd/execution-wrapper-config.yaml` file, adding a new step to the pipeline configuration.

Pipeline configuration update:

* [`v0/pipeline/stages/cd/execution-wrapper-config.yaml`](diffhunk://#diff-b25b4e2410ebc4eb41e2f09236f3c1ae918e159d079a4afe88799a67517e9162R116): Added a reference to the `artifact-verification-step-node.yaml` file to include the artifact verification step in the pipeline.