### PR TITLE
feat: [CDS-109193]: Spot traffic shifting schema changes for existing steps

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -42051,7 +42051,7 @@
               "$ref" : "#/definitions/pipeline/steps/cd/LoadBalancerSpec"
             }, {
               "type" : "object",
-              "required" : [ "loadBalancer", "prodListenerPort", "prodListenerRuleArn", "stageListenerPort", "stageListenerRuleArn" ],
+              "required" : [ "loadBalancer", "prodListenerPort", "prodListenerRuleArn" ],
               "properties" : {
                 "loadBalancer" : {
                   "type" : "string"
@@ -42067,6 +42067,12 @@
                 },
                 "stageListenerRuleArn" : {
                   "type" : "string"
+                },
+                "stageTargetGroupArn" : {
+                  "type" : "string"
+                },
+                "isTrafficShift" : {
+                  "type" : "boolean"
                 }
               }
             } ],

--- a/v0/pipeline/steps/cd/aws-load-balancer-config-yaml.yaml
+++ b/v0/pipeline/steps/cd/aws-load-balancer-config-yaml.yaml
@@ -6,8 +6,6 @@ allOf:
   - loadBalancer
   - prodListenerPort
   - prodListenerRuleArn
-  - stageListenerPort
-  - stageListenerRuleArn
   properties:
     loadBalancer:
       type: string
@@ -19,6 +17,10 @@ allOf:
       type: string
     stageListenerRuleArn:
       type: string
+    stageTargetGroupArn:
+      type: string
+    isTrafficShift:
+      type: boolean
 $schema: http://json-schema.org/draft-07/schema#
 properties:
   description:

--- a/v0/template.json
+++ b/v0/template.json
@@ -9792,7 +9792,7 @@
               "$ref" : "#/definitions/pipeline/steps/cd/LoadBalancerSpec"
             }, {
               "type" : "object",
-              "required" : [ "loadBalancer", "prodListenerPort", "prodListenerRuleArn", "stageListenerPort", "stageListenerRuleArn" ],
+              "required" : [ "loadBalancer", "prodListenerPort", "prodListenerRuleArn" ],
               "properties" : {
                 "loadBalancer" : {
                   "type" : "string"
@@ -9808,6 +9808,12 @@
                 },
                 "stageListenerRuleArn" : {
                   "type" : "string"
+                },
+                "stageTargetGroupArn" : {
+                  "type" : "string"
+                },
+                "isTrafficShift" : {
+                  "type" : "boolean"
                 }
               }
             } ],


### PR DESCRIPTION
Tech Spec: https://harness.atlassian.net/wiki/spaces/CDNG/pages/22307799569/Spot+Dual-Mode+Traffic+Shifting+support

This PR contains changes to Elastigroup BG Stage setup step for supporting traffic shifting : 
- `stageListenerPort` , `stageListenerRuleArn` are made optional
- `isTrafficShift` optional boolean field added
- `stageTargetGroupArn` new optional string field:


Example yaml for traffic shifting flow 
```
                    loadBalancers:
                      - type: AWSLoadBalancerConfig
                        spec:
                          loadBalancer: namanSpot
                          isTrafficShift: true
                          prodListenerPort: "8080"
                          prodListenerRuleArn: <+random>
                          stageTargetGroupArn: arn:aws:elasticloadbalancing:us-east-1:839162981415:targetgroup/namanTest80/8b7b2657b4a7a360
```

Example yaml for non-traffic shifting flow 
```
                    loadBalancers:
                      - type: AWSLoadBalancerConfig
                        spec:
                          loadBalancer: namanSpot
                          prodListenerPort: "8080"
                          prodListenerRuleArn: arn:aws:elasticloadbalancing:us-east-1:839162981415:listener-rule/app/namanSpot/105e349e47c35ed1/cfa8560b2769fda7/51dd83232e75576f
                          stageListenerPort: "8080"
                          stageListenerRuleArn: arn:aws:elasticloadbalancing:us-east-1:839162981415:listener-rule/app/namanSpot/105e349e47c35ed1/cfa8560b2769fda7/e81aede4663c95f5
```
Tested templates as well



