### PR TITLE
feat:[SSCA-3452]: Added support for SCS Steps to step template support

### DIFF
--- a/v0/template.json
+++ b/v0/template.json
@@ -533,6 +533,14 @@
                 "$ref" : "#/definitions/pipeline/steps/cd/GoogleCloudRunJobStepNode_template"
               }, {
                 "$ref" : "#/definitions/pipeline/steps/custom/EventListenerStepNode_template"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningStepNode_template"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/common/ArtifactVerificationStepNode_template"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepNode_template"
+              }, {
+                "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepNode_template"
               } ]
             },
             "tags" : {
@@ -39133,6 +39141,127 @@
               }
             }
           },
+          "SscaComplianceSource" : {
+            "title" : "SscaComplianceSource",
+            "type" : "object",
+            "required" : [ "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "scm", "github", "harness" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SscaComplianceSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "scm"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySscaComplianceSource"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "github"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySscaComplianceSource"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "harness"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/HarnessSscaComplianceSource"
+                  }
+                }
+              }
+            } ]
+          },
+          "RepositorySscaComplianceSource" : {
+            "title" : "RepositorySscaComplianceSource",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connectorRef", "scan_org" ],
+              "properties" : {
+                "connectorRef" : {
+                  "type" : "string"
+                },
+                "repoName" : {
+                  "type" : "string"
+                },
+                "scan_org" : {
+                  "oneOf" : [ {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+.*>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                },
+                "description" : {
+                  "desc" : "This is the description for RepositorySscaComplianceSource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "HarnessSscaComplianceSource" : {
+            "title" : "HarnessSscaComplianceSource",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "type", "pipelineIds" ],
+              "properties" : {
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "pipeline" ]
+                },
+                "pipelineIds" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "minLength" : 1
+                  } ]
+                },
+                "description" : {
+                  "desc" : "This is the description for RepositorySscaComplianceSource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
           "StageWhenCondition" : {
             "title" : "StageWhenCondition",
             "type" : "object",
@@ -40879,127 +41008,6 @@
                 "desc" : "This is the description for CdSscaOrchestrationStepInfo"
               }
             }
