### PR TITLE
feat:[SSCA-3356]: Added new enum type for signing and verification

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -29644,7 +29644,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har" ]
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har", "local" ]
               },
               "description" : {
                 "desc" : "This is the description for ArtifactSigningSource"
@@ -29910,7 +29910,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "workspace", "artifact_name" ],
+              "required" : [ "workspace" ],
               "properties" : {
                 "workspace" : {
                   "type" : "string"

--- a/v0/pipeline/steps/common/artifact-signing-source.yaml
+++ b/v0/pipeline/steps/common/artifact-signing-source.yaml
@@ -10,6 +10,7 @@ properties:
     - acr
     - gar
     - har
+    - local
   description:
     desc: This is the description for ArtifactSigningSource
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/template.json
+++ b/v0/template.json
@@ -59288,7 +59288,7 @@
             "properties" : {
               "type" : {
                 "type" : "string",
-                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har" ]
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har", "local" ]
               },
               "description" : {
                 "desc" : "This is the description for ArtifactSigningSource"
@@ -59554,7 +59554,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "workspace", "artifact_name" ],
+              "required" : [ "workspace" ],
               "properties" : {
                 "workspace" : {
                   "type" : "string"


### PR DESCRIPTION
This pull request includes several changes to the `v0/pipeline.json`, `v0/template.json`, and `v0/pipeline/steps/common/artifact-signing-source.yaml` files to add support for a new "local" artifact signing source and to modify the required properties for certain objects. The most important changes are:

Support for new "local" artifact signing source:

* Added "local" to the `enum` list for the `type` property in `v0/pipeline.json`.
* Added "local" to the `enum` list for the `type` property in `v0/template.json`.
* Added "local" to the `enum` list for the `type` property in `v0/pipeline/steps/common/artifact-signing-source.yaml`.

Modification of required properties:

* Removed `artifact_name` from the `required` list in `v0/pipeline.json`.
* Removed `artifact_name` from the `required` list in `v0/template.json`.