### PR TITLE
feat: [CDS-109192]: Spot traffic shift step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -57261,6 +57261,259 @@
                 "desc" : "This is the description for StandAloneTrafficShiftRollbackStepInfo"
               }
             }
+          },
+          "ElastigroupBlueGreenTrafficShiftStepNode" : {
+            "title" : "ElastigroupBlueGreenTrafficShiftStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ElastigroupBlueGreenTrafficShiftStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ElastigroupBlueGreenTrafficShift" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ElastigroupBlueGreenTrafficShift"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupBlueGreenTrafficShiftStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ElastigroupBlueGreenTrafficShiftStepInfo" : {
+            "title" : "ElastigroupBlueGreenTrafficShiftStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "elastigroupTrafficShiftWrapper" ],
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "elastigroupTrafficShiftWrapper" : {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupTrafficShiftWrapper"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "elastigroupTrafficShiftWrapper" ],
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "elastigroupTrafficShiftWrapper" : {
+                "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupTrafficShiftWrapper"
+              },
+              "description" : {
+                "desc" : "This is the description for ElastigroupBlueGreenTrafficShiftStepInfo"
+              }
+            }
+          },
+          "ElastigroupTrafficShiftWrapper" : {
+            "title" : "ElastigroupTrafficShiftWrapper",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Standalone", "Inherit" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ElastigroupTrafficShiftWrapper"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Standalone"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneElastigroupTrafficShiftSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Inherit"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/InheritElastigroupTrafficShiftSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneElastigroupTrafficShiftSpec" : {
+            "title" : "StandAloneElastigroupTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "loadBalancer", "listenerArn", "listenerRuleArn", "forwardTrafficConfig" ],
+              "properties" : {
+                "loadBalancer" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listenerArn" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listenerRuleArn" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "forwardTrafficConfig" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/cd/ALBTargetGroupTuple"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for StandAloneElastigroupTrafficShiftSpec"
+              }
+            }
+          },
+          "ElastigroupTrafficShiftSpec" : {
+            "title" : "ElastigroupTrafficShiftSpec",
+            "type" : "object",
+            "discriminator" : "type",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ElastigroupTrafficShiftSpec"
+              }
+            }
+          },
+          "InheritElastigroupTrafficShiftSpec" : {
+            "title" : "InheritElastigroupTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "weightPercentage" ],
+              "properties" : {
+                "weightPercentage" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32",
+                    "minimum" : 0,
+                    "maximum" : 100
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for InheritElastigroupTrafficShiftSpec"
+              }
+            }
           }
         },
         "cvng" : {
@@ -62221,6 +62474,8 @@
                   "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupBlueGreenTrafficShiftStepNode"
                 } ]
               },
               "stepGroup" : {

--- a/v0/pipeline/stages/cd/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/cd/execution-wrapper-config.yaml
@@ -174,6 +174,7 @@ properties:
     - $ref: ../../steps/cd/helm-delete-step-node.yaml
     - $ref: ../../steps/cd/ecs-blue-green-traffic-shift-step-node.yaml
     - $ref: ../../steps/cd/stand-alone-traffic-shift-rollback-step-node.yaml
+    - $ref: ../../steps/cd/elastigroup-blue-green-traffic-shift-step-node.yaml
 
   stepGroup:
     $ref: step-group-element-config.yaml

--- a/v0/pipeline/steps/cd/elastigroup-blue-green-traffic-shift-step-info.yaml
+++ b/v0/pipeline/steps/cd/elastigroup-blue-green-traffic-shift-step-info.yaml
@@ -1,0 +1,34 @@
+title: ElastigroupBlueGreenTrafficShiftStepInfo
+allOf:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    required:
+      - elastigroupTrafficShiftWrapper
+    properties:
+      delegateSelectors:
+        oneOf:
+          - type: array
+            items:
+              type: string
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+      elastigroupTrafficShiftWrapper:
+        $ref: elastigroup-traffic-shift-wrapper.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+  - elastigroupTrafficShiftWrapper
+properties:
+  delegateSelectors:
+    oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  elastigroupTrafficShiftWrapper:
+    $ref: elastigroup-traffic-shift-wrapper.yaml
+  description:
+    desc: This is the description for ElastigroupBlueGreenTrafficShiftStepInfo

--- a/v0/pipeline/steps/cd/elastigroup-blue-green-traffic-shift-step-node.yaml
+++ b/v0/pipeline/steps/cd/elastigroup-blue-green-traffic-shift-step-node.yaml
@@ -1,0 +1,56 @@
+title: ElastigroupBlueGreenTrafficShiftStepNode
+type: object
+required:
+  - identifier
+  - name
+  - spec
+  - type
+properties:
+  description:
+    type: string
+    desc: This is the description for ElastigroupBlueGreenTrafficShiftStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+      - type: array
+        items:
+          $ref: ../../common/failure-strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+      - $ref: ../../common/strategy-config.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+([\s]?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+      - ElastigroupBlueGreenTrafficShift
+  when:
+    oneOf:
+      - $ref: ../../common/step-when-condition.yaml
+      - type: string
+        pattern: ^<\+input>$
+        minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: ElastigroupBlueGreenTrafficShift
+    then:
+      properties:
+        spec:
+          $ref: elastigroup-blue-green-traffic-shift-step-info.yaml

--- a/v0/pipeline/steps/cd/elastigroup-traffic-shift-spec.yaml
+++ b/v0/pipeline/steps/cd/elastigroup-traffic-shift-spec.yaml
@@ -1,0 +1,7 @@
+title: ElastigroupTrafficShiftSpec
+type: object
+discriminator: type
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for ElastigroupTrafficShiftSpec

--- a/v0/pipeline/steps/cd/elastigroup-traffic-shift-wrapper.yaml
+++ b/v0/pipeline/steps/cd/elastigroup-traffic-shift-wrapper.yaml
@@ -1,0 +1,31 @@
+title: ElastigroupTrafficShiftWrapper
+type: object
+required:
+  - spec
+  - type
+properties:
+  type:
+    type: string
+    enum:
+      - Standalone
+      - Inherit
+  description:
+    desc: This is the description for ElastigroupTrafficShiftWrapper
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+  - if:
+      properties:
+        type:
+          const: Standalone
+    then:
+      properties:
+        spec:
+          $ref: stand-alone-elastigroup-traffic-shift-spec.yaml
+  - if:
+      properties:
+        type:
+          const: Inherit
+    then:
+      properties:
+        spec:
+          $ref: inherit-elastigroup-traffic-shift-spec.yaml

--- a/v0/pipeline/steps/cd/inherit-elastigroup-traffic-shift-spec.yaml
+++ b/v0/pipeline/steps/cd/inherit-elastigroup-traffic-shift-spec.yaml
@@ -1,0 +1,20 @@
+title: InheritElastigroupTrafficShiftSpec
+allOf:
+  - $ref: elastigroup-traffic-shift-spec.yaml
+  - type: object
+    required:
+      - weightPercentage
+    properties:
+      weightPercentage:
+        oneOf:
+          - type: integer
+            format: int32
+            minimum: 0
+            maximum: 100
+          - type: string
+            pattern: (<\+.+>.*)
+            minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for InheritElastigroupTrafficShiftSpec

--- a/v0/pipeline/steps/cd/stand-alone-elastigroup-traffic-shift-spec.yaml
+++ b/v0/pipeline/steps/cd/stand-alone-elastigroup-traffic-shift-spec.yaml
@@ -1,0 +1,31 @@
+title: StandAloneElastigroupTrafficShiftSpec
+allOf:
+  - $ref: elastigroup-traffic-shift-spec.yaml
+  - type: object
+    required:
+      - loadBalancer
+      - listenerArn
+      - listenerRuleArn
+      - forwardTrafficConfig
+    properties:
+      loadBalancer:
+        type: string
+        pattern: ^(?=\s*\S).*$
+      listenerArn:
+        type: string
+        pattern: ^(?=\s*\S).*$
+      listenerRuleArn:
+        type: string
+        pattern: ^(?=\s*\S).*$
+      forwardTrafficConfig:
+        oneOf:
+          - type: array
+            items:
+              $ref: alb-target-group-tuple.yaml
+          - type: string
+            pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|selectOneFrom|default|regex)\(.+?\)))*$
+            minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for StandAloneElastigroupTrafficShiftSpec