-          },
-          "SscaComplianceSource" : {
-            "title" : "SscaComplianceSource",
-            "type" : "object",
-            "required" : [ "type" ],
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "scm", "github", "harness" ]
-              },
-              "description" : {
-                "desc" : "This is the description for SscaComplianceSource"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "scm"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySscaComplianceSource"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "github"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/RepositorySscaComplianceSource"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "harness"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/HarnessSscaComplianceSource"
-                  }
-                }
-              }
-            } ]
-          },
-          "RepositorySscaComplianceSource" : {
-            "title" : "RepositorySscaComplianceSource",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connectorRef", "scan_org" ],
-              "properties" : {
-                "connectorRef" : {
-                  "type" : "string"
-                },
-                "repoName" : {
-                  "type" : "string"
-                },
-                "scan_org" : {
-                  "oneOf" : [ {
-                    "type" : "boolean"
-                  }, {
-                    "type" : "string",
-                    "pattern" : "^<\\+.*>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
-                    "minLength" : 1
-                  } ]
-                },
-                "description" : {
-                  "desc" : "This is the description for RepositorySscaComplianceSource"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#"
-          },
-          "HarnessSscaComplianceSource" : {
-            "title" : "HarnessSscaComplianceSource",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/custom/SbomSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "type", "pipelineIds" ],
-              "properties" : {
-                "type" : {
-                  "type" : "string",
-                  "enum" : [ "pipeline" ]
-                },
-                "pipelineIds" : {
-                  "oneOf" : [ {
-                    "type" : "array",
-                    "items" : {
-                      "type" : "string"
-                    }
-                  }, {
-                    "type" : "string",
-                    "minLength" : 1
-                  } ]
-                },
-                "description" : {
-                  "desc" : "This is the description for RepositorySscaComplianceSource"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#"
           }
         },
         "common" : {
@@ -58305,6 +58313,1101 @@
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object"
           },
+          "ArtifactSigningStepNode_template" : {
+            "title" : "ArtifactSigningStepNode_template",
+            "type" : "object",
+            "required" : [ "spec" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SscaArtifactSigning" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SscaArtifactSigning"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ArtifactSigningStepInfo" : {
+            "title" : "ArtifactSigningStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "if" : {
+                "properties" : {
+                  "source" : {
+                    "properties" : {
+                      "type" : {
+                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr", "har", "local" ]
+                      }
+                    }
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "signing" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
+                  }
+                }
+              }
+            } ],
+            "additonalProperties" : false,
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "uploadSignature" : {
+                "$ref" : "#/definitions/pipeline/steps/common/UploadSignature"
+              },
+              "description" : {
+                "desc" : "This is the description for ArtifactSigningStepInfo"
+              }
+            }
+          },
+          "AttestationV1" : {
+            "title" : "AttestationV1",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "cosign" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestation"
+              },
+              "spec" : {
+                "type" : "object"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "cosign"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "type" : "object",
+                    "oneOf" : [ {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignAttestation"
+                    }, {
+                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerProvenanceAttestation"
+                    } ]
+                  }
+                }
+              }
+            } ],
+            "additionalProperties" : false
+          },
+          "CosignAttestation" : {
+            "title" : "CosignAttestation",
+            "type" : "object",
+            "required" : [ "private_key", "password" ],
+            "properties" : {
+              "private_key" : {
+                "type" : "string"
+              },
+              "password" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for CosignAttestation"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
+          },
+          "AttestationSpecV1" : {
+            "title" : "AttestationSpecV1",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceAttestationSpec"
+              }
+            }
+          },
+          "CosignSecretManagerProvenanceAttestation" : {
+            "title" : "CosignSecretManagerProvenanceAttestation",
+            "type" : "object",
+            "required" : [ "connector", "key" ],
+            "properties" : {
+              "connector" : {
+                "type" : "string"
+              },
+              "key" : {
+                "type" : "string"
+              },
+              "description" : {
+                "type" : "string",
+                "description" : "This is the description for Cosign Provenance Attestation with Secret Manager"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "additionalProperties" : false,
+            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
+          },
+          "ArtifactSigningSource" : {
+            "title" : "ArtifactSigningSource",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har", "local" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ArtifactSigningSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "docker"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gcr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ecr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "acr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gar"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "har"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/custom/HarSbomSource"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "local"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/LocalSourceSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "DockerSourceSpec" : {
+            "title" : "DockerSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image", "connector" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ArtifactSigningSourceSpec" : {
+            "title" : "ArtifactSigningSourceSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ArtifactSigningSourceSpec"
+              }
+            }
+          },
+          "GcrSourceSpec" : {
+            "title" : "GcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "project_id", "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "project_id" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for GcrSourceSpec"
+              }
+            }
+          },
+          "EcrSourceSpec" : {
+            "title" : "EcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image", "connector", "region", "account" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "region" : {
+                  "type" : "string"
+                },
+                "account" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for EcrSourceSpec"
+              }
+            }
+          },
+          "AcrSourceSpec" : {
+            "title" : "AcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "subscription_id" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for AcrSourceSpec"
+              }
+            }
+          },
+          "GarSourceSpec" : {
+            "title" : "GarSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "project_id", "image" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "project_id" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for GarSourceSpec"
+              }
+            }
+          },
+          "LocalSourceSpec" : {
+            "title" : "LocalSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "workspace" ],
+              "properties" : {
+                "workspace" : {
+                  "type" : "string"
+                },
+                "artifact_name" : {
+                  "type" : "string"
+                },
+                "version" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for LocalSourceSpec"
+              }
+            }
+          },
+          "UploadSignature" : {
+            "title" : "UploadSignature",
+            "type" : "object",
+            "properties" : {
+              "upload" : {
+                "type" : "boolean",
+                "description" : "Enable or disable to upload signature to the registry"
+              }
+            }
+          },
+          "ArtifactVerificationStepNode_template" : {
+            "title" : "ArtifactVerificationStepNode_template",
+            "type" : "object",
+            "required" : [ "spec" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SscaArtifactVerification" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SscaArtifactVerification"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ArtifactVerificationStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ArtifactVerificationStepInfo" : {
+            "title" : "ArtifactVerificationStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
+                },
+                "verifySign" : {
+                  "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
+              },
+              "verifySign" : {
+                "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "description" : {
+                "desc" : "This is the description for ArtifactVerificationStepInfo"
+              }
+            }
+          },
+          "ProvenanceStepNode_template" : {
+            "title" : "ProvenanceStepNode_template",
+            "type" : "object",
+            "required" : [ "spec" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "provenance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "provenance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ProvenanceStepInfo" : {
+            "title" : "ProvenanceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "if" : {
+                "properties" : {
+                  "source" : {
+                    "properties" : {
+                      "type" : {
+                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr", "har" ]
+                      }
+                    }
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "attestation" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
+                  }
+                }
+              }
+            } ],
+            "additonalProperties" : false,
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSource"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaGenerationStepInfo"
+              }
+            }
+          },
+          "ProvenanceSource" : {
+            "title" : "ProvenanceSource",
+            "type" : "object",
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har" ]
+              },
+              "description" : {
+                "desc" : "This is the description for SlsaGenerationSource"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "docker"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceDockerSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gcr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceGcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ecr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceEcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "acr"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceAcrSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "gar"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceGarSourceSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "har"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceHarSourceSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "ProvenanceDockerSourceSpec" : {
+            "title" : "ProvenanceDockerSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "repo", "digest", "connector" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repo" : {
+                  "type" : "string"
+                },
+                "digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for DockerSourceSpec"
+              }
+            }
+          },
+          "ProvenanceSourceSpec" : {
+            "title" : "ProvenanceSourceSpec",
+            "type" : "object",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ProvenanceSourceSpec"
+              }
+            }
+          },
+          "ProvenanceGcrSourceSpec" : {
+            "title" : "ProvenanceGcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectID", "imageName", "digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectID" : {
+                  "type" : "string"
+                },
+                "imageName" : {
+                  "type" : "string"
+                },
+                "digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gcr source spec"
+              }
+            }
+          },
+          "ProvenanceEcrSourceSpec" : {
+            "title" : "ProvenanceEcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "image", "digest", "connector" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "region" : {
+                  "type" : "string"
+                },
+                "account" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Ecr source spec"
+              }
+            }
+          },
+          "ProvenanceAcrSourceSpec" : {
+            "title" : "ProvenanceAcrSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "repository", "digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "repository" : {
+                  "type" : "string"
+                },
+                "subscriptionId" : {
+                  "type" : "string"
+                },
+                "digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Acr source spec"
+              }
+            }
+          },
+          "ProvenanceGarSourceSpec" : {
+            "title" : "ProvenanceGarSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "connector", "host", "projectID", "imageName", "digest" ],
+              "properties" : {
+                "connector" : {
+                  "type" : "string"
+                },
+                "host" : {
+                  "type" : "string"
+                },
+                "projectID" : {
+                  "type" : "string"
+                },
+                "imageName" : {
+                  "type" : "string"
+                },
+                "digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Gar source spec"
+              }
+            }
+          },
+          "ProvenanceHarSourceSpec" : {
+            "title" : "ProvenanceHarSourceSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "registry", "image", "digest" ],
+              "properties" : {
+                "registry" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "digest" : {
+                  "type" : "string"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "Harness Artifact Registry source spec"
+              }
+            }
+          },
+          "SscaComplianceStepNode_template" : {
+            "title" : "SscaComplianceStepNode_template",
+            "type" : "object",
+            "required" : [ "spec" ],
+            "properties" : {
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "SscaCompliance" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SscaCompliance"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/common/SscaComplianceStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "SscaComplianceStepInfo" : {
+            "title" : "SscaComplianceStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "source" ],
+              "properties" : {
+                "description" : {
+                  "desc" : "This is the description for SscaComplianceStepInfo"
+                },
+                "source" : {
+                  "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "source" ],
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SscaComplianceStepInfo"
+              },
+              "source" : {
+                "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              }
+            }
+          },
           "BackgroundStepNode" : {
             "title" : "BackgroundStepNode",
             "type" : "object",
@@ -59527,333 +60630,6 @@
                 }
               }
             } ]
