### PR TITLE
Add support for GCP infrastructure under SSH deployments

### DIFF
--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -64240,7 +64240,7 @@
               },
               "type" : {
                 "type" : "string",
-                "enum" : [ "KubernetesDirect", "KubernetesGcp", "KubernetesAzure", "Pdc", "SshWinRmAzure", "ServerlessAwsLambda", "AzureWebApp", "AzureFunction", "SshWinRmAws", "CustomDeployment", "ECS", "Elastigroup", "TAS", "Asg", "GoogleCloudFunctions", "AWS_SAM", "AwsLambda", "KubernetesAws", "KubernetesRancher", "GoogleCloudRun" ]
+                "enum" : [ "KubernetesDirect", "KubernetesGcp", "KubernetesAzure", "Pdc", "SshWinRmAzure", "ServerlessAwsLambda", "AzureWebApp", "AzureFunction", "SshWinRmAws", "SshWinRmGcp", "CustomDeployment", "ECS", "Elastigroup", "TAS", "Asg", "GoogleCloudFunctions", "AWS_SAM", "AwsLambda", "KubernetesAws", "KubernetesRancher", "GoogleCloudRun" ]
               },
               "description" : {
                 "desc" : "This is the description for InfrastructureDef"
@@ -64529,6 +64529,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/stages/cd/SshWinRmAzureInfrastructure"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SshWinRmGcp"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/SshWinRmGcpInfrastructure"
                   }
                 }
               }
@@ -65584,6 +65599,79 @@
                 "desc" : "This is the description for SshWinRmAzureInfrastructure"
               }
             }
+          },
+          "SshWinRmGcpInfrastructure" : {
+            "title" : "SshWinRmGcpInfrastructure",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/Infrastructure"
+            }, {
+              "type" : "object",
+              "required" : [ "connectorRef", "credentialsRef", "hostConnectionType", "project", "zone" ],
+              "properties" : {
+                "gcpInstanceFilter" : {
+                  "$ref" : "#/definitions/pipeline/stages/cd/GcpInstanceFilter"
+                },
+                "connectorRef" : {
+                  "type" : "string",
+                  "minLength" : 1
+                },
+                "credentialsRef" : {
+                  "type" : "string",
+                  "minLength" : 1
+                },
+                "hostConnectionType" : {
+                  "type" : "string",
+                  "enum" : [ "PublicIP", "PrivateIP" ],
+                  "minLength" : 1
+                },
+                "project" : {
+                  "type" : "string",
+                  "minLength" : 1
+                },
+                "zone" : {
+                  "type" : "string",
+                  "minLength" : 1
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SshWinRmGcpInfrastructure"
+              }
+            }
+          },
+          "GcpInstanceFilter" : {
+            "title" : "GcpInstanceFilter",
+            "type" : "object",
+            "properties" : {
+              "labels" : {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "vpcs" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for GcpInstanceFilter"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "TanzuApplicationServiceInfrastructure" : {
             "title" : "TanzuApplicationServiceInfrastructure",

--- a/v0/pipeline.json
+++ b/v0/pipeline.json
@@ -65655,18 +65655,6 @@
                   "type" : "string"
                 } ]
               },
-              "vpcs" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
               "description" : {
                 "desc" : "This is the description for GcpInstanceFilter"
               }

--- a/v0/pipeline/stages/cd/gcp-instance-filter.yaml
+++ b/v0/pipeline/stages/cd/gcp-instance-filter.yaml
@@ -1,0 +1,20 @@
+title: GcpInstanceFilter
+type: object
+properties:
+  labels:
+    oneOf:
+    - type: object
+      additionalProperties:
+        type: string
+    - type: string
+  vpcs:
+    oneOf:
+      - type: array
+        items:
+          type: string
+      - type: string
+        pattern: (<\+.+>.*)
+        minLength: 1
+  description:
+    desc: This is the description for GcpInstanceFilter
+$schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/stages/cd/gcp-instance-filter.yaml
+++ b/v0/pipeline/stages/cd/gcp-instance-filter.yaml
@@ -7,14 +7,6 @@ properties:
       additionalProperties:
         type: string
     - type: string
-  vpcs:
-    oneOf:
-      - type: array
-        items:
-          type: string
-      - type: string
-        pattern: (<\+.+>.*)
-        minLength: 1
   description:
     desc: This is the description for GcpInstanceFilter
 $schema: http://json-schema.org/draft-07/schema#

--- a/v0/pipeline/stages/cd/infrastructure-def.yaml
+++ b/v0/pipeline/stages/cd/infrastructure-def.yaml
@@ -18,6 +18,7 @@ properties:
     - AzureWebApp
     - AzureFunction
     - SshWinRmAws
+    - SshWinRmGcp
     - CustomDeployment
     - ECS
     - Elastigroup
@@ -185,6 +186,14 @@ allOf:
     properties:
       spec:
         $ref: ssh-win-rm-azure-infrastructure.yaml
+- if:
+    properties:
+      type:
+        const: SshWinRmGcp
+  then:
+    properties:
+      spec:
+        $ref: ssh-win-rm-gcp-infrastructure.yaml
 - if:
     properties:
       type:

