### PR TITLE
feat:[SSCA-3653]: Make artifact digest not required field in SLSA Generation Schema

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -25102,7 +25102,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "repo", "digest", "connector" ],
+              "required" : [ "repo", "connector" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -25138,7 +25138,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "projectID", "imageName", "digest" ],
+              "required" : [ "connector", "host", "projectID", "imageName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -25170,7 +25170,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "image", "digest", "connector" ],
+              "required" : [ "image", "connector" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -25202,7 +25202,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "repository", "digest" ],
+              "required" : [ "connector", "repository" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -25231,7 +25231,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "projectID", "imageName", "digest" ],
+              "required" : [ "connector", "host", "projectID", "imageName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -25263,7 +25263,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "registry", "image", "digest" ],
+              "required" : [ "registry", "image" ],
               "properties" : {
                 "registry" : {
                   "type" : "string"

--- a/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-acr-source-spec.yaml
@@ -5,7 +5,6 @@ allOf:
     required:
       - connector
       - repository
-      - digest
     properties:
       connector:
         type: string

--- a/v0/pipeline/steps/common/provenance-docker-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-docker-source-spec.yaml
@@ -4,7 +4,6 @@ allOf:
 - type: object
   required:
     - repo
-    - digest
     - connector
   properties:
     connector:

--- a/v0/pipeline/steps/common/provenance-ecr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-ecr-source-spec.yaml
@@ -4,7 +4,6 @@ allOf:
   - type: object
     required:
       - image
-      - digest
       - connector
     properties:
       connector:

--- a/v0/pipeline/steps/common/provenance-gar-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-gar-source-spec.yaml
@@ -7,7 +7,6 @@ allOf:
   - host
   - projectID
   - imageName
-  - digest
   properties:
     connector:
       type: string

--- a/v0/pipeline/steps/common/provenance-gcr-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-gcr-source-spec.yaml
@@ -7,7 +7,6 @@ allOf:
   - host
   - projectID
   - imageName
-  - digest
   properties:
     connector:
       type: string

--- a/v0/pipeline/steps/common/provenance-har-source-spec.yaml
+++ b/v0/pipeline/steps/common/provenance-har-source-spec.yaml
@@ -5,7 +5,6 @@ allOf:
   required:
     - registry
     - image
-    - digest
   properties:
     registry:
       type: string

--- a/v0/template.json
+++ b/v0/template.json
@@ -59826,7 +59826,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "repo", "digest", "connector" ],
+              "required" : [ "repo", "connector" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -59862,7 +59862,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "projectID", "imageName", "digest" ],
+              "required" : [ "connector", "host", "projectID", "imageName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -59894,7 +59894,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "image", "digest", "connector" ],
+              "required" : [ "image", "connector" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -59926,7 +59926,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "repository", "digest" ],
+              "required" : [ "connector", "repository" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -59955,7 +59955,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "connector", "host", "projectID", "imageName", "digest" ],
+              "required" : [ "connector", "host", "projectID", "imageName" ],
               "properties" : {
                 "connector" : {
                   "type" : "string"
@@ -59987,7 +59987,7 @@
               "$ref" : "#/definitions/pipeline/steps/common/ProvenanceSourceSpec"
             }, {
               "type" : "object",
-              "required" : [ "registry", "image", "digest" ],
+              "required" : [ "registry", "image" ],
               "properties" : {
                 "registry" : {
                   "type" : "string"


### PR DESCRIPTION
This pull request includes changes to multiple JSON and YAML files to remove the `digest` field from the `required` properties in various provenance source specifications. These changes are aimed at simplifying the required fields for different provenance source types.

The most important changes include:

### Changes in `v0/pipeline.json`:

* Removed `digest` from the required properties of the provenance source specifications for various objects. [[1]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L25105-R25105) [[2]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L25141-R25141) [[3]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L25173-R25173) [[4]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L25205-R25205) [[5]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L25234-R25234) [[6]](diffhunk://#diff-47707a8e6ec1ce8b8accc4042a2a481d7326e615194d86699b01aa0c5d8abab2L25266-R25266)

### Changes in `v0/pipeline/steps/common`:

* [`provenance-acr-source-spec.yaml`](diffhunk://#diff-215d91001901ef448c2bd0eba2f4d519f04c6a987502716ae84de153e6170d6dL8): Removed `digest` from the required properties.
* [`provenance-docker-source-spec.yaml`](diffhunk://#diff-53a816bee8994fb1e4ad6168682f8b141dbc4d904cc6310c806de0c8511cc624L7): Removed `digest` from the required properties.
* [`provenance-ecr-source-spec.yaml`](diffhunk://#diff-0bc876b2cee87bbcc0230d8a90257018e482786a5c7506bf88521bda869e16dbL7): Removed `digest` from the required properties.
* [`provenance-gar-source-spec.yaml`](diffhunk://#diff-1be3985dfa908ff0732e94e2afdf7d29ea0eb2aa211b2caf9ab000335bc311eeL10): Removed `digest` from the required properties.
* [`provenance-gcr-source-spec.yaml`](diffhunk://#diff-509e635525161ba1294d37049f263981683909d265d2c3201dc5ebcca48c17bbL10): Removed `digest` from the required properties.
* [`provenance-har-source-spec.yaml`](diffhunk://#diff-4103f712fabb1a201b3d3ce1f4b1563084af2c90e99d77d2cf0b4a1b0871d46dL8): Removed `digest` from the required properties.

### Changes in `v0/template.json`:

* Removed `digest` from the required properties of the provenance source specifications for various objects. [[1]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL59829-R59829) [[2]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL59865-R59865) [[3]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL59897-R59897) [[4]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL59929-R59929) [[5]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL59958-R59958) [[6]](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cL59990-R59990)