-          },
-          "ArtifactVerificationStepInfo" : {
-            "title" : "ArtifactVerificationStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "properties" : {
-                "source" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
-                },
-                "verifySign" : {
-                  "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
-                },
-                "resources" : {
-                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "type" : "object",
-            "properties" : {
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
-              },
-              "verifySign" : {
-                "$ref" : "#/definitions/pipeline/steps/common/SlsaVerifyAttestation"
-              },
-              "resources" : {
-                "$ref" : "#/definitions/pipeline/common/ContainerResource"
-              },
-              "description" : {
-                "desc" : "This is the description for ArtifactVerificationStepInfo"
-              }
-            }
-          },
-          "ArtifactSigningSource" : {
-            "title" : "ArtifactSigningSource",
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har", "local" ]
-              },
-              "description" : {
-                "desc" : "This is the description for ArtifactSigningSource"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "docker"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/DockerSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "gcr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/GcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ecr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/EcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "acr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/AcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "gar"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/GarSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "har"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/custom/HarSbomSource"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "local"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/LocalSourceSpec"
-                  }
-                }
-              }
-            } ]
-          },
-          "DockerSourceSpec" : {
-            "title" : "DockerSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "image", "connector" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for DockerSourceSpec"
-              }
-            }
-          },
-          "ArtifactSigningSourceSpec" : {
-            "title" : "ArtifactSigningSourceSpec",
-            "type" : "object",
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for ArtifactSigningSourceSpec"
-              }
-            }
-          },
-          "GcrSourceSpec" : {
-            "title" : "GcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "host", "project_id", "image" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "host" : {
-                  "type" : "string"
-                },
-                "project_id" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for GcrSourceSpec"
-              }
-            }
-          },
-          "EcrSourceSpec" : {
-            "title" : "EcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "image", "connector", "region", "account" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "region" : {
-                  "type" : "string"
-                },
-                "account" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for EcrSourceSpec"
-              }
-            }
-          },
-          "AcrSourceSpec" : {
-            "title" : "AcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "image" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                },
-                "subscription_id" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for AcrSourceSpec"
-              }
-            }
-          },
-          "GarSourceSpec" : {
-            "title" : "GarSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "host", "project_id", "image" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "host" : {
-                  "type" : "string"
-                },
-                "project_id" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for GarSourceSpec"
-              }
-            }
-          },
-          "LocalSourceSpec" : {
-            "title" : "LocalSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "workspace" ],
-              "properties" : {
-                "workspace" : {
-                  "type" : "string"
-                },
-                "artifact_name" : {
-                  "type" : "string"
-                },
-                "version" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for LocalSourceSpec"
-              }
-            }
           },
           "SlsaVerificationStepNode" : {
             "title" : "SlsaVerificationStepNode",
@@ -64410,427 +65186,6 @@
               }
             } ]
           },
