### PR TITLE
feat:[IAC-3673]: adding Iacm TG step

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -30707,6 +30707,156 @@
                 }
               }
             }
+          },
+          "IACMTerragruntPluginStepNode" : {
+            "title" : "IACMTerragruntPluginStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for IACMTerragruntPluginStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+(\\s?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "IACMTerragruntPlugin" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "IACMTerragruntPlugin"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/iacm/IACMTerragruntPluginInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "IACMTerragruntPluginInfo" : {
+            "title" : "IACMTerragruntPluginInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "command" ],
+              "properties" : {
+                "command" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "target" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "replace" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "import" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "command" ],
+            "properties" : {
+              "command" : {
+                "type" : "string"
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for IACMTerragruntPluginInfo"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "target" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "replace" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "import" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                }
+              }
+            }
           }
         },
         "cd" : {
@@ -61563,6 +61713,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/SnykScanNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/iacm/IACMModuleTestPluginStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/iacm/IACMTerragruntPluginStepNode"
                 } ]
               },
               "description" : {

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -30803,22 +30803,40 @@
                   "$ref" : "#/definitions/pipeline/common/ContainerResource"
                 },
                 "target" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "replace" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "import" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],

--- a/v0/pipeline/stages/iacm/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/iacm/execution-wrapper-config.yaml
@@ -26,6 +26,7 @@ properties:
     - $ref: ../../steps/common/checkov-scan-node.yaml
     - $ref: ../../steps/common/snyk-scan-node.yaml
     - $ref: ../../steps/iacm/iacmmoduletest-plugin-step-node.yaml
+    - $ref: ../../steps/iacm/iacmterragrunt-plugin-step-node.yaml
 
   description:
     desc: This is the description for ExecutionWrapperConfig

--- a/v0/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml
+++ b/v0/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml
@@ -12,17 +12,29 @@ allOf:
       resources:
         $ref: ../../common/container-resource.yaml
       target:
-        type: array
-        items:
-          type: string
+        oneOf:
+        - type: array
+          items:
+            type: string
+        - type: string
+          pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+          minLength: 1
       replace:
-        type: array
-        items:
-          type: string
+        oneOf:
+        - type: array
+          items:
+            type: string
+        - type: string
+          pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+          minLength: 1
       import:
-        type: array
-        items:
-          $ref: ./iacm-import-command-parameter.yaml
+        oneOf:
+        - type: array
+          items:
+            $ref: ./iacm-import-command-parameter.yaml
+        - type: string
+          pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+          minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:

--- a/v0/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml
+++ b/v0/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml
@@ -1,0 +1,50 @@
+title: IACMTerragruntPluginInfo
+allOf:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    required:
+      - command
+    properties:
+      command:
+        type: string
+      image:
+        type: string
+      resources:
+        $ref: ../../common/container-resource.yaml
+      target:
+        type: array
+        items:
+          type: string
+      replace:
+        type: array
+        items:
+          type: string
+      import:
+        type: array
+        items:
+          $ref: ./iacm-import-command-parameter.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+  - command
+properties:
+  command:
+    type: string
+  image:
+    type: string
+  description:
+    desc: This is the description for IACMTerragruntPluginInfo
+  resources:
+    $ref: ../../common/container-resource.yaml
+  target:
+    type: array
+    items:
+      type: string
+  replace:
+    type: array
+    items:
+      type: string
+  import:
+    type: array
+    items:
+      $ref: ./iacm-import-command-parameter.yaml

--- a/v0/pipeline/steps/iacm/iacmterragrunt-plugin-step-node.yaml
+++ b/v0/pipeline/steps/iacm/iacmterragrunt-plugin-step-node.yaml
@@ -1,0 +1,56 @@
+title: IACMTerragruntPluginStepNode
+type: object
+required:
+- identifier
+- name
+- spec
+- type
+properties:
+  description:
+    type: string
+    desc: This is the description for IACMTerragruntPluginStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+    - type: array
+      items:
+        $ref: ../../common/failure-strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+    - $ref: ../../common/strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+(\s?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+    - IACMTerragruntPlugin
+  when:
+    oneOf:
+    - $ref: ../../common/step-when-condition.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: IACMTerragruntPlugin
+  then:
+    properties:
+      spec:
+        $ref: iacmterragrunt-plugin-info.yaml

--- a/v0/template.json
+++ b/v0/template.json
@@ -77640,22 +77640,40 @@
                   "$ref" : "#/definitions/pipeline/common/ContainerResource"
                 },
                 "target" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "replace" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "import" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],

