### PR TITLE
feat: [CDS-107795]: Allow runtime input in maxConcurrency for multiService deployment

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -67234,11 +67234,17 @@
                 "type" : "string",
                 "pattern" : "^(?!<\\+input>.*\\.executionInput\\(\\)(.*)$)"
               },
-              "maxConcurrency" : [ {
-                "type" : "integer",
-                "format" : "int32",
-                "minimum" : 1
-              } ]
+              "maxConcurrency" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32",
+                  "minimum" : 1
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },

--- a/v0/pipeline/stages/cd/multi-deployment-config.yaml
+++ b/v0/pipeline/stages/cd/multi-deployment-config.yaml
@@ -8,7 +8,11 @@ properties:
     type: string
     pattern: ^(?!<\+input>.*\.executionInput\(\)(.*)$)
   maxConcurrency:
-    - type: integer
-      format: int32
-      minimum: 1
+    oneOf:
+      - type: integer
+        format: int32
+        minimum: 1
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/template.json
+++ b/v0/template.json
@@ -83688,11 +83688,17 @@
                 "type" : "string",
                 "pattern" : "^(?!<\\+input>.*\\.executionInput\\(\\)(.*)$)"
               },
-              "maxConcurrency" : [ {
-                "type" : "integer",
-                "format" : "int32",
-                "minimum" : 1
-              } ]
+              "maxConcurrency" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32",
+                  "minimum" : 1
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
             },
             "$schema" : "http://json-schema.org/draft-07/schema#"
           },


### PR DESCRIPTION
Allow runtime input in maxConcurrency for multiService deployment
Tested that pipeline can only be saved with integer value and runtime input