-          "ProvenanceStepInfo" : {
-            "title" : "ProvenanceStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "if" : {
-                "properties" : {
-                  "source" : {
-                    "properties" : {
-                      "type" : {
-                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr", "har" ]
-                      }
-                    }
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "attestation" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
-                  }
-                }
-              }
-            } ],
-            "additonalProperties" : false,
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "type" : "object",
-            "properties" : {
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSource"
-              },
-              "resources" : {
-                "$ref" : "#/definitions/pipeline/common/ContainerResource"
-              },
-              "description" : {
-                "desc" : "This is the description for SlsaGenerationStepInfo"
-              }
-            }
-          },
-          "AttestationV1" : {
-            "title" : "AttestationV1",
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "cosign" ]
-              },
-              "description" : {
-                "desc" : "This is the description for ProvenanceAttestation"
-              },
-              "spec" : {
-                "type" : "object"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "cosign"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "type" : "object",
-                    "oneOf" : [ {
-                      "$ref" : "#/definitions/pipeline/steps/common/CosignAttestation"
-                    }, {
-                      "$ref" : "#/definitions/pipeline/steps/common/CosignSecretManagerProvenanceAttestation"
-                    } ]
-                  }
-                }
-              }
-            } ],
-            "additionalProperties" : false
-          },
-          "CosignAttestation" : {
-            "title" : "CosignAttestation",
-            "type" : "object",
-            "required" : [ "private_key", "password" ],
-            "properties" : {
-              "private_key" : {
-                "type" : "string"
-              },
-              "password" : {
-                "type" : "string"
-              },
-              "description" : {
-                "type" : "string",
-                "description" : "This is the description for CosignAttestation"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "additionalProperties" : false,
-            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
-          },
-          "AttestationSpecV1" : {
-            "title" : "AttestationSpecV1",
-            "type" : "object",
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for ProvenanceAttestationSpec"
-              }
-            }
-          },
-          "CosignSecretManagerProvenanceAttestation" : {
-            "title" : "CosignSecretManagerProvenanceAttestation",
-            "type" : "object",
-            "required" : [ "connector", "key" ],
-            "properties" : {
-              "connector" : {
-                "type" : "string"
-              },
-              "key" : {
-                "type" : "string"
-              },
-              "description" : {
-                "type" : "string",
-                "description" : "This is the description for Cosign Provenance Attestation with Secret Manager"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "additionalProperties" : false,
-            "$ref" : "#/definitions/pipeline/steps/common/AttestationSpecV1"
-          },
-          "ProvenanceSource" : {
-            "title" : "ProvenanceSource",
-            "type" : "object",
-            "properties" : {
-              "type" : {
-                "type" : "string",
-                "enum" : [ "docker", "gcr", "ecr", "acr", "gar", "har" ]
-              },
-              "description" : {
-                "desc" : "This is the description for SlsaGenerationSource"
-              }
-            },
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "allOf" : [ {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "docker"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceDockerSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "gcr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceGcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "ecr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceEcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "acr"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceAcrSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "gar"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceGarSourceSpec"
-                  }
-                }
-              }
-            }, {
-              "if" : {
-                "properties" : {
-                  "type" : {
-                    "const" : "har"
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "spec" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/ProvenanceHarSourceSpec"
-                  }
-                }
-              }
-            } ]
-          },
-          "ProvenanceDockerSourceSpec" : {
-            "title" : "ProvenanceDockerSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "repo", "digest", "connector" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "repo" : {
-                  "type" : "string"
-                },
-                "digest" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for DockerSourceSpec"
-              }
-            }
-          },
-          "ProvenanceSourceSpec" : {
-            "title" : "ProvenanceSourceSpec",
-            "type" : "object",
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for ProvenanceSourceSpec"
-              }
-            }
-          },
-          "ProvenanceGcrSourceSpec" : {
-            "title" : "ProvenanceGcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "host", "projectID", "imageName", "digest" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "host" : {
-                  "type" : "string"
-                },
-                "projectID" : {
-                  "type" : "string"
-                },
-                "imageName" : {
-                  "type" : "string"
-                },
-                "digest" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "Gcr source spec"
-              }
-            }
-          },
-          "ProvenanceEcrSourceSpec" : {
-            "title" : "ProvenanceEcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "image", "digest", "connector" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "region" : {
-                  "type" : "string"
-                },
-                "account" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                },
-                "digest" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "Ecr source spec"
-              }
-            }
-          },
-          "ProvenanceAcrSourceSpec" : {
-            "title" : "ProvenanceAcrSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "repository", "digest" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "repository" : {
-                  "type" : "string"
-                },
-                "subscriptionId" : {
-                  "type" : "string"
-                },
-                "digest" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "Acr source spec"
-              }
-            }
-          },
-          "ProvenanceGarSourceSpec" : {
-            "title" : "ProvenanceGarSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "connector", "host", "projectID", "imageName", "digest" ],
-              "properties" : {
-                "connector" : {
-                  "type" : "string"
-                },
-                "host" : {
-                  "type" : "string"
-                },
-                "projectID" : {
-                  "type" : "string"
-                },
-                "imageName" : {
-                  "type" : "string"
-                },
-                "digest" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "Gar source spec"
-              }
-            }
-          },
-          "ProvenanceHarSourceSpec" : {
-            "title" : "ProvenanceHarSourceSpec",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
-            }, {
-              "type" : "object",
-              "required" : [ "registry", "image", "digest" ],
-              "properties" : {
-                "registry" : {
-                  "type" : "string"
-                },
-                "image" : {
-                  "type" : "string"
-                },
-                "digest" : {
-                  "type" : "string"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "properties" : {
-              "description" : {
-                "desc" : "Harness Artifact Registry source spec"
-              }
-            }
-          },
           "ArtifactSigningStepNode" : {
             "title" : "ArtifactSigningStepNode",
             "type" : "object",
@@ -64907,59 +65262,6 @@
                 }
               }
             } ]
