### PR TITLE
feature/CDS-110240: Add configurable disallow email list in Approvers

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -3578,7 +3578,7 @@
                   "minLength" : 1
                 } ]
               },
-              "disallowedEmailIDs" : {
+              "disallowedUserEmails" : {
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {

--- a/v0/pipeline/steps/custom/approvers.yaml
+++ b/v0/pipeline/steps/custom/approvers.yaml
@@ -31,7 +31,7 @@ properties:
       - type: string
         pattern: (<\+.+>.*)
         minLength: 1
-  disallowedEmailIDs:
+  disallowedUserEmails:
     oneOf:
       - type: array
         items:

--- a/v0/template.json
+++ b/v0/template.json
@@ -38414,7 +38414,7 @@
                   "minLength" : 1
                 } ]
               },
-              "disallowedEmailIDs" : {
+              "disallowedUserEmails" : {
                 "oneOf" : [ {
                   "type" : "array",
                   "items" : {


### PR DESCRIPTION
An existing setting in approval step "Disallow the executor from approving the pipeline" prevents a user from approving a step if they are the executor of that pipeline execution. The ask (from JMPC) is to extend this restriction to webhook-triggered pipeline executions aswell (ex: github). To allow this functionality, a configurable "disallowUserEmails" field is added.

TechSpec: https://harness.atlassian.net/wiki/spaces/CDNG/pages/22511976631/Tech+Spec+Support+in+Approval+Step+to+exclude+user+who+triggered+a+pipeline+from+approval+list
Backend PR: https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/module/code/orgs/PROD/projects/Harness_Commons/repos/harness-core/pulls/103347