--- a/v0/pipeline/stages/cd/ssh-win-rm-gcp-infrastructure.yaml
+++ b/v0/pipeline/stages/cd/ssh-win-rm-gcp-infrastructure.yaml
@@ -1,0 +1,35 @@
+title: SshWinRmGcpInfrastructure
+allOf:
+- $ref: ../../steps/common/infrastructure.yaml
+- type: object
+  required:
+  - connectorRef
+  - credentialsRef
+  - hostConnectionType
+  - project
+  - zone
+  properties:
+    gcpInstanceFilter:
+      $ref: gcp-instance-filter.yaml
+    connectorRef:
+      type: string
+      minLength: 1
+    credentialsRef:
+      type: string
+      minLength: 1
+    hostConnectionType:
+      type: string
+      enum:
+      - PublicIP
+      - PrivateIP
+      minLength: 1
+    project:
+      type: string
+      minLength: 1
+    zone:
+      type: string
+      minLength: 1
+$schema: http://json-schema.org/draft-07/schema#
+properties:
+  description:
+    desc: This is the description for SshWinRmGcpInfrastructure

--- a/v0/template.json
+++ b/v0/template.json
@@ -82637,18 +82637,6 @@
                   "type" : "string"
                 } ]
               },
-              "vpcs" : {
-                "oneOf" : [ {
-                  "type" : "array",
-                  "items" : {
-                    "type" : "string"
-                  }
-                }, {
-                  "type" : "string",
-                  "pattern" : "(<\\+.+>.*)",
-                  "minLength" : 1
-                } ]
-              },
               "description" : {
                 "desc" : "This is the description for GcpInstanceFilter"
               }

--- a/v0/template.json
+++ b/v0/template.json
@@ -81222,7 +81222,7 @@
               },
               "type" : {
                 "type" : "string",
-                "enum" : [ "KubernetesDirect", "KubernetesGcp", "KubernetesAzure", "Pdc", "SshWinRmAzure", "ServerlessAwsLambda", "AzureWebApp", "AzureFunction", "SshWinRmAws", "CustomDeployment", "ECS", "Elastigroup", "TAS", "Asg", "GoogleCloudFunctions", "AWS_SAM", "AwsLambda", "KubernetesAws", "KubernetesRancher", "GoogleCloudRun" ]
+                "enum" : [ "KubernetesDirect", "KubernetesGcp", "KubernetesAzure", "Pdc", "SshWinRmAzure", "ServerlessAwsLambda", "AzureWebApp", "AzureFunction", "SshWinRmAws", "SshWinRmGcp", "CustomDeployment", "ECS", "Elastigroup", "TAS", "Asg", "GoogleCloudFunctions", "AWS_SAM", "AwsLambda", "KubernetesAws", "KubernetesRancher", "GoogleCloudRun" ]
               },
               "description" : {
                 "desc" : "This is the description for InfrastructureDef"
@@ -81511,6 +81511,21 @@
                 "properties" : {
                   "spec" : {
                     "$ref" : "#/definitions/pipeline/stages/cd/SshWinRmAzureInfrastructure"
+                  }
+                }
+              }
+            }, {
+              "if" : {
+                "properties" : {
+                  "type" : {
+                    "const" : "SshWinRmGcp"
+                  }
+                }
+              },
+              "then" : {
+                "properties" : {
+                  "spec" : {
+                    "$ref" : "#/definitions/pipeline/stages/cd/SshWinRmGcpInfrastructure"
                   }
                 }
               }
@@ -82566,6 +82581,79 @@
                 "desc" : "This is the description for SshWinRmAzureInfrastructure"
               }
             }
+          },
+          "SshWinRmGcpInfrastructure" : {
+            "title" : "SshWinRmGcpInfrastructure",
+            "allOf" : [ {
+              "$ref" : "#/definitions/pipeline/steps/common/Infrastructure"
+            }, {
+              "type" : "object",
+              "required" : [ "connectorRef", "credentialsRef", "hostConnectionType", "project", "zone" ],
+              "properties" : {
+                "gcpInstanceFilter" : {
+                  "$ref" : "#/definitions/pipeline/stages/cd/GcpInstanceFilter"
+                },
+                "connectorRef" : {
+                  "type" : "string",
+                  "minLength" : 1
+                },
+                "credentialsRef" : {
+                  "type" : "string",
+                  "minLength" : 1
+                },
+                "hostConnectionType" : {
+                  "type" : "string",
+                  "enum" : [ "PublicIP", "PrivateIP" ],
+                  "minLength" : 1
+                },
+                "project" : {
+                  "type" : "string",
+                  "minLength" : 1
+                },
+                "zone" : {
+                  "type" : "string",
+                  "minLength" : 1
+                }
+              }
+            } ],
+            "$schema" : "http://json-schema.org/draft-07/schema#",
+            "properties" : {
+              "description" : {
+                "desc" : "This is the description for SshWinRmGcpInfrastructure"
+              }
+            }
+          },
+          "GcpInstanceFilter" : {
+            "title" : "GcpInstanceFilter",
+            "type" : "object",
+            "properties" : {
+              "labels" : {
+                "oneOf" : [ {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string"
+                } ]
+              },
+              "vpcs" : {
+                "oneOf" : [ {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "string"
+                  }
+                }, {
+                  "type" : "string",
+                  "pattern" : "(<\\+.+>.*)",
+                  "minLength" : 1
+                } ]
+              },
+              "description" : {
+                "desc" : "This is the description for GcpInstanceFilter"
+              }
+            },
+            "$schema" : "http://json-schema.org/draft-07/schema#"
           },
           "TanzuApplicationServiceInfrastructure" : {
             "title" : "TanzuApplicationServiceInfrastructure",


### PR DESCRIPTION
Under SSH deployments CD stage, Azure, AWS and PDC are currently support. This change it to extended support for GCP. Through this enhancement, users will be able to run deployments through custom shell scripts on GCP VM instances.

This PR is for the MVP which includes GCP label based filtering of the VM instances.

TechSpec
https://harness.atlassian.net/wiki/spaces/CDNG/pages/22584689914/TechSpec+Support+GCP+Infrastructure+Type+in+SSH+Deployment+Type