-          },
-          "ArtifactSigningStepInfo" : {
-            "title" : "ArtifactSigningStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "if" : {
-                "properties" : {
-                  "source" : {
-                    "properties" : {
-                      "type" : {
-                        "enum" : [ "ecr", "docker", "gar", "gcr", "acr", "har", "local" ]
-                      }
-                    }
-                  }
-                }
-              },
-              "then" : {
-                "properties" : {
-                  "signing" : {
-                    "$ref" : "#/definitions/pipeline/steps/common/AttestationV1"
-                  }
-                }
-              }
-            } ],
-            "additonalProperties" : false,
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "type" : "object",
-            "properties" : {
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSource"
-              },
-              "resources" : {
-                "$ref" : "#/definitions/pipeline/common/ContainerResource"
-              },
-              "uploadSignature" : {
-                "$ref" : "#/definitions/pipeline/steps/common/UploadSignature"
-              },
-              "description" : {
-                "desc" : "This is the description for ArtifactSigningStepInfo"
-              }
-            }
-          },
-          "UploadSignature" : {
-            "title" : "UploadSignature",
-            "type" : "object",
-            "properties" : {
-              "upload" : {
-                "type" : "boolean",
-                "description" : "Enable or disable to upload signature to the registry"
-              }
-            }
           },
           "WizScanNode" : {
             "title" : "WizScanNode",
@@ -65114,40 +65416,6 @@
                 }
               }
             } ]
