### PR TITLE
Feat: [CDS-107999]: Schema changes: accept opt AWS connector in CDK steps

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -30117,6 +30117,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -30194,6 +30197,9 @@
             "required" : [ "connectorRef", "image" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {
@@ -30359,6 +30365,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -30451,6 +30460,9 @@
             "required" : [ "connectorRef", "image" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {
@@ -30631,6 +30643,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -30720,6 +30735,9 @@
             "required" : [ "connectorRef", "image" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {
@@ -30897,6 +30915,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -30995,6 +31016,9 @@
             "required" : [ "connectorRef", "image", "provisionerIdentifier" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {
@@ -31181,6 +31205,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -31270,6 +31297,9 @@
             "required" : [ "connectorRef", "image" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {

--- a/v0/pipeline/steps/common/aws-cdk-bootstrap-step-info.yaml
+++ b/v0/pipeline/steps/common/aws-cdk-bootstrap-step-info.yaml
@@ -8,6 +8,8 @@ allOf:
   properties:
     appPath:
       type: string
+    awsConnectorRef:
+      type: string
     commandOptions:
       oneOf:
       - type: array
@@ -65,6 +67,8 @@ required:
 properties:
   appPath:
     type: string
+  awsConnectorRef:
+      type: string
   commandOptions:
     oneOf:
     - type: array

--- a/v0/pipeline/steps/common/aws-cdk-deploy-step-info.yaml
+++ b/v0/pipeline/steps/common/aws-cdk-deploy-step-info.yaml
@@ -9,6 +9,8 @@ allOf:
   properties:
     appPath:
       type: string
+    awsConnectorRef:
+      type: string
     commandOptions:
       oneOf:
       - type: array
@@ -80,6 +82,8 @@ required:
 - provisionerIdentifier
 properties:
   appPath:
+    type: string
+  awsConnectorRef:
     type: string
   commandOptions:
     oneOf:

--- a/v0/pipeline/steps/common/aws-cdk-destroy-step-info.yaml
+++ b/v0/pipeline/steps/common/aws-cdk-destroy-step-info.yaml
@@ -8,6 +8,8 @@ allOf:
   properties:
     appPath:
       type: string
+    awsConnectorRef:
+      type: string
     commandOptions:
       oneOf:
       - type: array
@@ -72,6 +74,8 @@ required:
 - image
 properties:
   appPath:
+    type: string
+  awsConnectorRef:
     type: string
   commandOptions:
     oneOf:

--- a/v0/pipeline/steps/common/aws-cdk-diff-step-info.yaml
+++ b/v0/pipeline/steps/common/aws-cdk-diff-step-info.yaml
@@ -8,6 +8,8 @@ allOf:
   properties:
     appPath:
       type: string
+    awsConnectorRef:
+      type: string
     commandOptions:
       oneOf:
       - type: array
@@ -72,6 +74,8 @@ required:
 - image
 properties:
   appPath:
+    type: string
+  awsConnectorRef:
     type: string
   commandOptions:
     oneOf:

--- a/v0/pipeline/steps/common/aws-cdk-synth-step-info.yaml
+++ b/v0/pipeline/steps/common/aws-cdk-synth-step-info.yaml
@@ -8,6 +8,8 @@ allOf:
   properties:
     appPath:
       type: string
+    awsConnectorRef:
+      type: string
     commandOptions:
       oneOf:
       - type: array
@@ -74,6 +76,8 @@ required:
 - image
 properties:
   appPath:
+    type: string
+  awsConnectorRef:
     type: string
   commandOptions:
     oneOf:

--- a/v0/template.json
+++ b/v0/template.json
@@ -55827,6 +55827,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -55904,6 +55907,9 @@
             "required" : [ "connectorRef", "image" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {
@@ -56057,6 +56063,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -56149,6 +56158,9 @@
             "required" : [ "connectorRef", "image" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {
@@ -56317,6 +56329,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -56406,6 +56421,9 @@
             "required" : [ "connectorRef", "image" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {
@@ -56571,6 +56589,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -56669,6 +56690,9 @@
             "required" : [ "connectorRef", "image", "provisionerIdentifier" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {
@@ -57291,6 +57315,9 @@
                 "appPath" : {
                   "type" : "string"
                 },
+                "awsConnectorRef" : {
+                  "type" : "string"
+                },
                 "commandOptions" : {
                   "oneOf" : [ {
                     "type" : "array",
@@ -57380,6 +57407,9 @@
             "required" : [ "connectorRef", "image" ],
             "properties" : {
               "appPath" : {
+                "type" : "string"
+              },
+              "awsConnectorRef" : {
                 "type" : "string"
               },
               "commandOptions" : {


### PR DESCRIPTION
In CDK steps currently customers have to provide access and secret keys in env variables as shown in screenshot below. 
We want to add a optional connector that if provided can be used to derive these 

![image](https://github.com/user-attachments/assets/962bfbef-78c6-4832-bc1c-93d64b9337eb)
