### PR TITLE
feat:[SSCA-3356]: Making artifact_name not mandatory

### DIFF
--- a/v0/pipeline/steps/common/local-source-spec.yaml
+++ b/v0/pipeline/steps/common/local-source-spec.yaml
@@ -4,7 +4,6 @@ allOf:
   - type: object
     required:
       - workspace
-      - artifact_name
     properties:
       workspace:
         type: string


### PR DESCRIPTION
This pull request includes a change to the `v0/pipeline/steps/common/local-source-spec.yaml` file to remove the `artifact_name` property from the `required` list.

* [`v0/pipeline/steps/common/local-source-spec.yaml`](diffhunk://#diff-02f13fd3789eaeb144be408c65e6b3be706eb401741927b8ff87a975a03db81aL7): Removed `artifact_name` from the `required` list.