--- a/v0/template.json
+++ b/v0/template.json
@@ -35687,6 +35687,259 @@
                 "desc" : "This is the description for StandAloneTrafficShiftRollbackStepInfo"
               }
             }
+          },
+          "ElastigroupBlueGreenTrafficShiftStepNode" : {
+            "title" : "ElastigroupBlueGreenTrafficShiftStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for ElastigroupBlueGreenTrafficShiftStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+([\\s]?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "ElastigroupBlueGreenTrafficShift" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "ElastigroupBlueGreenTrafficShift"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupBlueGreenTrafficShiftStepInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "ElastigroupBlueGreenTrafficShiftStepInfo" : {
+            "title" : "ElastigroupBlueGreenTrafficShiftStepInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "elastigroupTrafficShiftWrapper" ],
+              "properties" : {
+                "delegateSelectors" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                },
+                "elastigroupTrafficShiftWrapper" : {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupTrafficShiftWrapper"
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "elastigroupTrafficShiftWrapper" ],
+            "properties" : {
+              "delegateSelectors" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "elastigroupTrafficShiftWrapper" : {
+                "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupTrafficShiftWrapper"
+              },
+              "description" : {
+                "desc" : "This is the description for ElastigroupBlueGreenTrafficShiftStepInfo"
+              }
+            }
+          },
+          "ElastigroupTrafficShiftWrapper" : {
+            "title" : "ElastigroupTrafficShiftWrapper",
+            "type" : "object",
+            "required" : [ "spec", "type" ],
+            "properties" : {
+              "type" : {
+                "type" : "string",
+                "enum" : [ "Standalone", "Inherit" ]
+              },
+              "description" : {
+                "desc" : "This is the description for ElastigroupTrafficShiftWrapper"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Standalone"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/StandAloneElastigroupTrafficShiftSpec"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "Inherit"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/cd/InheritElastigroupTrafficShiftSpec"
+                  }
+                }
+              }
+            } ]
+          },
+          "StandAloneElastigroupTrafficShiftSpec" : {
+            "title" : "StandAloneElastigroupTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "loadBalancer", "listenerArn", "listenerRuleArn", "forwardTrafficConfig" ],
+              "properties" : {
+                "loadBalancer" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listenerArn" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "listenerRuleArn" : {
+                  "type" : "string",
+                  "pattern" : "^(?=\\s*\\S).*$"
+                },
+                "forwardTrafficConfig" : {
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/cd/ALBTargetGroupTuple"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|selectOneFrom|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for StandAloneElastigroupTrafficShiftSpec"
+              }
+            }
+          },
+          "ElastigroupTrafficShiftSpec" : {
+            "title" : "ElastigroupTrafficShiftSpec",
+            "type" : "object",
+            "discriminator" : "type",
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for ElastigroupTrafficShiftSpec"
+              }
+            }
+          },
+          "InheritElastigroupTrafficShiftSpec" : {
+            "title" : "InheritElastigroupTrafficShiftSpec",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupTrafficShiftSpec"
+            }, {
+              "type" : "object",
+              "required" : [ "weightPercentage" ],
+              "properties" : {
+                "weightPercentage" : {
+                  "oneOf" : [ {
+                    "type" : "integer",
+                    "format" : "int32",
+                    "minimum" : 0,
+                    "maximum" : 100
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)",
+                    "minLength" : 1
+                  } ]
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for InheritElastigroupTrafficShiftSpec"
+              }
+            }
           }
         },
         "custom" : {
@@ -79167,6 +79420,8 @@
                   "$ref" : "#/definitions/pipeline/steps/cd/EcsBlueGreenTrafficShiftStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/cd/StandAloneTrafficShiftRollbackStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/cd/ElastigroupBlueGreenTrafficShiftStepNode"
                 } ]
               },
               "stepGroup" : {


### PR DESCRIPTION
Tech Spec: 
https://harness.atlassian.net/wiki/spaces/CDNG/pages/22307799569/Spot+Dual-Mode+Traffic+Shifting+support

Step Pojo PR: https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/PROD/projects/Harness_Commons/repos/harness-core/pulls/102625

Elastigroup Traffic Shift Step
- `elastigroupTrafficShiftWrapper` is required. 
- `type` and `spec` are required in `elastigroupTrafficShiftWrapper`
- `type` can be only ` "Standalone", "Inherit"`
-  **Inherit**: 
 `weightPercentage` required for inherit , can be between 0 to 100 inclusive only for fixed value, or runtime input or expression
- **StandAlone**: 
`loadBalancer` : required, blank value not allowed or runtime input or expression
`listenerArn` : required, blank value not allowed or runtime input or expression
`listenerRuleArn` : required, blank value not allowed or runtime input or expression
`forwardTrafficConfig` : required, runtime input but not expression or list of `ALBTargetGroupTuple`
- ALBTargetGroupTuple: 
   `targetGroupArn`  required, blank value not allowed or runtime input or expression
    `weight` required, runtime input or expression or fixed integer with min value 0
 
Checked the new yaml in templates as well. 

Example: 
```
              - step:
                  type: ElastigroupBlueGreenTrafficShift
                  name: ElastigroupBlueGreenTrafficShift_1
                  identifier: ElastigroupBlueGreenTrafficShift_1
                  timeout: 15m
                  spec:
                    elastigroupTrafficShiftWrapper:
                      type: Inherit
                      spec:
                        weightPercentage: 80
              - step:
                  type: ElastigroupBlueGreenTrafficShift
                  name: ElastigroupBlueGreenTrafficShift_1
                  identifier: ElastigroupBlueGreenTrafficShift_2
                  timeout: 15m
                  spec:
                    elastigroupTrafficShiftWrapper:
                      type: Standalone
                      spec:
                        loadBalancer: ecs-donot-delete-todolist
                        listenerRuleArn: arn:aws:elasticloadbalancing:us-east-1:479370281431:listener-rule/app/ecs-donot-delete-todolist/cd74c728114bef78/1974e8b6a03b83a7/77eb261cc0db12c4
                        listenerArn: arn:aws:elasticloadbalancing:us-east-1:479370281431:listener/app/ecs-donot-delete-todolist/cd74c728114bef78/1974e8b6a03b83a7
                        forwardTrafficConfig:
                          - targetGroupArn: stageTG
                            weight: 80
                          - targetGroupArn: prodTg
                            weight: 20       
```