-          },
-          "SscaComplianceStepInfo" : {
-            "title" : "SscaComplianceStepInfo",
-            "allOf" : [ {
-              "$ref" : "#/definitions/pipeline/common/StepSpecType"
-            }, {
-              "type" : "object",
-              "required" : [ "source" ],
-              "properties" : {
-                "description" : {
-                  "desc" : "This is the description for SscaComplianceStepInfo"
-                },
-                "source" : {
-                  "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
-                },
-                "resources" : {
-                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
-                }
-              }
-            } ],
-            "$schema" : "http://json-schema.org/draft-07/schema#",
-            "type" : "object",
-            "required" : [ "source" ],
-            "properties" : {
-              "description" : {
-                "desc" : "This is the description for SscaComplianceStepInfo"
-              },
-              "source" : {
-                "$ref" : "#/definitions/pipeline/steps/custom/SscaComplianceSource"
-              },
-              "resources" : {
-                "$ref" : "#/definitions/pipeline/common/ContainerResource"
-              }
-            }
           },
           "DockerInfraYaml" : {
             "title" : "DockerInfraYaml",

--- a/v0/template/template_config.yaml
+++ b/v0/template/template_config.yaml
@@ -247,6 +247,10 @@ step_template_types:
   - ../pipeline/steps/cd/google-cloud-run-rollback-step-node.yaml
   - ../pipeline/steps/cd/google-cloud-run-job-step-node.yaml
   - ../pipeline/steps/custom/event-listener-step-node.yaml
+  - ../pipeline/steps/common/artifact-signing-step-node.yaml
+  - ../pipeline/steps/common/artifact-verification-step-node.yaml
+  - ../pipeline/steps/common/provenance-step-node.yaml
+  - ../pipeline/steps/common/ssca-compliance-step-node.yaml
 
 stage_template_types:
   - ../pipeline/stages/custom/custom-stage-node.yaml


### PR DESCRIPTION
This pull request includes several changes to the `trigger.json` files and the `template_config.yaml` file. The main changes involve adding new step templates and removing certain trigger types and their associated specifications.

### Additions to step templates:
* Added `artifact-signing-step-node`, `artifact-verification-step-node`, `provenance-step-node`, and `ssca-compliance-step-node` to the list of step templates in `template_config.yaml`.

### Removals in `v0/trigger.json`:
* Removed the `Create` type from the `enum` list and its associated conditional and specification. [[1]](diffhunk://#diff-caa53cc8954d528235b093d63d228120c982de60522c6da492567b5eaf37cfbaL2373-R2373) [[2]](diffhunk://#diff-caa53cc8954d528235b093d63d228120c982de60522c6da492567b5eaf37cfbaL2451-L2465) [[3]](diffhunk://#diff-caa53cc8954d528235b093d63d228120c982de60522c6da492567b5eaf37cfbaL2668-L2699)
* Removed the `Tag` type from the `enum` list and its associated conditional and specification. [[1]](diffhunk://#diff-caa53cc8954d528235b093d63d228120c982de60522c6da492567b5eaf37cfbaL2709-R2662) [[2]](diffhunk://#diff-caa53cc8954d528235b093d63d228120c982de60522c6da492567b5eaf37cfbaL2757-L2771) [[3]](diffhunk://#diff-caa53cc8954d528235b093d63d228120c982de60522c6da492567b5eaf37cfbaL2900-L2934)

### Removals in `v1/trigger.json`:
* Removed the `create` type from the `enum` list and its associated conditional and specification. [[1]](diffhunk://#diff-be8744f1e9e3369e35b8ed1a761da3b8ef39b3c62bdc3f99cdda69aa09c58dd4L2073-R2073) [[2]](diffhunk://#diff-be8744f1e9e3369e35b8ed1a761da3b8ef39b3c62bdc3f99cdda69aa09c58dd4L2151-L2165) [[3]](diffhunk://#diff-be8744f1e9e3369e35b8ed1a761da3b8ef39b3c62bdc3f99cdda69aa09c58dd4L2318-L2339)
* Removed the `tag` type from the `enum` list and its associated conditional and specification. [[1]](diffhunk://#diff-be8744f1e9e3369e35b8ed1a761da3b8ef39b3c62bdc3f99cdda69aa09c58dd4L2350-R2313) [[2]](diffhunk://#diff-be8744f1e9e3369e35b8ed1a761da3b8ef39b3c62bdc3f99cdda69aa09c58dd4L2398-L2412) [[3]](diffhunk://#diff-be8744f1e9e3369e35b8ed1a761da3b8ef39b3c62bdc3f99cdda69aa09c58dd4L2511-L2535)