### PR TITLE
feat: [CDS-105760]: schema changes for ecs traffic shifting

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -38103,7 +38103,7 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn", "stageListener", "stageListenerRuleArn" ],
+              "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn" ],
               "properties" : {
                 "delegateSelectors" : {
                   "oneOf" : [ {
@@ -38158,12 +38158,18 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "stageTargetGroupArn" : {
+                  "type" : "string"
+                },
+                "isTrafficShift" : {
+                  "type" : "boolean"
                 }
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn", "stageListener", "stageListenerRuleArn" ],
+            "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn" ],
             "properties" : {
               "delegateSelectors" : {
                 "oneOf" : [ {
@@ -38218,6 +38224,12 @@
                   "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
+              },
+              "stageTargetGroupArn" : {
+                "type" : "string"
+              },
+              "isTrafficShift" : {
+                "type" : "boolean"
               },
               "description" : {
                 "desc" : "This is the description for EcsBlueGreenCreateServiceStepInfo"
@@ -56479,6 +56491,404 @@
                 } ]
               }
             }
+          },
+          "EcsBlueGreenTrafficShiftStepNode" : {
+            "title" : "EcsBlueGreenTrafficShiftStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for EcsBlueGreenTrafficShiftStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "EcsBlueGreenTrafficShift" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "EcsBlueGreenTrafficShift"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "EcsBlueGreenTrafficShiftStepInfo" : {
+            "title" : "EcsBlueGreenTrafficShiftStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "ecsTrafficShiftWrapper" ],
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "ecsTrafficShiftWrapper" : {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftWrapper"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "ecsTrafficShiftWrapper" ],
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "ecsTrafficShiftWrapper" : {
+                "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftWrapper"
+              },
+              "description" : {
+                "desc" : "This is the description for EcsBlueGreenTrafficShiftStepInfo"
+              }
+            }
+          },
+          "EcsTrafficShiftWrapper" : {
+            "title" : "EcsTrafficShiftWrapper",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Standalone", "Inherit" ]
+              },
+              "description" : {
+                "desc" : "This is the description for EcsTrafficShiftWrapper"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Standalone"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneEcsTrafficShiftSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Inherit"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/InheritEcsTrafficShiftSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneEcsTrafficShiftSpec" : {
+            "title" : "StandAloneEcsTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "loadBalancer", "listener", "listenerRuleArn", "forwardConfig" ],
+              "properties" : {
+                "loadBalancer" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listener" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listenerRuleArn" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "forwardConfig" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/cd/ALBTargetGroupTuple"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for StandAloneEcsTrafficShiftSpec"
+              }
+            }
+          },
+          "EcsTrafficShiftSpec" : {
+            "title" : "EcsTrafficShiftSpec",
+            "type" : "object",
+            "discriminator" : "type",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for EcsTrafficShiftSpec"
+              }
+            }
+          },
+          "ALBTargetGroupTuple" : {
+            "title" : "ALBTargetGroupTuple",
+            "type" : "object",
+            "required" : [ "targetGroupArn", "weight" ],
+            "properties" : {
+              "targetGroupArn" : {
+                "type" : "string",
+                "pattern" : "^(?=\\s*\\S).*$"
+              },
+              "weight" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32",
+                  "minimum" : 0
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ALBTargetGroupTuple"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "InheritEcsTrafficShiftSpec" : {
+            "title" : "InheritEcsTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "weightPercentage" ],
+              "properties" : {
+                "weightPercentage" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32",
+                    "minimum" : 0,
+                    "maximum" : 100
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for InheritEcsTrafficShiftSpec"
+              }
+            }
+          },
+          "StandAloneTrafficShiftRollbackStepNode" : {
+            "title" : "StandAloneTrafficShiftRollbackStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for StandAloneTrafficShiftRollbackStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "StandAloneTrafficShiftRollback" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "StandAloneTrafficShiftRollback"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneTrafficShiftRollbackStepInfo" : {
+            "title" : "StandAloneTrafficShiftRollbackStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for StandAloneTrafficShiftRollbackStepInfo"
+              }
+            }
           }
         },
         "cvng" : {
@@ -61405,6 +61815,10 @@
                   "$ref" : "#/definitions/pipeline/steps/custom/EventListenerStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/HelmDeleteStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepNode"
                 } ]
               },
               "stepGroup" : {

--- a/v0/pipeline/stages/cd/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/cd/execution-wrapper-config.yaml
@@ -172,6 +172,8 @@ properties:
     - $ref: ../../steps/cd/google-cloud-run-job-step-node.yaml
     - $ref: ../../steps/custom/event-listener-step-node.yaml
     - $ref: ../../steps/cd/helm-delete-step-node.yaml
+    - $ref: ../../steps/cd/ecs-blue-green-traffic-shift-step-node.yaml
+    - $ref: ../../steps/cd/stand-alone-traffic-shift-rollback-step-node.yaml
 
   stepGroup:
     $ref: step-group-element-config.yaml

--- a/v0/pipeline/steps/cd/alb-target-group-tuple.yaml
+++ b/v0/pipeline/steps/cd/alb-target-group-tuple.yaml
@@ -1,0 +1,21 @@
+title: ALBTargetGroupTuple
+type: object
+required:
+  - targetGroupArn
+  - weight
+properties:
+  targetGroupArn:
+    type: string
+    pattern: ^(?=\s*\S).*$
+  weight:
+    oneOf:
+      - type: integer
+        format: int32
+        minimum: 0
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  description:
+    type: string
+    desc: This is the description for ALBTargetGroupTuple
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
+++ b/v0/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
@@ -6,8 +6,6 @@ allOf:
   - loadBalancer
   - prodListener
   - prodListenerRuleArn
-  - stageListener
-  - stageListenerRuleArn
   properties:
     delegateSelectors:
       oneOf:
@@ -45,14 +43,16 @@ allOf:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
+    stageTargetGroupArn:
+      type: string
+    isTrafficShift:
+      type: boolean
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
 - loadBalancer
 - prodListener
 - prodListenerRuleArn
-- stageListener
-- stageListenerRuleArn
 properties:
   delegateSelectors:
     oneOf:
@@ -90,5 +90,9 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
+  stageTargetGroupArn:
+      type: string
+  isTrafficShift:
+      type: boolean
   description:
     desc: This is the description for EcsBlueGreenCreateServiceStepInfo

--- a/v0/pipeline/steps/cd/ecs-blue-green-traffic-shift-step-info.yaml
+++ b/v0/pipeline/steps/cd/ecs-blue-green-traffic-shift-step-info.yaml
@@ -1,0 +1,34 @@
+title: EcsBlueGreenTrafficShiftStepInfo
+allOf:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    required:
+      - ecsTrafficShiftWrapper
+    properties:
+      delegateSelectors:
+        oneOf:
+          - type: array
+            items:
+              type: string
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+      ecsTrafficShiftWrapper:
+        $ref: ecs-traffic-shift-wrapper.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+  - ecsTrafficShiftWrapper
+properties:
+  delegateSelectors:
+    oneOf:
+        - type: array
+          items:
+            type: string
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
+  ecsTrafficShiftWrapper:
+    $ref: ecs-traffic-shift-wrapper.yaml
+  description:
+    desc: This is the description for EcsBlueGreenTrafficShiftStepInfo

--- a/v0/pipeline/steps/cd/ecs-blue-green-traffic-shift-step-node.yaml
+++ b/v0/pipeline/steps/cd/ecs-blue-green-traffic-shift-step-node.yaml
@@ -1,0 +1,56 @@
+title: EcsBlueGreenTrafficShiftStepNode
+type: object
+required:
+  - identifier
+  - name
+  - spec
+  - type
+properties:
+  description:
+    type: string
+    desc: This is the description for EcsBlueGreenTrafficShiftStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+      - $ref: ../../common/strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+      - EcsBlueGreenTrafficShift
+  when:
+    oneOf:
+      - $ref: ../../common/step-when-condition.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: EcsBlueGreenTrafficShift
+    then:
+      properties:
+        spec:
+          $ref: ecs-blue-green-traffic-shift-step-info.yaml

--- a/v0/pipeline/steps/cd/ecs-traffic-shift-spec.yaml
+++ b/v0/pipeline/steps/cd/ecs-traffic-shift-spec.yaml
@@ -1,0 +1,7 @@
+title: EcsTrafficShiftSpec
+type: object
+discriminator: type
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for EcsTrafficShiftSpec

--- a/v0/pipeline/steps/cd/ecs-traffic-shift-wrapper.yaml
+++ b/v0/pipeline/steps/cd/ecs-traffic-shift-wrapper.yaml
@@ -1,0 +1,31 @@
+title: EcsTrafficShiftWrapper
+type: object
+required:
+  - spec
+  - type
+properties:
+  type:
+    type: string
+    enum:
+      - Standalone
+      - Inherit
+  description:
+    desc: This is the description for EcsTrafficShiftWrapper
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: Standalone
+    then:
+      properties:
+        spec:
+          $ref: stand-alone-ecs-traffic-shift-spec.yaml
+  - if:
+      properties:
+        type:
+          const: Inherit
+    then:
+      properties:
+        spec:
+          $ref: inherit-ecs-traffic-shift-spec.yaml

--- a/v0/pipeline/steps/cd/inherit-ecs-traffic-shift-spec.yaml
+++ b/v0/pipeline/steps/cd/inherit-ecs-traffic-shift-spec.yaml
@@ -1,0 +1,20 @@
+title: InheritEcsTrafficShiftSpec
+allOf:
+  - $ref: ecs-traffic-shift-spec.yaml
+  - type: object
+    required:
+      - weightPercentage
+    properties:
+      weightPercentage:
+        oneOf:
+          - type: integer
+            format: int32
+            minimum: 0
+            maximum: 100
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for InheritEcsTrafficShiftSpec

--- a/v0/pipeline/steps/cd/stand-alone-ecs-traffic-shift-spec.yaml
+++ b/v0/pipeline/steps/cd/stand-alone-ecs-traffic-shift-spec.yaml
@@ -1,0 +1,31 @@
+title: StandAloneEcsTrafficShiftSpec
+allOf:
+  - $ref: ecs-traffic-shift-spec.yaml
+  - type: object
+    required:
+      - loadBalancer
+      - listener
+      - listenerRuleArn
+      - forwardConfig
+    properties:
+      loadBalancer:
+        type: string
+        pattern: ^(?=\s*\S).*$
+      listener:
+        type: string
+        pattern: ^(?=\s*\S).*$
+      listenerRuleArn:
+        type: string
+        pattern: ^(?=\s*\S).*$
+      forwardConfig:
+        oneOf:
+          - type: array
+            items:
+              $ref: alb-target-group-tuple.yaml
+          - type: string
+            pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|selectOneFrom|default|regex)\(.+?\)))*$
+            minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for StandAloneEcsTrafficShiftSpec