--- a/v0/template.json
+++ b/v0/template.json
@@ -77544,6 +77544,156 @@
                 }
               }
             } ]
+          },
+          "IACMTerragruntPluginStepNode" : {
+            "title" : "IACMTerragruntPluginStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for IACMTerragruntPluginStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+(\\s?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "IACMTerragruntPlugin" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "IACMTerragruntPlugin"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/iacm/IACMTerragruntPluginInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "IACMTerragruntPluginInfo" : {
+            "title" : "IACMTerragruntPluginInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "command" ],
+              "properties" : {
+                "command" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "target" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "replace" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "import" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "command" ],
+            "properties" : {
+              "command" : {
+                "type" : "string"
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for IACMTerragruntPluginInfo"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "target" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "replace" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "import" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                }
+              }
+            }
           }
         }
       },
@@ -89231,6 +89381,8 @@
                   "$ref" : "#/definitions/pipeline/steps/common/SnykScanNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/iacm/IACMModuleTestPluginStepNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/iacm/IACMTerragruntPluginStepNode"
                 } ]
               },
               "description" : {

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -30294,22 +30294,40 @@
                   "$ref" : "#/definitions/pipeline/common/ContainerResource"
                 },
                 "target" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "replace" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "import" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],

--- a/v1/pipeline.json
+++ b/v1/pipeline.json
@@ -403,6 +403,8 @@
                   "$ref" : "#/definitions/pipeline/steps/iacm/IACMModuleTestPluginStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/CheckmarxOneScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/iacm/IACMTerragruntPluginStepNode"
                 } ]
               },
               "description" : {
@@ -30193,6 +30195,156 @@
                 "type" : "array",
                 "items" : {
                   "type" : "string"
+                }
+              }
+            }
+          },
+          "IACMTerragruntPluginStepNode" : {
+            "title" : "IACMTerragruntPluginStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for IACMTerragruntPluginStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+(\\s?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "IACMTerragruntPlugin" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "IACMTerragruntPlugin"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/iacm/IACMTerragruntPluginInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "IACMTerragruntPluginInfo" : {
+            "title" : "IACMTerragruntPluginInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "command" ],
+              "properties" : {
+                "command" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "target" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "replace" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "import" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "command" ],
+            "properties" : {
+              "command" : {
+                "type" : "string"
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for IACMTerragruntPluginInfo"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "target" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "replace" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "import" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
                 }
               }
             }

--- a/v1/pipeline/stages/iacm/execution-wrapper-config.yaml
+++ b/v1/pipeline/stages/iacm/execution-wrapper-config.yaml
@@ -25,6 +25,7 @@ properties:
     - $ref: ../../steps/common/snyk-scan-node.yaml
     - $ref: ../../steps/iacm/iacmmoduletest-plugin-step-node.yaml
     - $ref: ../../steps/common/checkmarx-one-scan-node.yaml
+    - $ref: ../../steps/iacm/iacmterragrunt-plugin-step-node.yaml
 
   description:
     desc: This is the description for ExecutionWrapperConfig

--- a/v1/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml
+++ b/v1/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml
@@ -12,17 +12,29 @@ allOf:
       resources:
         $ref: ../../common/container-resource.yaml
       target:
-        type: array
-        items:
-          type: string
+        oneOf:
+        - type: array
+          items:
+            type: string
+        - type: string
+          pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+          minLength: 1
       replace:
-        type: array
-        items:
-          type: string
+        oneOf:
+        - type: array
+          items:
+            type: string
+        - type: string
+          pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+          minLength: 1
       import:
-        type: array
-        items:
-          $ref: ./iacm-import-command-parameter.yaml
+        oneOf:
+        - type: array
+          items:
+            $ref: ./iacm-import-command-parameter.yaml
+        - type: string
+          pattern: ^<\+input>((\.)((executionInput\(\))|(allowedValues|default|regex)\(.+?\)))*$
+          minLength: 1
 $schema: http://json-schema.org/draft-07/schema#
 type: object
 required:

