### PR TITLE
feat: [IAC-3904]: Add desc and tags for workspace templates

### DIFF
--- a/v0/template.json
+++ b/v0/template.json
@@ -1064,6 +1064,15 @@
               "type" : "string",
               "pattern" : "^[0-9a-zA-Z][^\\s/&]{0,127}$"
             },
+            "description" : {
+              "type" : "string"
+            },
+            "tags" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
             "spec" : {
               "type" : "object",
               "properties" : {

--- a/v0/template/workspace/template.yaml
+++ b/v0/template/workspace/template.yaml
@@ -19,6 +19,12 @@ properties:
   versionLabel:
     type: string
     pattern: "^[0-9a-zA-Z][^\\s/&]{0,127}$"
+  description:
+    type: string
+  tags:
+    type: array
+    items:
+      type: string
   spec:
     type: object
     properties:

--- a/v1/template.json
+++ b/v1/template.json
@@ -1196,6 +1196,15 @@
               "type" : "string",
               "pattern" : "^[0-9a-zA-Z][^\\s/&]{0,127}$"
             },
+            "description" : {
+              "type" : "string"
+            },
+            "tags" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
             "spec" : {
               "type" : "object",
               "properties" : {

--- a/v1/template/workspace/template.yaml
+++ b/v1/template/workspace/template.yaml
@@ -19,6 +19,12 @@ properties:
   versionLabel:
     type: string
     pattern: "^[0-9a-zA-Z][^\\s/&]{0,127}$"
+  description:
+    type: string
+  tags:
+    type: array
+    items:
+      type: string
   spec:
     type: object
     properties:


### PR DESCRIPTION
This pull request introduces new fields, `description` and `tags`, to the template schema across multiple versions (`v0` and `v1`). These changes enhance the schema by allowing additional metadata to be associated with templates.

Schema updates:

* [`v0/template.json`](diffhunk://#diff-6c0f24251df68b230837bfd880ada4985d7b2b49d80929c20bfa14bac2c7673cR1067-R1075): Added `description` (type: string) and `tags` (type: array of strings) fields to the template schema.
* [`v0/template/workspace/template.yaml`](diffhunk://#diff-37d7dc4b7e81158925cb7e71c26db3f8ce363f41742aac4cd5ae2a80b9cdc21bR22-R27): Added `description` and `tags` fields with corresponding types to the workspace template schema.
* [`v1/template.json`](diffhunk://#diff-0397c2f1db0c2902bc79c0a01d74f44496e170634c80fc3894c2d04dfc2af6beR1199-R1207): Added `description` (type: string) and `tags` (type: array of strings) fields to the template schema for version 1.
* [`v1/template/workspace/template.yaml`](diffhunk://#diff-37d7dc4b7e81158925cb7e71c26db3f8ce363f41742aac4cd5ae2a80b9cdc21bR22-R27): Added `description` and `tags` fields with corresponding types to the workspace template schema for version 1.