--- a/v0/pipeline/steps/cd/stand-alone-traffic-shift-rollback-step-info.yaml
+++ b/v0/pipeline/steps/cd/stand-alone-traffic-shift-rollback-step-info.yaml
@@ -1,0 +1,26 @@
+title: StandAloneTrafficShiftRollbackStepInfo
+allOf:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    properties:
+      delegateSelectors:
+        oneOf:
+          - type: array
+            items:
+              type: string
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+properties:
+  delegateSelectors:
+    oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  description:
+    desc: This is the description for StandAloneTrafficShiftRollbackStepInfo

--- a/v0/pipeline/steps/cd/stand-alone-traffic-shift-rollback-step-node.yaml
+++ b/v0/pipeline/steps/cd/stand-alone-traffic-shift-rollback-step-node.yaml
@@ -1,0 +1,56 @@
+title: StandAloneTrafficShiftRollbackStepNode
+type: object
+required:
+  - identifier
+  - name
+  - spec
+  - type
+properties:
+  description:
+    type: string
+    desc: This is the description for StandAloneTrafficShiftRollbackStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+      - $ref: ../../common/strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+      - StandAloneTrafficShiftRollback
+  when:
+    oneOf:
+      - $ref: ../../common/step-when-condition.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: StandAloneTrafficShiftRollback
+    then:
+      properties:
+        spec:
+          $ref: stand-alone-traffic-shift-rollback-step-info.yaml

