### PR TITLE
feat: [PIPE-26408]: add validation requiring one of step/parallel/stepGroup/insert in execution wrappers

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -60468,6 +60468,19 @@
             }
           }
         },
+        "ExecutionWrapperValidation" : {
+          "title" : "ExecutionWrapperValidation",
+          "type" : "object",
+          "oneOf" : [ {
+            "required" : [ "step" ]
+          }, {
+            "required" : [ "parallel" ]
+          }, {
+            "required" : [ "stepGroup" ]
+          }, {
+            "required" : [ "insert" ]
+          } ]
+        },
         "StepElementConfig" : {
           "title" : "StepElementConfig",
           "type" : "object",
@@ -61706,6 +61719,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/iacm/ParallelStepElementConfig"
@@ -62485,6 +62501,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/ParallelStepElementConfig"
@@ -69121,6 +69140,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/security/ParallelStepElementConfig"
@@ -69605,6 +69627,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/ci/ParallelStepElementConfig"
@@ -70208,6 +70233,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/approval/ParallelStepElementConfig"
@@ -70737,6 +70765,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/custom/ParallelStepElementConfig"
@@ -71179,6 +71210,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/cf/ParallelStepElementConfig"
@@ -71734,6 +71768,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/idp/ParallelStepElementConfig"

--- a/v0/pipeline/common/execution-wrapper-validation.yaml
+++ b/v0/pipeline/common/execution-wrapper-validation.yaml
@@ -1,0 +1,7 @@
+title: ExecutionWrapperValidation
+type: object
+oneOf:
+  - required: [step]
+  - required: [parallel]
+  - required: [stepGroup]
+  - required: [insert]

--- a/v0/pipeline/stages/approval/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/approval/execution-wrapper-config.yaml
@@ -1,5 +1,7 @@
 title: ExecutionWrapperConfig
 type: object
+allOf:
+  - $ref: ../../common/execution-wrapper-validation.yaml
 properties:
   parallel:
     $ref: parallel-step-element-config.yaml

--- a/v0/pipeline/stages/cd/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/cd/execution-wrapper-config.yaml
@@ -1,5 +1,7 @@
 title: ExecutionWrapperConfig
 type: object
+allOf:
+  - $ref: ../../common/execution-wrapper-validation.yaml
 properties:
   parallel:
     $ref: parallel-step-element-config.yaml

--- a/v0/pipeline/stages/cf/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/cf/execution-wrapper-config.yaml
@@ -1,5 +1,7 @@
 title: ExecutionWrapperConfig
 type: object
+allOf:
+  - $ref: ../../common/execution-wrapper-validation.yaml
 properties:
   parallel:
     $ref: parallel-step-element-config.yaml

--- a/v0/pipeline/stages/ci/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/ci/execution-wrapper-config.yaml
@@ -1,5 +1,7 @@
 title: ExecutionWrapperConfig
 type: object
+allOf:
+  - $ref: ../../common/execution-wrapper-validation.yaml
 properties:
   parallel:
     $ref: parallel-step-element-config.yaml

--- a/v0/pipeline/stages/custom/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/custom/execution-wrapper-config.yaml
@@ -1,5 +1,7 @@
 title: ExecutionWrapperConfig
 type: object
+allOf:
+  - $ref: ../../common/execution-wrapper-validation.yaml
 properties:
   parallel:
     $ref: parallel-step-element-config.yaml

--- a/v0/pipeline/stages/iacm/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/iacm/execution-wrapper-config.yaml
@@ -1,5 +1,7 @@
 title: ExecutionWrapperConfig
 type: object
+allOf:
+  - $ref: ../../common/execution-wrapper-validation.yaml
 properties:
   parallel:
     $ref: parallel-step-element-config.yaml

--- a/v0/pipeline/stages/idp/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/idp/execution-wrapper-config.yaml
@@ -1,5 +1,7 @@
 title: ExecutionWrapperConfig
 type: object
+allOf:
+  - $ref: ../../common/execution-wrapper-validation.yaml
 properties:
   parallel:
     $ref: parallel-step-element-config.yaml

--- a/v0/pipeline/stages/security/execution-wrapper-config.yaml
+++ b/v0/pipeline/stages/security/execution-wrapper-config.yaml
@@ -1,5 +1,7 @@
 title: ExecutionWrapperConfig
 type: object
+allOf:
+  - $ref: ../../common/execution-wrapper-validation.yaml
 properties:
   parallel:
     $ref: parallel-step-element-config.yaml

--- a/v0/template.json
+++ b/v0/template.json
@@ -78486,6 +78486,19 @@
           },
           "$schema" : "http://json-schema.org/draft-07/schema#"
         },
+        "ExecutionWrapperValidation" : {
+          "title" : "ExecutionWrapperValidation",
+          "type" : "object",
+          "oneOf" : [ {
+            "required" : [ "step" ]
+          }, {
+            "required" : [ "parallel" ]
+          }, {
+            "required" : [ "stepGroup" ]
+          }, {
+            "required" : [ "insert" ]
+          } ]
+        },
         "StepElementConfig" : {
           "title" : "StepElementConfig",
           "type" : "object",
@@ -79501,6 +79514,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/cd/ParallelStepElementConfig"
@@ -86220,6 +86236,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/custom/ParallelStepElementConfig"
@@ -86911,6 +86930,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/approval/ParallelStepElementConfig"
@@ -87526,6 +87548,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/ci/ParallelStepElementConfig"
@@ -88232,6 +88257,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/cf/ParallelStepElementConfig"
@@ -88858,6 +88886,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/security/ParallelStepElementConfig"
@@ -89383,6 +89414,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/iacm/ParallelStepElementConfig"
@@ -89774,6 +89808,9 @@
           "ExecutionWrapperConfig" : {
             "title" : "ExecutionWrapperConfig",
             "type" : "object",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/common/ExecutionWrapperValidation"
+            } ],
             "properties" : {
               "parallel" : {
                 "$ref" : "#/definitions/pipeline/stages/idp/ParallelStepElementConfig"


### PR DESCRIPTION
**Add Execution Wrapper Validation**
**Problem**
Pipeline steps can be incorrectly defined without their required wrapper elements (step:, parallel:, etc.), causing validation failures:

```yaml
CopyInsert
steps:
  - identifier: CI_AWS_Lambda_Deploy  # Missing 'step:' wrapper
    name: CI_AWS_Lambda_Deploy
    # ...
```

**Solution**
Added execution-wrapper-validation.yaml schema to enforce proper step wrapping
Applied validation to all stage types (CD, CI, IACM, Approval, CF, Custom, IDP, Security)

**Impact**
Improves user experience by providing clear validation errors when pipeline steps lack proper wrappers, helping users quickly identify and fix configuration issues.