### PR TITLE
Removed the support of object in the notification template schema

### DIFF
--- a/v0/template.json
+++ b/v0/template.json
@@ -1314,9 +1314,7 @@
               "enum" : [ "JSON", "YAML", "STRING", "HTML" ]
             },
             "content" : {
-              "oneOf" : [ {
-                "type" : "string"
-              } ]
+              "type" : "string"
             }
           }
         }

--- a/v0/template.json
+++ b/v0/template.json
@@ -1315,8 +1315,6 @@
             },
             "content" : {
               "oneOf" : [ {
-                "type" : "object"
-              }, {
                 "type" : "string"
               } ]
             }

--- a/v0/template/notification/notification_template_body.yaml
+++ b/v0/template/notification/notification_template_body.yaml
@@ -13,5 +13,4 @@ properties:
       - HTML
   content:
     oneOf:
-      - type: object
       - type: string

--- a/v0/template/notification/notification_template_body.yaml
+++ b/v0/template/notification/notification_template_body.yaml
@@ -12,5 +12,4 @@ properties:
       - STRING
       - HTML
   content:
-    oneOf:
-      - type: string
+    type: string


### PR DESCRIPTION
We consider and parse the content in the schema as a string, across the FE behaviour and the backend code.

However, due to the added suupoort of object in the schema, UI visual breaks, as it considers the content to be a string.
Removing the '|' in the yaml , should therefore result in a schema validation error, instead of breaking the UI.