--- a/v0/template.json
+++ b/v0/template.json
@@ -8043,7 +8043,7 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn", "stageListener", "stageListenerRuleArn" ],
+              "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn" ],
               "properties" : {
                 "delegateSelectors" : {
                   "oneOf" : [ {
@@ -8098,12 +8098,18 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "stageTargetGroupArn" : {
+                  "type" : "string"
+                },
+                "isTrafficShift" : {
+                  "type" : "boolean"
                 }
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn", "stageListener", "stageListenerRuleArn" ],
+            "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn" ],
             "properties" : {
               "delegateSelectors" : {
                 "oneOf" : [ {
@@ -8158,6 +8164,12 @@
                   "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
+              },
+              "stageTargetGroupArn" : {
+                "type" : "string"
+              },
+              "isTrafficShift" : {
+                "type" : "boolean"
               },
               "description" : {
                 "desc" : "This is the description for EcsBlueGreenCreateServiceStepInfo"
@@ -34691,6 +34703,404 @@
                 }
               }
             } ]
+          },
+          "EcsBlueGreenTrafficShiftStepNode" : {
+            "title" : "EcsBlueGreenTrafficShiftStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for EcsBlueGreenTrafficShiftStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "EcsBlueGreenTrafficShift" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "EcsBlueGreenTrafficShift"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "EcsBlueGreenTrafficShiftStepInfo" : {
+            "title" : "EcsBlueGreenTrafficShiftStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "ecsTrafficShiftWrapper" ],
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "ecsTrafficShiftWrapper" : {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftWrapper"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "ecsTrafficShiftWrapper" ],
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "ecsTrafficShiftWrapper" : {
+                "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftWrapper"
+              },
+              "description" : {
+                "desc" : "This is the description for EcsBlueGreenTrafficShiftStepInfo"
+              }
+            }
+          },
+          "EcsTrafficShiftWrapper" : {
+            "title" : "EcsTrafficShiftWrapper",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Standalone", "Inherit" ]
+              },
+              "description" : {
+                "desc" : "This is the description for EcsTrafficShiftWrapper"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Standalone"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneEcsTrafficShiftSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Inherit"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/InheritEcsTrafficShiftSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneEcsTrafficShiftSpec" : {
+            "title" : "StandAloneEcsTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "loadBalancer", "listener", "listenerRuleArn", "forwardConfig" ],
+              "properties" : {
+                "loadBalancer" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listener" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listenerRuleArn" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "forwardConfig" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/cd/ALBTargetGroupTuple"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for StandAloneEcsTrafficShiftSpec"
+              }
+            }
+          },
+          "EcsTrafficShiftSpec" : {
+            "title" : "EcsTrafficShiftSpec",
+            "type" : "object",
+            "discriminator" : "type",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for EcsTrafficShiftSpec"
+              }
+            }
+          },
+          "ALBTargetGroupTuple" : {
+            "title" : "ALBTargetGroupTuple",
+            "type" : "object",
+            "required" : [ "targetGroupArn", "weight" ],
+            "properties" : {
+              "targetGroupArn" : {
+                "type" : "string",
+                "pattern" : "^(?=\\s*\\S).*$"
+              },
+              "weight" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32",
+                  "minimum" : 0
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ALBTargetGroupTuple"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "InheritEcsTrafficShiftSpec" : {
+            "title" : "InheritEcsTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "weightPercentage" ],
+              "properties" : {
+                "weightPercentage" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32",
+                    "minimum" : 0,
+                    "maximum" : 100
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for InheritEcsTrafficShiftSpec"
+              }
+            }
+          },
+          "StandAloneTrafficShiftRollbackStepNode" : {
+            "title" : "StandAloneTrafficShiftRollbackStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for StandAloneTrafficShiftRollbackStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "StandAloneTrafficShiftRollback" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "StandAloneTrafficShiftRollback"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneTrafficShiftRollbackStepInfo" : {
+            "title" : "StandAloneTrafficShiftRollbackStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for StandAloneTrafficShiftRollbackStepInfo"
+              }
+            }
           }
         },
         "custom" : {
@@ -78093,6 +78503,10 @@
                   "$ref" : "#/definitions/pipeline/steps/custom/EventListenerStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/HelmDeleteStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepNode"
                 } ]
               },
               "stepGroup" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -1987,6 +1987,10 @@
                   "$ref" : "#/definitions/pipeline/steps/cd/GoogleCloudRunJobStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/HelmDeleteStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepNode"
                 } ]
               },
               "stepGroup" : {
@@ -37472,7 +37476,7 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn", "stageListener", "stageListenerRuleArn" ],
+              "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn" ],
               "properties" : {
                 "delegateSelectors" : {
                   "oneOf" : [ {
@@ -37527,12 +37531,18 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "stageTargetGroupArn" : {
+                  "type" : "string"
+                },
+                "isTrafficShift" : {
+                  "type" : "boolean"
                 }
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn", "stageListener", "stageListenerRuleArn" ],
+            "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn" ],
             "properties" : {
               "delegateSelectors" : {
                 "oneOf" : [ {
@@ -37587,6 +37597,12 @@
                   "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
+              },
+              "stageTargetGroupArn" : {
+                "type" : "string"
+              },
+              "isTrafficShift" : {
+                "type" : "boolean"
               },
               "description" : {
                 "desc" : "This is the description for EcsBlueGreenCreateServiceStepInfo"
@@ -56537,6 +56553,404 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              }
+            }
+          },
+          "EcsBlueGreenTrafficShiftStepNode" : {
+            "title" : "EcsBlueGreenTrafficShiftStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for EcsBlueGreenTrafficShiftStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "EcsBlueGreenTrafficShift" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "EcsBlueGreenTrafficShift"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "EcsBlueGreenTrafficShiftStepInfo" : {
+            "title" : "EcsBlueGreenTrafficShiftStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "ecsTrafficShiftWrapper" ],
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "ecsTrafficShiftWrapper" : {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftWrapper"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "ecsTrafficShiftWrapper" ],
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "ecsTrafficShiftWrapper" : {
+                "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftWrapper"
+              },
+              "description" : {
+                "desc" : "This is the description for EcsBlueGreenTrafficShiftStepInfo"
+              }
+            }
+          },
+          "EcsTrafficShiftWrapper" : {
+            "title" : "EcsTrafficShiftWrapper",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Standalone", "Inherit" ]
+              },
+              "description" : {
+                "desc" : "This is the description for EcsTrafficShiftWrapper"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Standalone"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneEcsTrafficShiftSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Inherit"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/InheritEcsTrafficShiftSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneEcsTrafficShiftSpec" : {
+            "title" : "StandAloneEcsTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "loadBalancer", "listener", "listenerRuleArn", "forwardConfig" ],
+              "properties" : {
+                "loadBalancer" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listener" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listenerRuleArn" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "forwardConfig" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/cd/ALBTargetGroupTuple"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for StandAloneEcsTrafficShiftSpec"
+              }
+            }
+          },
+          "EcsTrafficShiftSpec" : {
+            "title" : "EcsTrafficShiftSpec",
+            "type" : "object",
+            "discriminator" : "type",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for EcsTrafficShiftSpec"
+              }
+            }
+          },
+          "ALBTargetGroupTuple" : {
+            "title" : "ALBTargetGroupTuple",
+            "type" : "object",
+            "required" : [ "targetGroupArn", "weight" ],
+            "properties" : {
+              "targetGroupArn" : {
+                "type" : "string",
+                "pattern" : "^(?=\\s*\\S).*$"
+              },
+              "weight" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32",
+                  "minimum" : 0
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ALBTargetGroupTuple"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "InheritEcsTrafficShiftSpec" : {
+            "title" : "InheritEcsTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "weightPercentage" ],
+              "properties" : {
+                "weightPercentage" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32",
+                    "minimum" : 0,
+                    "maximum" : 100
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for InheritEcsTrafficShiftSpec"
+              }
+            }
+          },
+          "StandAloneTrafficShiftRollbackStepNode" : {
+            "title" : "StandAloneTrafficShiftRollbackStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for StandAloneTrafficShiftRollbackStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "StandAloneTrafficShiftRollback" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "StandAloneTrafficShiftRollback"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneTrafficShiftRollbackStepInfo" : {
+            "title" : "StandAloneTrafficShiftRollbackStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for StandAloneTrafficShiftRollbackStepInfo"
               }
             }
           }

