### PR TITLE
feat:[CDS-108186]: Add flag in harness helm deployment steps to skip helm install

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -30865,6 +30865,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -30891,6 +30902,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {
@@ -54956,6 +54978,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -54982,6 +55015,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {
@@ -55220,6 +55264,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -55250,6 +55305,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {

--- a/v0/pipeline/steps/cd/helm-canary-step-info.yaml
+++ b/v0/pipeline/steps/cd/helm-canary-step-info.yaml
@@ -26,6 +26,13 @@ allOf:
           - type: string
             pattern: (<\+.+>.*)
             minLength: 1
+      useUpgradeInstall:
+        oneOf:
+        - $ref: parameter-field-boolean.yaml
+        - type: boolean
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -52,5 +59,12 @@ properties:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
+  useUpgradeInstall:
+    oneOf:
+    - $ref: parameter-field-boolean.yaml
+    - type: boolean
+    - type: string
+      pattern: (<\+.+>.*)
+      minLength: 1
   description:
     desc: This is the description for HelmCanaryDeployStepInfo

--- a/v0/pipeline/steps/cd/helm-deploy-step-info.yaml
+++ b/v0/pipeline/steps/cd/helm-deploy-step-info.yaml
@@ -22,6 +22,13 @@ allOf:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
+    useUpgradeInstall:
+      oneOf:
+      - $ref: parameter-field-boolean.yaml
+      - type: boolean
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -38,6 +45,13 @@ properties:
     - type: boolean
     - type: string
   skipSteadyStateCheck:
+    oneOf:
+    - $ref: parameter-field-boolean.yaml
+    - type: boolean
+    - type: string
+      pattern: (<\+.+>.*)
+      minLength: 1
+  useUpgradeInstall:
     oneOf:
     - $ref: parameter-field-boolean.yaml
     - type: boolean

--- a/v0/pipeline/steps/cd/helm-stage-step-info.yaml
+++ b/v0/pipeline/steps/cd/helm-stage-step-info.yaml
@@ -22,6 +22,13 @@ allOf:
           - type: string
             pattern: (<\+.+>.*)
             minLength: 1
+      useUpgradeInstall:
+        oneOf:
+        - $ref: parameter-field-boolean.yaml
+        - type: boolean
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -44,5 +51,12 @@ properties:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
+  useUpgradeInstall:
+    oneOf:
+    - $ref: parameter-field-boolean.yaml
+    - type: boolean
+    - type: string
+      pattern: (<\+.+>.*)
+      minLength: 1
   description:
     desc: This is the description for HelmBlueGreenStepInfo

--- a/v0/template.json
+++ b/v0/template.json
@@ -11162,6 +11162,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -11188,6 +11199,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {
@@ -34075,6 +34097,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -34101,6 +34134,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {
@@ -34339,6 +34383,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -34369,6 +34424,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -30340,6 +30340,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -30366,6 +30377,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {
@@ -54990,6 +55012,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -55016,6 +55049,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {
@@ -55254,6 +55298,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -55284,6 +55339,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {

--- a/v1/pipeline/steps/cd/helm-canary-step-info.yaml
+++ b/v1/pipeline/steps/cd/helm-canary-step-info.yaml
@@ -26,6 +26,13 @@ allOf:
           - type: string
             pattern: (<\+.+>.*)
             minLength: 1
+      useUpgradeInstall:
+        oneOf:
+        - $ref: parameter-field-boolean.yaml
+        - type: boolean
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:
@@ -52,5 +59,12 @@ properties:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
+  useUpgradeInstall:
+    oneOf:
+    - $ref: parameter-field-boolean.yaml
+    - type: boolean
+    - type: string
+      pattern: (<\+.+>.*)
+      minLength: 1
   description:
     desc: This is the description for HelmCanaryDeployStepInfo

--- a/v1/pipeline/steps/cd/helm-deploy-step-info.yaml
+++ b/v1/pipeline/steps/cd/helm-deploy-step-info.yaml
@@ -22,6 +22,13 @@ allOf:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
+    useUpgradeInstall:
+      oneOf:
+      - $ref: parameter-field-boolean.yaml
+      - type: boolean
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -38,6 +45,13 @@ properties:
     - type: boolean
     - type: string
   skipSteadyStateCheck:
+    oneOf:
+    - $ref: parameter-field-boolean.yaml
+    - type: boolean
+    - type: string
+      pattern: (<\+.+>.*)
+      minLength: 1
+  useUpgradeInstall:
     oneOf:
     - $ref: parameter-field-boolean.yaml
     - type: boolean

--- a/v1/pipeline/steps/cd/helm-stage-step-info.yaml
+++ b/v1/pipeline/steps/cd/helm-stage-step-info.yaml
@@ -22,6 +22,13 @@ allOf:
           - type: string
             pattern: (<\+.+>.*)
             minLength: 1
+      useUpgradeInstall:
+        oneOf:
+        - $ref: parameter-field-boolean.yaml
+        - type: boolean
+        - type: string
+          pattern: (<\+.+>.*)
+          minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 properties:
@@ -44,5 +51,12 @@ properties:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
+  useUpgradeInstall:
+    oneOf:
+    - $ref: parameter-field-boolean.yaml
+    - type: boolean
+    - type: string
+      pattern: (<\+.+>.*)
+      minLength: 1
   description:
     desc: This is the description for HelmBlueGreenStepInfo

--- a/v1/template.json
+++ b/v1/template.json
@@ -12937,6 +12937,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -12963,6 +12974,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {
@@ -36281,6 +36303,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -36307,6 +36340,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {
@@ -36545,6 +36589,17 @@
                     "pattern" : "(<\\+.+>.*)",
                     "minLength" : 1
                   } ]
+                },
+                "useUpgradeInstall" : {
+                  "oneOf" : [ {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                  }, {
+                    "type" : "boolean"
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],
@@ -36575,6 +36630,17 @@
                 } ]
               },
               "skipSteadyStateCheck" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
+                }, {
+                  "type" : "boolean"
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "useUpgradeInstall" : {
                 "oneOf" : [ {
                   "$ref" : "#/definitions/pipeline/steps/cd/ParameterFieldBoolean"
                 }, {


### PR DESCRIPTION
- Allow users to specify, using a step flag, whether Helm should use the CLI `helm install` command or `helm upgrade --install` for service deployment.
- Named the new flag "**Use Upgrade with Install**" which easily describes what backend is doing