### PR TITLE
feat:[SSCA-3356]: Added support for non container artifacts to Artifact Signing and Artifact Verification Step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -29741,6 +29741,21 @@
                   }
                 }
               }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "local"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/LocalSourceSpec"
+                  }
+                }
+              }
             } ]
           },
           "DockerSourceSpec" : {
@@ -29886,6 +29901,32 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for GarSourceSpec"
+              }
+            }
+          },
+          "LocalSourceSpec" : {
+            "title" : "LocalSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "workspace", "artifact_name" ],
+              "properties" : {
+                "workspace" : {
+                  "type" : "string"
+                },
+                "artifact_name" : {
+                  "type" : "string"
+                },
+                "version" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for LocalSourceSpec"
               }
             }
           },
@@ -36375,7 +36416,7 @@
                   "source" : {
                     "properties" : {
                       "type" : {
-                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr", "har" ]
+                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr", "har", "local" ]
                       }
                     }
                   }

--- a/v0/pipeline/steps/common/artifact-signing-source.yaml
+++ b/v0/pipeline/steps/common/artifact-signing-source.yaml
@@ -62,3 +62,11 @@ allOf:
     properties:
       spec:
         $ref: ../custom/har-sbom-source.yaml
+- if:
+    properties:
+      type:
+        const: local
+  then:
+    properties:
+      spec:
+        $ref: local-source-spec.yaml

--- a/v0/pipeline/steps/common/artifact-signing-step-info.yaml
+++ b/v0/pipeline/steps/common/artifact-signing-step-info.yaml
@@ -7,7 +7,7 @@ allOf:
       source:
         properties:
           type:
-            enum: ["ecr", "docker", "gar", "gcr", "acr","har"]
+            enum: ["ecr", "docker", "gar", "gcr", "acr","har","local"]
   then:
     properties:
       signing:

--- a/v0/pipeline/steps/common/local-source-spec.yaml
+++ b/v0/pipeline/steps/common/local-source-spec.yaml
@@ -1,0 +1,18 @@
+title: LocalSourceSpec
+allOf:
+  - $ref: artifact-signing-source-spec.yaml
+  - type: object
+    required:
+      - workspace
+      - artifact_name
+    properties:
+      workspace:
+        type: string
+      artifact_name:
+        type: string
+      version:
+        type: string
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for LocalSourceSpec

--- a/v0/template.json
+++ b/v0/template.json
@@ -59385,6 +59385,21 @@
                   }
                 }
               }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "local"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/LocalSourceSpec"
+                  }
+                }
+              }
             } ]
           },
           "DockerSourceSpec" : {
@@ -59530,6 +59545,32 @@
             "properties" : {
               "description" : {
                 "desc" : "This is the description for GarSourceSpec"
+              }
+            }
+          },
+          "LocalSourceSpec" : {
+            "title" : "LocalSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "workspace", "artifact_name" ],
+              "properties" : {
+                "workspace" : {
+                  "type" : "string"
+                },
+                "artifact_name" : {
+                  "type" : "string"
+                },
+                "version" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for LocalSourceSpec"
               }
             }
           },
@@ -64597,7 +64638,7 @@
                   "source" : {
                     "properties" : {
                       "type" : {
-                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr", "har" ]
+                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr", "har", "local" ]
                       }
                     }
                   }


### PR DESCRIPTION
This pull request introduces support for a new source type, "local", in the pipeline configuration. The changes span multiple files and involve adding new schema definitions and updating existing ones to accommodate the new source type.

Key changes include:

### Additions to Pipeline Schema

* [`v0/pipeline.json`](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2R29744-R29758): Added a new conditional block to handle the "local" source type and defined a new `LocalSourceSpec` schema. This includes specifying required properties such as `workspace` and `artifact_name`, and adding the "local" type to the existing enum list. [[1]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2R29744-R29758) [[2]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2R29907-R29932) [[3]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L36378-R36419)

### Updates to YAML Specifications

* [`v0/pipeline/steps/common/artifact-signing-source.yaml`](diffhunk://#diff-98ba7c38e641312ca0c0fd312ec2b36ff83922d3e95bdc10230de8ec5909fa74R65-R72): Added conditional logic to handle the "local" source type and reference the new `local-source-spec.yaml`.
* [`v0/pipeline/steps/common/artifact-signing-step-info.yaml`](diffhunk://#diff-5354d9f126ef13bc52a2269998107dc7a66de0b32e9061e31af42443fb5fef4cL10-R10): Updated the enum list to include the "local" type.
* [`v0/pipeline/steps/common/local-source-spec.yaml`](diffhunk://#diff-02f13fd3789eaeb144be408c65e6b3be706eb401741927b8ff87a975a03db81aR1-R18): Created a new YAML specification for `LocalSourceSpec` with required properties and schema details.

### Template Updates

* [`v0/template.json`](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cR59388-R59402): Similar to `pipeline.json`, added a new conditional block and defined the `LocalSourceSpec` schema, including updating the enum list for the "local" type. [[1]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cR59388-R59402) [[2]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cR59551-R59576) [[3]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL64600-R64641)