### PR TITLE
feat:[SSCA-3580]: Added auto and manual detection for Non Container Artifact Signing and Aritfact Verification

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -18181,16 +18181,42 @@
               "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "workspace" ],
+              "required" : [ "workspace", "type" ],
               "properties" : {
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "manual", "auto" ]
+                },
                 "workspace" : {
                   "type" : "string"
                 },
                 "artifact_name" : {
-                  "type" : "string"
+                  "type" : "string",
+                  "description" : "Required when type is manual",
+                  "if" : {
+                    "properties" : {
+                      "type" : {
+                        "const" : "manual"
+                      }
+                    }
+                  },
+                  "then" : {
+                    "minLength" : 1
+                  }
                 },
                 "version" : {
-                  "type" : "string"
+                  "type" : "string",
+                  "description" : "Required when type is manual",
+                  "if" : {
+                    "properties" : {
+                      "type" : {
+                        "const" : "manual"
+                      }
+                    }
+                  },
+                  "then" : {
+                    "minLength" : 1
+                  }
                 }
               }
             } ],

--- a/v0/pipeline/steps/common/local-source-spec.yaml
+++ b/v0/pipeline/steps/common/local-source-spec.yaml
@@ -4,13 +4,33 @@ allOf:
   - type: object
     required:
       - workspace
+      - type
     properties:
+      type:
+        type: string
+        enum:
+          - manual
+          - auto
       workspace:
         type: string
       artifact_name:
         type: string
+        description: Required when type is manual
+        if:
+          properties:
+            type:
+              const: manual
+        then:
+          minLength: 1
       version:
         type: string
+        description: Required when type is manual
+        if:
+          properties:
+            type:
+              const: manual
+        then:
+          minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/template.json
+++ b/v0/template.json
@@ -58978,16 +58978,42 @@
               "$ref" : "#/definitions/pipeline/steps/common/ArtifactSigningSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "workspace" ],
+              "required" : [ "workspace", "type" ],
               "properties" : {
+                "type" : {
+                  "type" : "string",
+                  "enum" : [ "manual", "auto" ]
+                },
                 "workspace" : {
                   "type" : "string"
                 },
                 "artifact_name" : {
-                  "type" : "string"
+                  "type" : "string",
+                  "description" : "Required when type is manual",
+                  "if" : {
+                    "properties" : {
+                      "type" : {
+                        "const" : "manual"
+                      }
+                    }
+                  },
+                  "then" : {
+                    "minLength" : 1
+                  }
                 },
                 "version" : {
-                  "type" : "string"
+                  "type" : "string",
+                  "description" : "Required when type is manual",
+                  "if" : {
+                    "properties" : {
+                      "type" : {
+                        "const" : "manual"
+                      }
+                    }
+                  },
+                  "then" : {
+                    "minLength" : 1
+                  }
                 }
               }
             } ],


### PR DESCRIPTION
This pull request includes changes to the JSON schema definitions and YAML specifications to introduce a new `type` property with conditional requirements for `artifact_name` and `version` properties. The most important changes are as follows:

### Schema Updates:

* [`v0/pipeline.json`](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L18184-R18219): Added a new `type` property with `manual` and `auto` options to the required properties list. Introduced conditional requirements for `artifact_name` and `version` properties when `type` is `manual`.
* [`v0/template.json`](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL58981-R59016): Similar to changes in `v0/pipeline.json`, added a new `type` property and conditional requirements for `artifact_name` and `version` properties.

### YAML Specification Updates:

* [`v0/pipeline/steps/common/local-source-spec.yaml`](diffhunk://#diff-02f13fd3789eaeb144be408c65e6b3be706eb401741927b8ff87a975a03db81aR7-R33): Added a new `type` property with `manual` and `auto` options to the required properties list. Introduced conditional requirements for `artifact_name` and `version` properties when `type` is `manual`.