### PR TITLE
feat: [IAC-3519]: Add defaultPipelines to workspace template schema

### DIFF
--- a/v0/template.json
+++ b/v0/template.json
@@ -1225,6 +1225,26 @@
                       }
                     }
                   }
+                },
+                "defaultPipelines" : {
+                  "type" : "object",
+                  "properties" : {
+                    "plan" : {
+                      "type" : "string"
+                    },
+                    "apply" : {
+                      "type" : "string"
+                    },
+                    "destroy" : {
+                      "type" : "string"
+                    },
+                    "drift" : {
+                      "type" : "string"
+                    },
+                    "locked" : {
+                      "type" : "boolean"
+                    }
+                  }
                 }
               }
             }

--- a/v0/template/workspace/template.yaml
+++ b/v0/template/workspace/template.yaml
@@ -131,3 +131,16 @@ properties:
               type: boolean
             locked:
               type: boolean
+      defaultPipelines:
+        type: object
+        properties:
+          plan:
+            type: string
+          apply:
+            type: string
+          destroy:
+            type: string
+          drift:
+            type: string
+          locked:
+            type: boolean

--- a/v1/template.json
+++ b/v1/template.json
@@ -1363,6 +1363,26 @@
                       }
                     }
                   }
+                },
+                "defaultPipelines" : {
+                  "type" : "object",
+                  "properties" : {
+                    "plan" : {
+                      "type" : "string"
+                    },
+                    "apply" : {
+                      "type" : "string"
+                    },
+                    "destroy" : {
+                      "type" : "string"
+                    },
+                    "drift" : {
+                      "type" : "string"
+                    },
+                    "locked" : {
+                      "type" : "boolean"
+                    }
+                  }
                 }
               }
             }

--- a/v1/template/workspace/template.yaml
+++ b/v1/template/workspace/template.yaml
@@ -131,3 +131,16 @@ properties:
               type: boolean
             locked:
               type: boolean
+      defaultPipelines:
+        type: object
+        properties:
+          plan:
+            type: string
+          apply:
+            type: string
+          destroy:
+            type: string
+          drift:
+            type: string
+          locked:
+            type: boolean


### PR DESCRIPTION
This pull request introduces a new `defaultPipelines` object to the schema definitions in both `v0` and `v1` templates. This object defines properties related to pipeline configurations, such as `plan`, `apply`, `destroy`, `drift`, and `locked`. These changes ensure consistency across JSON and YAML schema files for both versions.

### Schema Updates for `defaultPipelines`:

* **`v0/template.json`**: Added a `defaultPipelines` object with properties (`plan`, `apply`, `destroy`, `drift`, `locked`) to the schema.
* **`v0/template/workspace/template.yaml`**: Mirrored the `defaultPipelines` object and its properties in the YAML schema.
* **`v1/template.json`**: Introduced the `defaultPipelines` object with the same properties as in `v0/template.json`.
* **`v1/template/workspace/template.yaml`**: Added the `defaultPipelines` object and properties to the YAML schema for `v1`.