--- a/v1/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml
+++ b/v1/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml
@@ -1,0 +1,50 @@
+title: IACMTerragruntPluginInfo
+allOf:
+  - $ref: ../../common/step-spec-type.yaml
+  - type: object
+    required:
+      - command
+    properties:
+      command:
+        type: string
+      image:
+        type: string
+      resources:
+        $ref: ../../common/container-resource.yaml
+      target:
+        type: array
+        items:
+          type: string
+      replace:
+        type: array
+        items:
+          type: string
+      import:
+        type: array
+        items:
+          $ref: ./iacm-import-command-parameter.yaml
+$schema: http://json-schema.org/draft-07/schema#
+type: object
+required:
+  - command
+properties:
+  command:
+    type: string
+  image:
+    type: string
+  description:
+    desc: This is the description for IACMTerragruntPluginInfo
+  resources:
+    $ref: ../../common/container-resource.yaml
+  target:
+    type: array
+    items:
+      type: string
+  replace:
+    type: array
+    items:
+      type: string
+  import:
+    type: array
+    items:
+      $ref: ./iacm-import-command-parameter.yaml

--- a/v1/pipeline/steps/iacm/iacmterragrunt-plugin-step-node.yaml
+++ b/v1/pipeline/steps/iacm/iacmterragrunt-plugin-step-node.yaml
@@ -1,0 +1,56 @@
+title: IACMTerragruntPluginStepNode
+type: object
+required:
+- identifier
+- name
+- spec
+- type
+properties:
+  description:
+    type: string
+    desc: This is the description for IACMTerragruntPluginStepNode
+  enforce:
+    $ref: ../../common/policy-config.yaml
+  failureStrategies:
+    oneOf:
+    - type: array
+      items:
+        $ref: ../../common/failure-strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  identifier:
+    type: string
+    pattern: ^[a-zA-Z_][0-9a-zA-Z_]{0,127}$
+  name:
+    type: string
+    pattern: ^[a-zA-Z_0-9-.][-0-9a-zA-Z_\s.]{0,127}$
+  strategy:
+    oneOf:
+    - $ref: ../../common/strategy-config.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+  timeout:
+    type: string
+    pattern: ^(([1-9])+\d+[s])|(((([1-9])+\d*[mhwd])+(\s?\d+[smhwd])*)|(.*<\+.*>(?!.*\.executionInput\(\)).*)|(^$))$
+  type:
+    type: string
+    enum:
+    - IACMTerragruntPlugin
+  when:
+    oneOf:
+    - $ref: ../../common/step-when-condition.yaml
+    - type: string
+      pattern: ^<\+input>$
+      minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+allOf:
+- if:
+    properties:
+      type:
+        const: IACMTerragruntPlugin
+  then:
+    properties:
+      spec:
+        $ref: iacmterragrunt-plugin-info.yaml

--- a/v1/template.json
+++ b/v1/template.json
@@ -67447,22 +67447,40 @@
                   "$ref" : "#/definitions/pipeline/common/ContainerResource"
                 },
                 "target" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "replace" : {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "type" : "string"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 },
                 "import" : {
-                  "type" : "array",
-                  "items" : {
-                    "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
-                  }
+                  "oneOf" : [ {
+                    "type" : "array",
+                    "items" : {
+                      "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                    }
+                  }, {
+                    "type" : "string",
+                    "pattern" : "^<\\+input>((\\.)((executionInput\\(\\))|(allowedValues|default|regex)\\(.+?\\)))*$",
+                    "minLength" : 1
+                  } ]
                 }
               }
             } ],

--- a/v1/template.json
+++ b/v1/template.json
@@ -67351,6 +67351,156 @@
                 }
               }
             } ]