--- a/v1/pipeline/stages/cd/execution-wrapper-config.yaml
+++ b/v1/pipeline/stages/cd/execution-wrapper-config.yaml
@@ -162,6 +162,8 @@ properties:
     - $ref: ../../steps/cd/google-cloud-run-rollback-step-node.yaml
     - $ref: ../../steps/cd/google-cloud-run-job-step-node.yaml
     - $ref: ../../steps/cd/helm-delete-step-node.yaml
+    - $ref: ../../steps/cd/ecs-blue-green-traffic-shift-step-node.yaml
+    - $ref: ../../steps/cd/stand-alone-traffic-shift-rollback-step-node.yaml
 
   stepGroup:
     $ref: step-group-element-config.yaml

--- a/v1/pipeline/steps/cd/alb-target-group-tuple.yaml
+++ b/v1/pipeline/steps/cd/alb-target-group-tuple.yaml
@@ -1,0 +1,21 @@
+title: ALBTargetGroupTuple
+type: object
+required:
+  - targetGroupArn
+  - weight
+properties:
+  targetGroupArn:
+    type: string
+    pattern: ^(?=\s*\S).*$
+  weight:
+    oneOf:
+      - type: integer
+        format: int32
+        minimum: 0
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  description:
+    type: string
+    desc: This is the description for ALBTargetGroupTuple
+$schema: http://json-schema.org/draft-07/schema#

