### PR TITLE
feat: [DBOPS-1024]: Ensure the 'tag' field in the rollback schema step is not an empty string.

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -20560,13 +20560,8 @@
                   }
                 },
                 "tag" : {
-                  "oneOf" : [ {
-                    "type" : "string",
-                    "minLength" : 1
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)"
-                  } ]
+                  "type" : "string",
+                  "minLength" : 1
                 },
                 "delegateSelectors" : {
                   "oneOf" : [ {
@@ -20639,7 +20634,8 @@
                 "type" : "string"
               },
               "tag" : {
-                "type" : "string"
+                "type" : "string",
+                "minLength" : 1
               },
               "delegateSelectors" : {
                 "oneOf" : [ {

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -20542,7 +20542,7 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
+              "required" : [ "connectorRef", "dbInstance", "dbSchema" ],
               "properties" : {
                 "dbInstance" : {
                   "type" : "string"
@@ -20622,7 +20622,7 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
+            "required" : [ "connectorRef", "dbInstance", "dbSchema" ],
             "properties" : {
               "dbInstance" : {
                 "type" : "string"

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -20560,7 +20560,13 @@
                   }
                 },
                 "tag" : {
-                  "type" : "string"
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "minLength" : 1
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)"
+                  } ]
                 },
                 "delegateSelectors" : {
                   "oneOf" : [ {

--- a/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
+++ b/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
@@ -19,11 +19,8 @@ allOf:
         additionalProperties:
           type: string
       tag:
-        oneOf:
-          - type: string
-            minLength: 1
-          - type: string
-            pattern: (<\+.+>.*)
+        type: string
+        minLength: 1
       delegateSelectors:
         oneOf:
           - type: array
@@ -79,6 +76,7 @@ properties:
     type: string
   tag:
     type: string
+    minLength: 1
   delegateSelectors:
     oneOf:
       - type: array

--- a/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
+++ b/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
@@ -6,7 +6,6 @@ allOf:
       - connectorRef
       - dbInstance
       - dbSchema
-      - tag
     properties:
       dbInstance:
         type: string
@@ -66,7 +65,6 @@ required:
   - connectorRef
   - dbInstance
   - dbSchema
-  - tag
 properties:
   dbInstance:
     type: string

--- a/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
+++ b/v0/pipeline/steps/common/dbops-rollback-schema-step-info.yaml
@@ -19,7 +19,11 @@ allOf:
         additionalProperties:
           type: string
       tag:
-        type: string
+        oneOf:
+          - type: string
+            minLength: 1
+          - type: string
+            pattern: (<\+.+>.*)
       delegateSelectors:
         oneOf:
           - type: array

--- a/v0/template.json
+++ b/v0/template.json
@@ -58359,13 +58359,8 @@
                   }
                 },
                 "tag" : {
-                  "oneOf" : [ {
-                    "type" : "string",
-                    "minLength" : 1
-                  }, {
-                    "type" : "string",
-                    "pattern" : "(<\\+.+>.*)"
-                  } ]
+                  "type" : "string",
+                  "minLength" : 1
                 },
                 "delegateSelectors" : {
                   "oneOf" : [ {
@@ -58438,7 +58433,8 @@
                 "type" : "string"
               },
               "tag" : {
-                "type" : "string"
+                "type" : "string",
+                "minLength" : 1
               },
               "delegateSelectors" : {
                 "oneOf" : [ {

--- a/v0/template.json
+++ b/v0/template.json
@@ -58341,7 +58341,7 @@
               "$ref" : "#/definitions/pipeline/common/StepSpecType"
             }, {
               "type" : "object",
-              "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
+              "required" : [ "connectorRef", "dbInstance", "dbSchema" ],
               "properties" : {
                 "dbInstance" : {
                   "type" : "string"
@@ -58421,7 +58421,7 @@
             } ],
             "$schema" : "http://json-schema.org/draft-07/schema#",
             "type" : "object",
-            "required" : [ "connectorRef", "dbInstance", "dbSchema", "tag" ],
+            "required" : [ "connectorRef", "dbInstance", "dbSchema" ],
             "properties" : {
               "dbInstance" : {
                 "type" : "string"

--- a/v0/template.json
+++ b/v0/template.json
@@ -58359,7 +58359,13 @@
                   }
                 },
                 "tag" : {
-                  "type" : "string"
+                  "oneOf" : [ {
+                    "type" : "string",
+                    "minLength" : 1
+                  }, {
+                    "type" : "string",
+                    "pattern" : "(<\\+.+>.*)"
+                  } ]
                 },
                 "delegateSelectors" : {
                   "oneOf" : [ {


### PR DESCRIPTION
Ensure the 'tag' field in the rollback schema step is not an empty string.

![string cannot be empty](https://github.com/user-attachments/assets/f40d29fb-f927-4910-913b-0aa4ccefcdde)