+          },
+          "IACMTerragruntPluginStepNode" : {
+            "title" : "IACMTerragruntPluginStepNode",
+            "type" : "object",
+            "required" : [ "identifier", "name", "spec", "type" ],
+            "properties" : {
+              "description" : {
+                "type" : "string",
+                "desc" : "This is the description for IACMTerragruntPluginStepNode"
+              },
+              "enforce" : {
+                "$ref" : "#/definitions/pipeline/common/PolicyConfig"
+              },
+              "failureStrategies" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/common/FailureStrategyConfig"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "identifier" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_][0-9a-zA-Z_]{0,127}$"
+              },
+              "name" : {
+                "type" : "string",
+                "pattern" : "^[a-zA-Z_0-9-.][-0-9a-zA-Z_\\s.]{0,127}$"
+              },
+              "strategy" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StrategyConfig"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              },
+              "timeout" : {
+                "type" : "string",
+                "pattern" : "^(([1-9])+\\d+[s])|(((([1-9])+\\d*[mhwd])+(\\s?\\d+[smhwd])*)|(.*<\\+.*>(?!.*\\.executionInput\\(\\)).*)|(^$))$"
+              },
+              "type" : {
+                "type" : "string",
+                "enum" : [ "IACMTerragruntPlugin" ]
+              },
+              "when" : {
+                "oneOf" : [ {
+                  "$ref" : "#/definitions/pipeline/common/StepWhenCondition"
+                }, {
+                  "type" : "string",
+                  "pattern" : "^<\\+input>$",
+                  "minLength" : 1
+                } ]
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "allOf" : [ {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "IACMTerragruntPlugin"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/steps/iacm/IACMTerragruntPluginInfo"
+                  }
+                }
+              }
+            } ]
+          },
+          "IACMTerragruntPluginInfo" : {
+            "title" : "IACMTerragruntPluginInfo",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/StepSpecType"
+            }, {
+              "type" : "object",
+              "required" : [ "command" ],
+              "properties" : {
+                "command" : {
+                  "type" : "string"
+                },
+                "image" : {
+                  "type" : "string"
+                },
+                "resources" : {
+                  "$ref" : "#/definitions/pipeline/common/ContainerResource"
+                },
+                "target" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "replace" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                },
+                "import" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                  }
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "type" : "object",
+            "required" : [ "command" ],
+            "properties" : {
+              "command" : {
+                "type" : "string"
+              },
+              "image" : {
+                "type" : "string"
+              },
+              "description" : {
+                "desc" : "This is the description for IACMTerragruntPluginInfo"
+              },
+              "resources" : {
+                "$ref" : "#/definitions/pipeline/common/ContainerResource"
+              },
+              "target" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "replace" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "string"
+                }
+              },
+              "import" : {
+                "type" : "array",
+                "items" : {
+                  "$ref" : "#/definitions/pipeline/steps/iacm/ImportCommandParameterField"
+                }
+              }
+            }
           }
         },
         "idp" : {
@@ -73152,6 +73302,8 @@
                   "$ref" : "#/definitions/pipeline/steps/iacm/IACMModuleTestPluginStepNode"
                 }, {
                   "$ref" : "#/definitions/pipeline/steps/common/CheckmarxOneScanNode"
+                }, {
+                  "$ref" : "#/definitions/pipeline/steps/iacm/IACMTerragruntPluginStepNode"
                 } ]
               },
               "description" : {


### PR DESCRIPTION
# Add Terragrunt Step Schema to IACM Pipeline

## Summary
Added schema definitions for the Terragrunt step in IACM pipeline, following the same pattern as existing Terraform and OpenTofu steps. This addition will enable Terragrunt support in the YAML editor with proper auto-intellisense capabilities.

## Changes
1. Added new schema files in v0:
   - `v0/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml`: Defines the Terragrunt step configuration
   - `v0/pipeline/steps/iacm/iacmterragrunt-plugin-step-node.yaml`: Defines the step node structure
   - Updated `v0/pipeline/stages/iacm/execution-wrapper-config.yaml` to include Terragrunt step

2. Added corresponding schema files in v1:
   - [v1/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml](cci:7://file:///Users/rajendrabaviskar/harness-schema/v1/pipeline/steps/iacm/iacmterragrunt-plugin-info.yaml:0:0-0:0)
   - [v1/pipeline/steps/iacm/iacmterragrunt-plugin-step-node.yaml](cci:7://file:///Users/rajendrabaviskar/harness-schema/v1/pipeline/steps/iacm/iacmterragrunt-plugin-step-node.yaml:0:0-0:0)
   - Updated [v1/pipeline/stages/iacm/execution-wrapper-config.yaml](cci:7://file:///Users/rajendrabaviskar/harness-schema/v1/pipeline/stages/iacm/execution-wrapper-config.yaml:0:0-0:0)

3. Generated updated schema files using `bazel run bundler/schema_store:module`

## Testing
The changes can be tested by:
1. Local Testing:
   - Copy the generated schema from schema repo to local `v0/pipeline.json` and `v0/template.json`
   - Restart pipeline/template service
   - Verify in YAML editor that Terragrunt step is available in IACM stage

## Related
- JIRA: IAC-3673