--- a/v1/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
+++ b/v1/pipeline/steps/cd/ecs-blue-green-create-service-step-info.yaml
@@ -6,8 +6,6 @@ allOf:
   - loadBalancer
   - prodListener
   - prodListenerRuleArn
-  - stageListener
-  - stageListenerRuleArn
   properties:
     delegateSelectors:
       oneOf:
@@ -45,14 +43,16 @@ allOf:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
+    stageTargetGroupArn:
+      type: string
+    isTrafficShift:
+      type: boolean
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
 - loadBalancer
 - prodListener
 - prodListenerRuleArn
-- stageListener
-- stageListenerRuleArn
 properties:
   delegateSelectors:
     oneOf:
@@ -90,5 +90,9 @@ properties:
     - type: string
       pattern: (<\+.+>.*)
       minLength: 1
+  stageTargetGroupArn:
+    type: string
+  isTrafficShift:
+    type: boolean
   description:
     desc: This is the description for EcsBlueGreenCreateServiceStepInfo

--- a/v1/pipeline/steps/cd/ecs-blue-green-traffic-shift-step-info.yaml
+++ b/v1/pipeline/steps/cd/ecs-blue-green-traffic-shift-step-info.yaml
@@ -1,0 +1,34 @@
+title: EcsBlueGreenTrafficShiftStepInfo
+allOf:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    required:
+      - ecsTrafficShiftWrapper
+    properties:
+      delegateSelectors:
+        oneOf:
+          - type: array
+            items:
+              type: string
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+      ecsTrafficShiftWrapper:
+        $ref: ecs-traffic-shift-wrapper.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+  - ecsTrafficShiftWrapper
+properties:
+  delegateSelectors:
+    oneOf:
+        - type: array
+          items:
+            type: string
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
+  ecsTrafficShiftWrapper:
+    $ref: ecs-traffic-shift-wrapper.yaml
+  description:
+    desc: This is the description for EcsBlueGreenTrafficShiftStepInfo

--- a/v1/pipeline/steps/cd/ecs-blue-green-traffic-shift-step-node.yaml
+++ b/v1/pipeline/steps/cd/ecs-blue-green-traffic-shift-step-node.yaml
@@ -1,0 +1,56 @@
+title: EcsBlueGreenTrafficShiftStepNode
+type: object
+required:
+  - identifier
+  - name
+  - spec
+  - type
+properties:
+  description:
+    type: string
+    desc: This is the description for EcsBlueGreenTrafficShiftStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+      - $ref: ../../common/strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+      - EcsBlueGreenTrafficShift
+  when:
+    oneOf:
+      - $ref: ../../common/step-when-condition.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: EcsBlueGreenTrafficShift
+    then:
+      properties:
+        spec:
+          $ref: ecs-blue-green-traffic-shift-step-info.yaml

--- a/v1/pipeline/steps/cd/ecs-traffic-shift-spec.yaml
+++ b/v1/pipeline/steps/cd/ecs-traffic-shift-spec.yaml
@@ -1,0 +1,7 @@
+title: EcsTrafficShiftSpec
+type: object
+discriminator: type
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for EcsTrafficShiftSpec

--- a/v1/pipeline/steps/cd/ecs-traffic-shift-wrapper.yaml
+++ b/v1/pipeline/steps/cd/ecs-traffic-shift-wrapper.yaml
@@ -1,0 +1,31 @@
+title: EcsTrafficShiftWrapper
+type: object
+required:
+  - spec
+  - type
+properties:
+  type:
+    type: string
+    enum:
+      - Standalone
+      - Inherit
+  description:
+    desc: This is the description for EcsTrafficShiftWrapper
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: Standalone
+    then:
+      properties:
+        spec:
+          $ref: stand-alone-ecs-traffic-shift-spec.yaml
+  - if:
+      properties:
+        type:
+          const: Inherit
+    then:
+      properties:
+        spec:
+          $ref: inherit-ecs-traffic-shift-spec.yaml

--- a/v1/pipeline/steps/cd/inherit-ecs-traffic-shift-spec.yaml
+++ b/v1/pipeline/steps/cd/inherit-ecs-traffic-shift-spec.yaml
@@ -1,0 +1,20 @@
+title: InheritEcsTrafficShiftSpec
+allOf:
+  - $ref: ecs-traffic-shift-spec.yaml
+  - type: object
+    required:
+      - weightPercentage
+    properties:
+      weightPercentage:
+        oneOf:
+          - type: integer
+            format: int32
+            minimum: 0
+            maximum: 100
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for InheritEcsTrafficShiftSpec

--- a/v1/pipeline/steps/cd/stand-alone-ecs-traffic-shift-spec.yaml
+++ b/v1/pipeline/steps/cd/stand-alone-ecs-traffic-shift-spec.yaml
@@ -1,0 +1,31 @@
+title: StandAloneEcsTrafficShiftSpec
+allOf:
+  - $ref: ecs-traffic-shift-spec.yaml
+  - type: object
+    required:
+      - loadBalancer
+      - listener
+      - listenerRuleArn
+      - forwardConfig
+    properties:
+      loadBalancer:
+        type: string
+        pattern: ^(?=\s*\S).*$
+      listener:
+        type: string
+        pattern: ^(?=\s*\S).*$
+      listenerRuleArn:
+        type: string
+        pattern: ^(?=\s*\S).*$
+      forwardConfig:
+        oneOf:
+          - type: array
+            items:
+              $ref: alb-target-group-tuple.yaml
+          - type: string
+            pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|selectOneFrom|default|regex)\(.+?\)))*$
+            minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for StandAloneEcsTrafficShiftSpec

--- a/v1/pipeline/steps/cd/stand-alone-traffic-shift-rollback-step-info.yaml
+++ b/v1/pipeline/steps/cd/stand-alone-traffic-shift-rollback-step-info.yaml
@@ -1,0 +1,26 @@
+title: StandAloneTrafficShiftRollbackStepInfo
+allOf:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    properties:
+      delegateSelectors:
+        oneOf:
+          - type: array
+            items:
+              type: string
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+properties:
+  delegateSelectors:
+    oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  description:
+    desc: This is the description for StandAloneTrafficShiftRollbackStepInfo

--- a/v1/pipeline/steps/cd/stand-alone-traffic-shift-rollback-step-node.yaml
+++ b/v1/pipeline/steps/cd/stand-alone-traffic-shift-rollback-step-node.yaml
@@ -1,0 +1,56 @@
+title: StandAloneTrafficShiftRollbackStepNode
+type: object
+required:
+  - identifier
+  - name
+  - spec
+  - type
+properties:
+  description:
+    type: string
+    desc: This is the description for StandAloneTrafficShiftRollbackStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+      - $ref: ../../common/strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+      - StandAloneTrafficShiftRollback
+  when:
+    oneOf:
+      - $ref: ../../common/step-when-condition.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: StandAloneTrafficShiftRollback
+    then:
+      properties:
+        spec:
+          $ref: stand-alone-traffic-shift-rollback-step-info.yaml

--- a/v1/template.json
+++ b/v1/template.json
@@ -9818,7 +9818,7 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn", "stageListener", "stageListenerRuleArn" ],
+              "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn" ],
               "properties" : {
                 "delegateSelectors" : {
                   "oneOf" : [ {
@@ -9873,12 +9873,18 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "stageTargetGroupArn" : {
+                  "type" : "string"
+                },
+                "isTrafficShift" : {
+                  "type" : "boolean"
                 }
               }
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn", "stageListener", "stageListenerRuleArn" ],
+            "required" : [ "loadBalancer", "prodListener", "prodListenerRuleArn" ],
             "properties" : {
               "delegateSelectors" : {
                 "oneOf" : [ {
@@ -9933,6 +9939,12 @@
                   "pattern" : "(<\\+.+>.*)",
                   "minLength" : 1
                 } ]
+              },
+              "stageTargetGroupArn" : {
+                "type" : "string"
+              },
+              "isTrafficShift" : {
+                "type" : "boolean"
               },
               "description" : {
                 "desc" : "This is the description for EcsBlueGreenCreateServiceStepInfo"
@@ -37144,6 +37156,404 @@
                   "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
                   "minLength" : 1
                 } ]
+              }
+            }
+          },
+          "EcsBlueGreenTrafficShiftStepNode" : {
+            "title" : "EcsBlueGreenTrafficShiftStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for EcsBlueGreenTrafficShiftStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "EcsBlueGreenTrafficShift" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "EcsBlueGreenTrafficShift"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "EcsBlueGreenTrafficShiftStepInfo" : {
+            "title" : "EcsBlueGreenTrafficShiftStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "ecsTrafficShiftWrapper" ],
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "ecsTrafficShiftWrapper" : {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftWrapper"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "ecsTrafficShiftWrapper" ],
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "ecsTrafficShiftWrapper" : {
+                "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftWrapper"
+              },
+              "description" : {
+                "desc" : "This is the description for EcsBlueGreenTrafficShiftStepInfo"
+              }
+            }
+          },
+          "EcsTrafficShiftWrapper" : {
+            "title" : "EcsTrafficShiftWrapper",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Standalone", "Inherit" ]
+              },
+              "description" : {
+                "desc" : "This is the description for EcsTrafficShiftWrapper"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Standalone"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneEcsTrafficShiftSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Inherit"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/InheritEcsTrafficShiftSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneEcsTrafficShiftSpec" : {
+            "title" : "StandAloneEcsTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "loadBalancer", "listener", "listenerRuleArn", "forwardConfig" ],
+              "properties" : {
+                "loadBalancer" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listener" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listenerRuleArn" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "forwardConfig" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/cd/ALBTargetGroupTuple"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for StandAloneEcsTrafficShiftSpec"
+              }
+            }
+          },
+          "EcsTrafficShiftSpec" : {
+            "title" : "EcsTrafficShiftSpec",
+            "type" : "object",
+            "discriminator" : "type",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for EcsTrafficShiftSpec"
+              }
+            }
+          },
+          "ALBTargetGroupTuple" : {
+            "title" : "ALBTargetGroupTuple",
+            "type" : "object",
+            "required" : [ "targetGroupArn", "weight" ],
+            "properties" : {
+              "targetGroupArn" : {
+                "type" : "string",
+                "pattern" : "^(?=\\s*\\S).*$"
+              },
+              "weight" : {
+                "oneOf" : [ {
+                  "type" : "integer",
+                  "format" : "int32",
+                  "minimum" : 0
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ALBTargetGroupTuple"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
+          },
+          "InheritEcsTrafficShiftSpec" : {
+            "title" : "InheritEcsTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/EcsTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "weightPercentage" ],
+              "properties" : {
+                "weightPercentage" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32",
+                    "minimum" : 0,
+                    "maximum" : 100
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for InheritEcsTrafficShiftSpec"
+              }
+            }
+          },
+          "StandAloneTrafficShiftRollbackStepNode" : {
+            "title" : "StandAloneTrafficShiftRollbackStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for StandAloneTrafficShiftRollbackStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "StandAloneTrafficShiftRollback" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "StandAloneTrafficShiftRollback"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneTrafficShiftRollbackStepInfo" : {
+            "title" : "StandAloneTrafficShiftRollbackStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for StandAloneTrafficShiftRollbackStepInfo"
               }
             }
           }
@@ -69478,6 +69888,10 @@
                   "$ref" : "#/definitions/pipeline/steps/cd/GoogleCloudRunJobStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/HelmDeleteStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepNode"
                 } ]
               },
               "stepGroup" : {


### PR DESCRIPTION
Tech Spec: https://harness.atlassian.net/wiki/spaces/CDNG/pages/22178104525/Tech+Spec+Support+Traffic+shift+during+ECS+BG+deployment#LLD-for-Final-Proposal-for-dual-BG-traffic-shifting-step-in-ECS

Functional PR: https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/PROD/projects/Harness_Commons/repos/harness-core/pulls/101735

ECS Traffic Shift Step
- `ecsTrafficShiftWrapper` is required. 
- `type` and `spec` are required in `ecsTrafficShiftWrapper`
- `type` can be only ` "Standalone", "Inherit"`
-  **Inherit**: 
 `weightPercentage` required for inherit , can be between 0 to 100 inclusive only for fixed value, or runtime input or expression
- **StandAlone**: 
`loadBalancer` : required, blank value not allowed or runtime input or expression
`listener` : required, blank value not allowed or runtime input or expression
`listenerRuleArn` : required, blank value not allowed or runtime input or expression
`forwardConfig` : required, runtime input but not expression or list of `ALBTargetGroupTuple`
- ALBTargetGroupTuple: 
   `targetGroupArn`  required, blank value not allowed or runtime input or expression
    `weight` required, runtime input or expression or fixed integer with min value 0
 
Stand Alone Traffic Shift Rollback - no parameters

Ecs Create Service Step (Existing) : 
- `stageListener` optional now 
- `stageListenerRuleArn` optional now 
- added optional field `isTrafficShift` only accepts true or false 
- added optional field `stageTargetGroupArn` (ficed/runtime input/ expressson)

Checked the new yaml in templates as well. 

Example: 
```
          - step:
              name: EcsBlueGreenTrafficShift
              identifier: EcsBlueGreenTrafficShiftInherit
              type: EcsBlueGreenTrafficShift
              timeout: 15m
              spec:
                ecsTrafficShiftWrapper:
                  type: Inherit
                  spec:
                    weightPercentage: 0
          - step:
              name: EcsBlueGreenTrafficShift
              identifier: EcsBlueGreenTrafficShiftStandalone
              type: EcsBlueGreenTrafficShift
              timeout: 15m
              spec:
                ecsTrafficShiftWrapper:
                  type: Standalone
                  spec:
                    loadBalancer: ecs-donot-delete-todolist
                    listenerRuleArn: arn:aws:elasticloadbalancing:us-east-1:479370281431:listener-rule/app/ecs-donot-delete-todolist/cd74c728114bef78/1974e8b6a03b83a7/77eb261cc0db12c4
                    listener: arn:aws:elasticloadbalancing:us-east-1:479370281431:listener/app/ecs-donot-delete-todolist/cd74c728114bef78/1974e8b6a03b83a7
                    forwardConfig: <+input>
        rollbackSteps:
          - step:
              name: ECS Blue Green Rollback
              identifier: EcsBlueGreenRollback
              type: EcsBlueGreenRollback
              timeout: 10m
              spec: {}
          - step:
              name: StandAloneTrafficShiftRollback
              identifier: StandAloneTrafficShiftRollback
              type: StandAloneTrafficShiftRollback
              timeout: 10m
              spec: {}
```
